### PR TITLE
fix doc ci deployment

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           pip install .
 
-      - name: Install requirements
+      - name: Install doc build requirements
         run: |
           pip install -r requirements_docs.txt
 
@@ -52,8 +52,9 @@ jobs:
           path: doc/_build/html
           retention-days: 7
 
+      # Deploys only on cron-job nightly builds
       - name: Deploy
-        if: startsWith(github.event.ref, 'refs/heads/main')
+        if: github.event_name != 'push' && startsWith(github.event.ref, 'refs/heads/main')
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           repository-name: pyansys/pyaedt-dev-docs


### PR DESCRIPTION
This PR slighly modifies the doc build CI by only triggering the deployment step on nightly cron jobs.
