### PR TITLE
Update Contributing.rst to have the correct directory for our built docs

### DIFF
--- a/doc/source/Resources/Contributing.rst
+++ b/doc/source/Resources/Contributing.rst
@@ -179,7 +179,7 @@ Otherwise, if running Windows, build the documentation by running:
    cd doc
    make.bat html
 
-After the documentation builds successfully, you can open the local build by opening in your brower the file ``index.html`` in ``docs/build/html/``.
+After the documentation builds successfully, you can open the local build by opening in your brower the file ``index.html`` in ``doc/_build/html/``.
 
 Continuous Integration and Continuous Delivery (CI/CD)
 ------------------------------------------------------


### PR DESCRIPTION
Simple fix in contributing to have the right location for `index.html` with locally compiled docs.