### PR TITLE
distutils-compatible setup script

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include _setup_common.py

--- a/_setup_common.py
+++ b/_setup_common.py
@@ -1,0 +1,64 @@
+import fnmatch
+import os
+import sys
+
+# required since Python 2.7's glob.iglob does not support recursive keyword
+def recursive_glob(startpath, filepattern):
+    """Return a list of files matching a pattern, searching recursively from a start path.
+
+    Keyword Arguments:
+    startpath -- starting path (directory)
+    filepattern -- fnmatch-style filename pattern
+    """
+    return [
+        os.path.join(dirpath, filename)
+            for dirpath, _, filenames in os.walk(startpath)
+            for filename in filenames if fnmatch.fnmatch(filename, filepattern)
+    ]
+
+open3 = open
+if sys.version_info < (3, 0):
+    import io
+    open3 = io.open
+
+# loosely from https://packaging.python.org/guides/single-sourcing-package-version/
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+name='pyaedt'
+
+with open(os.path.join(HERE, 'pyaedt', 'version.txt'), 'r') as f:
+    version = f.readline()
+
+author='ANSYS, Inc.'
+
+maintainer='Massimo Capodiferro'
+
+maintainer_email='massimo.capodiferro@ansys.com'
+
+description='Higher-Level Pythonic Ansys Electronics Destkop Framework'
+
+# Get the long description from the README file
+with open3(os.path.join(HERE, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
+
+packages=['pyaedt', 'pyaedt.misc', 'pyaedt.application', 'pyaedt.modeler', 'pyaedt.modules',
+            'pyaedt.generic', 'pyaedt.edb_core', 'pyaedt.examples']
+
+data_files=[('dlls', recursive_glob(os.path.join('pyaedt', 'dlls'), '*')),
+            ('misc', recursive_glob(os.path.join('pyaedt', 'misc'), '*')),
+            ('License', recursive_glob('.', '*.md')),
+            ('version', ['pyaedt/version.txt']),
+            ('setup-distutils', ['setup-distutils.py'])]
+
+license="MIT"
+
+classifiers=[
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+]

--- a/doc/source/Resources/Installation.rst
+++ b/doc/source/Resources/Installation.rst
@@ -24,14 +24,9 @@ To use IronPython in AEDT:
 
 1. Download the PyAEDT package from ``https://pypi.org/project/pyaedt/#files``
 2. Extract the files.
-3. Copy pyaedt folder to the ``PersonalLib`` folder of the AEDT framework.
-4. Run Aedt
+3. Run the following command to install PyAEDT into Electronics Desktop (specify the full paths to ipy64 and setup-distutils.py as needed)
 
-If you don't know which is current ``PersonalLib`` folder:
-    - run AEDT
-    - go to Tools-> Options -> General Options
-    - Select Directories Menus
-    - View and Set your PersonalLib Folder
+``ipy64 setup-distutils.py install --user``
 
 Using Standalone IronPython
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/Resources/Installation.rst
+++ b/doc/source/Resources/Installation.rst
@@ -7,7 +7,7 @@ This tool has been tested on HFSS, Icepak, and Maxwell 3D. It also provides basi
 
 Requirements
 ~~~~~~~~~~~~
-In addition to the runtime dependencies listed in the installation information, EDB Utilities requires ANSYS EM Suite 2021 R1 or later.
+In addition to the runtime dependencies listed in the installation information, PyAEDT requires ANSYS EM Suite 2021 R1 or later.
 
 Installing on CPython v3.7-v3.8
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup-distutils.py
+++ b/setup-distutils.py
@@ -1,15 +1,8 @@
-import setuptools
-import sys
+from distutils.core import setup
 
 from _setup_common import name, version, author, maintainer, maintainer_email, description, long_description, packages, data_files, license, classifiers
 
-if sys.version_info >= (3, 0):
-    install_requires = ["pywin32 >= 2.2.7;platform_system=='Windows'",
-                        "pythonnet >= 2.4.0;platform_system=='Windows'"]
-else:
-    install_requires = []
-
-setuptools.setup(
+setup(
     name=name,
     version=version,
     author=author,
@@ -17,11 +10,8 @@ setuptools.setup(
     maintainer_email=maintainer_email,
     description=description,
     long_description=long_description,
-    long_description_content_type="text/x-rst",
-    install_requires=install_requires,
     packages=packages,
     data_files=data_files,
-    include_package_data=True,
     license=license,
     classifiers=classifiers,
 )


### PR DESCRIPTION
Add a new distutils-compatible setup script to facilitate installation of PyAEDT with the AEDT-provided IronPython installation.  Move common setup data into a shared file so it has a single source location.  In local testing I confirmed that CPython 3.8 and IronPython from AEDT can run the install command of the setup.py and setup-distutils.py scripts, respectively.