### PR TITLE
Doc/edits to main application files

### DIFF
--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -65,7 +65,7 @@ def from_rkm(code):
     Returns
     -------
     str
-        String with a decimal point and R value.
+        String with a decimal point and an R value.
 
     Examples
     --------
@@ -126,11 +126,11 @@ def to_aedt(code):
     Parameters
     ----------
     code : str
-        
-
+    
     Returns
     -------
     str
+    
     """
     pattern = r'([{}]{})'.format(''.join(AEDT_MAPS.keys()), '{1}')
     regex = re.compile(pattern, re.I)
@@ -149,6 +149,7 @@ def from_rkm_to_aedt(code):
     Returns
     -------
     str
+    
     """
     return to_aedt(from_rkm(code))
 
@@ -187,73 +188,72 @@ class Circuit(FieldAnalysisCircuit, object):
     release_on_exit : bool, optional
         Whether to release AEDT on exit.
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
-    Create an instance of `Circuit` and connect to an existing HFSS
+    Create an instance of Circuit and connect to an existing HFSS
     design or create a new HFSS design if one does not exist.
 
     >>> from pyaedt import Circuit
     >>> aedtapp = Circuit()
 
-    Create an instance of `Circuit` and link to a project named
+    Create an instance of Circuit and link to a project named
     ``projectname``. If this project does not exist, create one with
     this name.
 
     >>> aedtapp = Circuit(projectname)
 
-    Create an instance of `Circuit` and link to a design named
+    Create an instance of Circuit and link to a design named
     ``designname`` in a project named ``projectname``.
 
     >>> aedtapp = Circuit(projectname,designame)
 
-    Create an instance of `Circuit` and open the specified project,
+    Create an instance of Circuit and open the specified project,
     which is ``myfie.aedt``.
 
     >>> aedtapp = Circuit("myfile.aedt")
 
-    Create an instance of `Circuit` using the 2021 R1 version and
+    Create an instance of Circuit using the 2021 R1 version and
     open the specified project, which is ``myfie.aedt``.
 
     >>> aedtapp = Circuit(specified_version="2021.1", projectname="myfile.aedt")
 
-    Create an instance of ``Circuit`` using the 2021 R2 student version and open
+    Create an instance of Circuit using the 2021 R2 student version and open
     the specified project, which is named ``"myfile.aedt"``.
 
     >>> hfss = Circuit(specified_version="2021.2", projectname="myfile.aedt", student_version=True)
 
     Examples
     --------
-    Create an instance of ``Circuit`` and connect to an existing HFSS
+    Create an instance of Circuit and connect to an existing HFSS
     design or create a new HFSS design if one does not exist.
 
     >>> from pyaedt import Circuit
     >>> aedtapp = Circuit()
 
-    Create an instance of ``Circuit`` and link to a project named
+    Create an instance of Circuit and link to a project named
     ``projectname``. If this project does not exist, create one with
     this name.
 
     >>> aedtapp = Circuit(projectname)
 
-    Create an instance of ``Circuit`` and link to a design named
+    Create an instance of Circuit and link to a design named
     ``designname`` in a project named ``projectname``.
 
     >>> aedtapp = Circuit(projectname,designame)
 
-    Create an instance of ``Circuit`` and open the specified project,
+    Create an instance of Circuit and open the specified project,
     which is ``myfie.aedt``.
 
     >>> aedtapp = Circuit("myfile.aedt")
 
-    Create an instance of ``Circuit`` using the 2021 R1 version and
+    Create an instance of Circuit using the 2021 R1 version and
     open the specified project, which is ``myfie.aedt``.
 
     >>> aedtapp = Circuit(specified_version="2021.1", projectname="myfile.aedt")
 
     """
-
     def __init__(self, projectname=None, designname=None, solution_type=None, setup_name=None,
                  specified_version=None, NG=False, AlwaysNew=False, release_on_exit=False, student_version=False):
         FieldAnalysisCircuit.__init__(self, "Circuit Design", projectname, designname, solution_type, setup_name,
@@ -301,6 +301,7 @@ class Circuit(FieldAnalysisCircuit, object):
         -------
         bool
              ``True`` when successful, ``False`` when failed.
+        
         """
         xpos = 0
         ypos = 0
@@ -509,6 +510,7 @@ class Circuit(FieldAnalysisCircuit, object):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         xpos = 0
         ypos = 0
@@ -632,6 +634,7 @@ class Circuit(FieldAnalysisCircuit, object):
         -------
         str
             Type of Mentor net list comoponet.
+        
         """
         if refid[1] == "R":
             return "resistor:RES."
@@ -667,8 +670,8 @@ class Circuit(FieldAnalysisCircuit, object):
         -------
         list
             List of pin names.
+        
         """
-
         if not source_project_name or self.project_name == source_project_name:
             oSrcProject = self._desktop.GetActiveProject()
         else:
@@ -704,6 +707,7 @@ class Circuit(FieldAnalysisCircuit, object):
         -------
         list
             List of ports.
+        
         """
         if filename[-2:] == "ts":
             with open(filename, "r") as f:
@@ -767,8 +771,8 @@ class Circuit(FieldAnalysisCircuit, object):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
-
         # Normalize the save path
         if not filename:
             appendix = ""
@@ -846,6 +850,7 @@ class Circuit(FieldAnalysisCircuit, object):
         -------
         str
             File name if the export is successful.
+        
         """
         if not designname:
             designname = self.design_name

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -280,7 +280,7 @@ class Desktop:
     release_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``True``.
     student_version : bool, optional
-        Whether to enable the student version of AEDT. The default is
+        Whether to open the AEDT student version. The default is
         ``False``.
 
     Examples
@@ -637,7 +637,7 @@ class Desktop:
         force_close_desktop()
 
     def enable_autosave(self):
-        """Enable auto save option.
+        """Enable the auto save option.
 
         Examples
         --------
@@ -651,7 +651,7 @@ class Desktop:
         self._main.oDesktop.EnableAutoSave(True)
 
     def disable_autosave(self):
-        """Disable auto save option.
+        """Disable the auto save option.
 
         Examples
         --------
@@ -671,7 +671,7 @@ def get_version_env_variable(version_id):
     Parameters
     ----------
     version_id : str
-        Full AEDT version number, such as "2021.1".
+        Full AEDT version number, such as ``"2021.1"``.
 
     Returns
     -------

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -283,7 +283,6 @@ class Edb(object):
     @aedt_exception_handler
     def open_edb_inside_aedt(self, init_dlls=False):
         """Open EDB inside of AEDT.
-        
         Parameters
         ----------
         init_dlls :
@@ -613,7 +612,8 @@ class Edb(object):
 
         Parameters
         ----------
-        func : 
+        func : str
+            Function to execute.
             
 
         Returns
@@ -683,7 +683,7 @@ class Edb(object):
             List of references to add. The default is ``["GND"]``.
         extent_type : str
             Type of the extension. Options are ``"Conforming"`` and 
-            ``"Bounding"``. The default is ``Conformaing``.
+            ``"Bounding"``. The default is ``"Conforming"``.
         expansion_size : float
             Expansion size ratio in meters. The default is ``0.002``.
         use_round_corner : bool, optional
@@ -769,7 +769,7 @@ class Edb(object):
         path_to_output : str
             Full path to the configuration file where the 3D export optons are to be saved.
         
-        config_dictionaries : optional
+        config_dictionaries : dict, optional
         
         """
         option_config = {

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1,4 +1,4 @@
-"""This module contains the ``Edb`` class.
+"""This module contains the `Edb` class.
 
 This module is implicitily loaded in HFSS 3D Layout when launched.
 

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -63,17 +63,16 @@ class Edb(object):
 
     Examples
     --------
-    Create an ``Edb`` object and a new EDB cell.
+    Create an `Edb` object and a new EDB cell.
 
     >>> from pyaedt import Edb
     >>> app = Edb()     
 
-    Create an ``Edb`` object and open the specified project.
+    Create an `Edb` object and open the specified project.
 
     >>> app = Edb("myfile.aedb")
 
     """
-
     def __init__(self, edbpath=None, cellname=None, isreadonly=False, edbversion="2021.1", isaedtowned=False, oproject=None, student_version=False):
         if edb_initialized:
             self.oproject = oproject
@@ -127,53 +126,51 @@ class Edb(object):
     def add_info_message(self, message_text):
         """Add a type 0 "Info" message to the active design level of the Message Manager tree.
 
-                Also add an info message to the logger if the handler is present.
+        Also add an info message to the logger if the handler is present.
 
-                Parameters
-                ----------
-                message_text : str
-                    Text to display as the info message.
+        Parameters
+        ----------
+        message_text : str
+            Text to display as the info message.
+            
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
 
+        Examples
+        --------
+        >>> from pyaedt import Edb
+        >>> edb = Edb()
+        >>> edb.add_info_message("Design info message")
 
-                Returns
-                -------
-                bool
-                    ``True`` if succeeded.
-
-                Examples
-                --------
-                >>> from pyaedt import Edb
-                >>> edb = Edb()
-                >>> edb.add_info_message("Design info message")
-
-                """
+        """
         self._messenger.add_info_message(message_text)
         return True
 
     @aedt_exception_handler
     def add_warning_message(self, message_text):
         """Add a type 0 "Warning" message to the active design level of the Message Manager tree.
+        
+        Also add an info message to the logger if the handler is present.
 
-                Also add an info message to the logger if the handler is present.
+        Parameters
+        ----------
+        message_text : str
+            Text to display as the warning message.
+        
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
 
-                Parameters
-                ----------
-                message_text : str
-                    Text to display as the warning message.
+        Examples
+        --------
+        >>> from pyaedt import Edb
+        >>> edb = Edb()
+        >>> edb.add_warning_message("Design warning message")
 
-
-                Returns
-                -------
-                bool
-                    ``True`` if succeeded.
-
-                Examples
-                --------
-                >>> from pyaedt import Edb
-                >>> edb = Edb()
-                >>> edb.add_warning_message("Design warning message")
-
-                """
+        """
         self._messenger.add_warning_message(message_text)
         return True
 
@@ -181,26 +178,26 @@ class Edb(object):
     def add_error_message(self, message_text):
         """Add a type 0 "Error" message to the active design level of the Message Manager tree.
 
-                Also add an error message to the logger if the handler is present.
+        Also add an error message to the logger if the handler is present.
 
-                Parameters
-                ----------
-                message_text : str
-                    Text to display as the error message.
+        Parameters
+        ----------
+        message_text : str
+            Text to display as the error message.
 
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+             
 
-                Returns
-                -------
-                bool
-                    ``True`` if succeeded.
+        Examples
+        --------
+        >>> from pyaedt import Edb
+        >>> edb = Edb()
+        >>> edb.add_error_message("Design error message")
 
-                Examples
-                --------
-                >>> from pyaedt import Edb
-                >>> edb = Edb()
-                >>> edb.add_error_message("Design error message")
-
-                """
+        """
         self._messenger.add_error_message(message_text)
         return True
 
@@ -250,12 +247,12 @@ class Edb(object):
 
     @aedt_exception_handler
     def open_edb(self, init_dlls=False):
-        """
+        """Open EDB.
 
         Parameters
         ----------
         init_dlls : bool
-             Whether to initialize DLLs. The default is ``False``.
+            Whether to initialize DLLs. The default is ``False``.
 
         Returns
         -------
@@ -282,12 +279,12 @@ class Edb(object):
 
     @aedt_exception_handler
     def open_edb_inside_aedt(self, init_dlls=False):
-        """
-
+        """Open EDB inside of AEDT.
+        
         Parameters
         ----------
         init_dlls :
-             Whether to initialize DLLs. The default is ``False``.
+            Whether to initialize DLLs. The default is ``False``.
 
         Returns
         -------
@@ -309,12 +306,12 @@ class Edb(object):
 
     @aedt_exception_handler
     def create_edb(self, init_dlls=False):
-        """
+        """Create EDB.
 
         Parameters
         ----------
         init_dlls :
-             Whether to initialize DLLs. The default is ``False``.
+            Whether to initialize DLLs. The default is ``False``.
 
         Returns
         -------
@@ -334,21 +331,21 @@ class Edb(object):
 
     @aedt_exception_handler
     def import_layout_pcb(self, input_file, working_dir, init_dlls=False):
-        """Import a brd file and generate an ``edb.def`` file in the working directory.
+        """Import a board file and generate an ``edb.def`` file in the working directory.
 
         Parameters
         ----------
         input_file : str
             Full path to the brd file.
         working_dir : str
-            Directory in which to create the ``aedb`` folder. The aedb name will be the same as the brd name.
+            Directory in which to create the ``aedb`` folder. The AEDB name will be the same as the BRD name.
         init_dlls : bool
-             Whether to initialize DLLs. The default is ``False``.
+            Whether to initialize DLLs. The default is ``False``.
 
         Returns
         -------
-        type
-            Full path to the aedb file.
+        str
+            Full path to the AEDB file.
 
         """
         if init_dlls:
@@ -369,7 +366,7 @@ class Edb(object):
             self.edb_exception(ex_value, ex_traceback)
 
     def edb_exception(self, ex_value, tb_data):
-        """Write the trace stack to the desktop when a python error occurs.
+        """Write the trace stack to the desktop when a Python error occurs.
 
         Parameters
         ----------
@@ -439,62 +436,62 @@ class Edb(object):
 
     @property
     def active_cell(self):
-        """ """
+        """Active cell."""
         return self._active_cell
 
 
     @property
     def core_components(self):
-        """ """
+        """Core components."""
         if not self._components:
             self._components = Components(self)
         return self._components
 
     @property
     def core_stackup(self):
-        """ """
+        """Core stackup."""
         if not self._stackup:
             self._stackup = EdbStackup(self)
         return self._stackup
 
     @property
     def core_padstack(self):
-        """ """
+        """Core padstacks."""
         if not self._padstack:
             self._padstack = EdbPadstacks(self)
         return self._padstack
 
     @property
     def core_siwave(self):
-        """ """
+        """Core SI Wave."""
         if not self._siwave:
             self._siwave = EdbSiwave(self)
         return self._siwave
 
     @property
     def core_hfss(self):
-        """ """
+        """Core HFSS."""
         if not self._hfss:
             self._hfss = Edb3DLayout(self)
         return self._hfss
 
     @property
     def core_nets(self):
-        """ """
+        """Core nets."""
         if not self._nets:
             self._nets = EdbNets(self)
         return self._nets
 
     @property
     def core_primitives(self):
-        """ """
+        """Core primitives."""
         if not self._core_primitives:
             self._core_primitives = EdbLayout(self)
         return self._core_primitives
 
     @property
     def active_layout(self):
-        """ """
+        """Active layout."""
         return self.active_cell.GetLayout()
 
     # @property
@@ -503,7 +500,14 @@ class Edb(object):
 
     @property
     def pins(self):
-        """:return:List of All Pins"""
+        """Pins.
+        
+        Returns
+        -------
+        list
+            List of all pins.
+        """
+        
         pins=[]
         for el in self.core_components.components:
             comp = self.edb.Cell.Hierarchy.Component.FindByName(self.active_layout, el)
@@ -515,12 +519,34 @@ class Edb(object):
 
 
     class Boundaries:
-        """ """
+        """Boundaries.
+        
+        Parameters
+        ----------
+        port :
+        
+        Pec :
+        
+        RLC :
+        
+        CurrentSource :
+        
+        VoltageSource :
+        
+        NexximGround :
+        
+        NexximPort :
+        
+        DCTerminal :
+        
+        VoltageProbe :
+        
+        """
         (Port, Pec, RLC, CurrentSource, VoltageSource, NexximGround, NexximPort, DcTerminal, VoltageProbe) = range(0, 9)
 
     @aedt_exception_handler
     def edb_value(self, val):
-        """
+        """EDB value.
 
         Parameters
         ----------
@@ -535,26 +561,43 @@ class Edb(object):
 
     @aedt_exception_handler
     def close_edb(self):
-        """ """
+        """Close EDB.
+        
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+        
+        """
         self._db.Close()
         return True
 
     @aedt_exception_handler
     def save_edb(self):
-        """ """
+        """Save EDB.
+        
+       Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+       
+       """
         self._db.Save()
         return True
 
     @aedt_exception_handler
     def save_edb_as(self, fname):
-        """
+        """Save EDB as.
 
         Parameters
         ----------
-        fname
+        fname : str
+            Name of the file to save to.
 
         Returns
         -------
+        bool
+            ``True`` when successful, ``False`` when failed.
 
         """
         self._db.SaveAs(fname)
@@ -562,36 +605,38 @@ class Edb(object):
 
     @aedt_exception_handler
     def execute(self, func):
-        """
+        """Execute.
 
         Parameters
         ----------
-        func :
+        func : 
             
 
         Returns
         -------
+        bool
+            ``True`` when successful, ``False`` when failed.
 
         """
         return self.edb.Utility.Command.Execute(func)
 
 
-
     @aedt_exception_handler
     def import_cadence_file(self, inputBrd, WorkDir=None):
-        """Import a brd file and generate an ``edb.def`` file in the working directory.
+        """Import a BRD file and generate an ``edb.def`` file in the working directory.
 
         Parameters
         ----------
         inputBrd : str
-            Full path to the brd file.
+            Full path to the BRD file.
         WorkDir : str
-            The directory in which to create the ``aedb`` folder. The aedb name will be the same as the brd name. The default value is ``None``.
+            Directory in which to create the ``aedb`` folder. The AEDB name will be the 
+            same as the BRD name. The default value is ``None``.
 
         Returns
         -------
-        type
-            Boolean
+        bool
+            ``True`` when successful, ``False`` when failed.
 
         """
         if self.import_layout_pcb(inputBrd, working_dir=WorkDir):
@@ -601,19 +646,20 @@ class Edb(object):
 
     @aedt_exception_handler
     def import_gds_file(self, inputGDS, WorkDir=None):
-        """Import a brd file and generate an ``edb.def`` file in the working directory.
+        """Import a BRD file and generate an ``edb.def`` file in the working directory.
 
         Parameters
         ----------
         inputGDS : str
-            Full path to the brd file.
+            Full path to the BRD file.
         WorkDir : str
-            The directory in which to create the ``aedb` folder. The aedb name will be the same as the brd name. The default value is ``None``.
+            Directory in which to create the ``aedb` folder. The AEDB name will be the 
+            same as the BRD name. The default value is ``None``.
 
         Returns
         -------
-        type
-            The full path to the aedb file.
+        bool
+            ``True`` when successful, ``False`` when failed.
 
         """
         if self.import_layout_pcb(inputGDS, working_dir=WorkDir):
@@ -623,23 +669,26 @@ class Edb(object):
 
     def create_cutout(self, signal_list, reference_list=["GND"], extent_type="Conforming", expansion_size=0.002,
                       use_round_corner=False, output_aedb_path=None, replace_design_with_cutout=True):
-        """
-        Create a new Cutout and Save it to a new aedb file.
+        """Create a cutout and save it to a new AEDB file.
 
         Parameters
         ----------
-        signal_list: list
-            list of signal strings
-        reference_list: list
-            list of reference lists to be added. Default ["GND"]
-        extent_type: str
-            type of extension: "Conforming" or "Bounding"
-        expansion_size: float
-            expansion size ratio in meter. Default 2mm
-        use_round_corner: bool
-        output_aedb_path: str, optional
-            the full path to new aedb file
-        replace_design_with_cutout
+        signal_list : list
+            List of signal strings
+        reference_list : list
+            List of references to add. The default is ``["GND"]``.
+        extent_type : str
+            Type of the extension. Options are ``"Conforming"`` or 
+            ``"Bounding"``. The default is ``Conformaing``.
+        expansion_size : float
+            Expansion size ratio in meters. The default is ``0.002``.
+        use_round_corner : bool, optional
+            Whether to use round corners. The default is ``False``.
+        output_aedb_path : str, optional
+            Full path to the new AEDB file.
+        replace_design_with_cutout : bool, optional
+            Whether to replace the design with the cutou. The default 
+            is ``True``.      
 
         Returns
         -------
@@ -731,21 +780,19 @@ class Edb(object):
 
     @aedt_exception_handler
     def export_hfss(self, path_to_output, net_list=None):
-        """
-        Export Edb to HFSS
+        """Export EDB to HFSS.
 
         Parameters
         ----------
         path_to_output : str
-            full path to where aedt will be saved
+            Full path to where to save the AEDT file.
         net_list : list, optional
-            if provided, only nets in list will be exported
-
+            If provided, export only the nets in the list.
 
         Returns
         -------
         str
-            path to .aedt file
+            Path to the AEDT file.
 
         Examples
         --------
@@ -758,26 +805,26 @@ class Edb(object):
         >>> edb.write_export3d_option_config_file(r"C:\temp", options_config)
         >>> edb.export_hfss(r"C:\temp")
         "C:\\temp\\hfss_siwave.aedt"
+
         """
         siwave_s = SiwaveSolve(self.edbpath, aedt_installer_path=self.base_path)
         return siwave_s.export_3d_cad("HFSS", path_to_output,net_list)
 
     @aedt_exception_handler
     def export_q3d(self, path_to_output, net_list=None):
-        """
-        Export Edb to HFSS
+        """Export EDB to HFSS.
 
         Parameters
         ----------
         path_to_output : str
-            full path to where aedt will be saved
+            Full path to where to save the AEDT file.
         net_list : list, optional
-            if provided, only nets in list will be exported
+            If provided, export only the nets in the list.
 
         Returns
         -------
         str
-            path to .aedt file
+            Path to the AEDT file.
 
         Examples
         --------
@@ -790,6 +837,7 @@ class Edb(object):
         >>> edb.write_export3d_option_config_file(r"C:\temp", options_config)
         >>> edb.export_q3d(r"C:\temp")
         "C:\\temp\\q3d_siwave.aedt"
+        
         """
 
         siwave_s = SiwaveSolve(self.edbpath, aedt_installer_path=self.base_path)
@@ -798,20 +846,19 @@ class Edb(object):
 
     @aedt_exception_handler
     def export_maxwell(self, path_to_output, net_list=None):
-        """
-        Export Edb to Maxwell 3D
+        """Export EDB to Maxwell 3D.
 
         Parameters
         ----------
         path_to_output : str
-            full path to where aedt will be saved
+            Full path to where to save the AEDT file.
         net_list : list, optional
-            if provided, only nets in list will be exported
+            If provided, export only the nets in the list.
 
         Returns
         -------
         str
-            path to .aedt file
+            Path to the AEDT file.
 
         Examples
         --------
@@ -824,7 +871,7 @@ class Edb(object):
         >>> edb.write_export3d_option_config_file(r"C:\temp", options_config)
         >>> edb.export_maxwell(r"C:\temp")
         "C:\\temp\\maxwell_siwave.aedt"
+        
         """
-
         siwave_s = SiwaveSolve(self.edbpath, aedt_installer_path=self.base_path)
         return siwave_s.export_3d_cad("Maxwell", path_to_output, net_list)

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -29,7 +29,7 @@ try:
         _ironpython = True
     edb_initialized = True
 except ImportError:
-    warnings.warn("The clr is missing. Install Pythonnet or use an Ironpython version if you want to use the EDB Module.")
+    warnings.warn("The clr is missing. Install Python.NET or use an IronPython version if you want to use the EDB module.")
     edb_initialized = False
 
 
@@ -43,8 +43,7 @@ from .generic.process import SiwaveSolve
 class Edb(object):
     """EDB instance interface.
 
-    This module contains all functionalities in EDB. It inherits all
-    objects that belong to EDB.
+    This module inherits all objects that belong to EDB.
 
     Parameters
     ----------
@@ -60,6 +59,10 @@ class Edb(object):
     isaedtowned : bool, optional
         Whether to launch ``edb_core`` from HFSS 3D Layout. The
         default is ``False``.
+    oproject : optional
+    
+    student_version : bool, optional
+        Whether to open the AEDT student version. The default is ``False.``
 
     Examples
     --------
@@ -204,7 +207,7 @@ class Edb(object):
 
     @aedt_exception_handler
     def _init_dlls(self):
-        """ """
+        """Initialize DLLs."""
         sys.path.append(os.path.join(os.path.dirname(__file__), "dlls", "EDBLib"))
         if os.name == 'posix':
             if env_value(self.edbversion) in os.environ:
@@ -331,14 +334,15 @@ class Edb(object):
 
     @aedt_exception_handler
     def import_layout_pcb(self, input_file, working_dir, init_dlls=False):
-        """Import a board file and generate an ``edb.def`` file in the working directory.
+        """Import a BRD file and generate an ``edb.def`` file in the working directory.
 
         Parameters
         ----------
         input_file : str
-            Full path to the brd file.
+            Full path to the BRD file.
         working_dir : str
-            Directory in which to create the ``aedb`` folder. The AEDB name will be the same as the BRD name.
+            Directory in which to create the ``aedb`` folder. The AEDB file name will be the 
+            same as the BRD file name.
         init_dlls : bool
             Whether to initialize DLLs. The default is ``False``.
 
@@ -456,7 +460,7 @@ class Edb(object):
 
     @property
     def core_padstack(self):
-        """Core padstacks."""
+        """Core padstack."""
         if not self._padstack:
             self._padstack = EdbPadstacks(self)
         return self._padstack
@@ -523,7 +527,7 @@ class Edb(object):
         
         Parameters
         ----------
-        port :
+        Port :
         
         Pec :
         
@@ -537,7 +541,7 @@ class Edb(object):
         
         NexximPort :
         
-        DCTerminal :
+        DcTerminal :
         
         VoltageProbe :
         
@@ -592,7 +596,7 @@ class Edb(object):
         Parameters
         ----------
         fname : str
-            Name of the file to save to.
+            Name of the file to save EDB to.
 
         Returns
         -------
@@ -605,7 +609,7 @@ class Edb(object):
 
     @aedt_exception_handler
     def execute(self, func):
-        """Execute.
+        """Execute a function.
 
         Parameters
         ----------
@@ -630,8 +634,8 @@ class Edb(object):
         inputBrd : str
             Full path to the BRD file.
         WorkDir : str
-            Directory in which to create the ``aedb`` folder. The AEDB name will be the 
-            same as the BRD name. The default value is ``None``.
+            Directory in which to create the ``aedb`` folder. The AEDB file name will be 
+            the same as the BRD file name. The default value is ``None``.
 
         Returns
         -------
@@ -653,8 +657,8 @@ class Edb(object):
         inputGDS : str
             Full path to the BRD file.
         WorkDir : str
-            Directory in which to create the ``aedb` folder. The AEDB name will be the 
-            same as the BRD name. The default value is ``None``.
+            Directory in which to create the ``aedb` folder. The AEDB file name will be 
+            the same as the BRD file name. The default value is ``None``.
 
         Returns
         -------
@@ -678,7 +682,7 @@ class Edb(object):
         reference_list : list
             List of references to add. The default is ``["GND"]``.
         extent_type : str
-            Type of the extension. Options are ``"Conforming"`` or 
+            Type of the extension. Options are ``"Conforming"`` and 
             ``"Bounding"``. The default is ``Conformaing``.
         expansion_size : float
             Expansion size ratio in meters. The default is ``0.002``.
@@ -687,11 +691,13 @@ class Edb(object):
         output_aedb_path : str, optional
             Full path to the new AEDB file.
         replace_design_with_cutout : bool, optional
-            Whether to replace the design with the cutou. The default 
+            Whether to replace the design with the cutout. The default 
             is ``True``.      
 
         Returns
         -------
+        bool
+            ``True`` when successful, ``False`` when failed.
 
         """
         _signal_nets = []
@@ -756,6 +762,16 @@ class Edb(object):
 
     @aedt_exception_handler
     def write_export3d_option_config_file(self, path_to_output, config_dictionaries=None):
+        """Write the options for a 3D export to a configuration file.
+        
+        Parameters
+        ----------
+        path_to_output : str
+            Full path to the configuration file where the 3D export optons are to be saved.
+        
+        config_dictionaries : optional
+        
+        """
         option_config = {
             "UNITE_NETS": 1,
             "ASSIGN_SOLDER_BALLS_AS_SOURCES": 0,

--- a/pyaedt/emit.py
+++ b/pyaedt/emit.py
@@ -1,4 +1,4 @@
-"""This module contains the ``Emit`` class."""
+ """This module contains the ``Emit`` class."""
 
 from __future__ import absolute_import
 
@@ -11,11 +11,10 @@ from .generic.general_methods import aedt_exception_handler, generate_unique_nam
 
 
 class Emit(FieldAnalysisEmit, object):
-    """Emit class.
+    """Creates only a skeleton for an empty design currently.
 
     .. note::
-       At the moment, this object has very limited functionalities. It
-       contains only a skeleton for creating an empty design. No methods
+       This object has very limited functionalities. No methods
        are implemented yet.
 
     Parameters
@@ -88,6 +87,6 @@ class Emit(FieldAnalysisEmit, object):
         return self
 
     def __exit__(self, ex_type, ex_value, ex_traceback):
-        """ Push exit up to parent object Design """
+        """Push exit up to parent object Design """
         if ex_type:
             exception_to_desktop(self, ex_value, ex_traceback)

--- a/pyaedt/emit.py
+++ b/pyaedt/emit.py
@@ -1,5 +1,3 @@
- """This module contains the ``Emit`` class."""
-
 from __future__ import absolute_import
 
 import numbers
@@ -11,11 +9,11 @@ from .generic.general_methods import aedt_exception_handler, generate_unique_nam
 
 
 class Emit(FieldAnalysisEmit, object):
-    """Creates only a skeleton for an empty design currently.
+    """Creates currently only a skeleton for an empty design.
 
     .. note::
        This object has very limited functionalities. No methods
-       are implemented yet.
+       have been implemented yet.
 
     Parameters
     ----------

--- a/pyaedt/emit.py
+++ b/pyaedt/emit.py
@@ -9,7 +9,7 @@ from .generic.general_methods import aedt_exception_handler, generate_unique_nam
 
 
 class Emit(FieldAnalysisEmit, object):
-    """Creates currently only a skeleton for an empty design.
+    """Creates only a skeleton for an empty design.
 
     .. note::
        This object has very limited functionalities. No methods

--- a/pyaedt/emit.py
+++ b/pyaedt/emit.py
@@ -30,14 +30,14 @@ class Emit(FieldAnalysisEmit, object):
         ``None``, try to get an active design and, if no designs are
         present, create an empty design.
     solution_type : str, optional
-        Solution type to apply to design. The default is ``None``. If
-        ``None``, the default type is applied.
+        Solution type to apply to the design. The default is ``None``, in which
+        case the default type is applied.
     setup_name : str, optional
        Name of the setup to use as the nominal. The default is
-       ``None``. If ``None``, the active setup is used or nothing is
+       ``None``, in which case the active setup is used or nothing is
        used.
     specified_version : str, optional
-        Version of AEDT to use. The default is ``None``. If ``None``,
+        Version of AEDT to use. The default is ``None``, in which case
         the active setup is used or the latest installed version is
         used.
     NG : bool, optional
@@ -50,28 +50,28 @@ class Emit(FieldAnalysisEmit, object):
     release_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``True``.
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
-    Create an instance of ``Emit`` and connect to an existing Maxwell
+    Create an instance of Emit and connect to an existing Maxwell
     design or create a new Emit design if one does not exist.
 
     >>> from pyaedt import Emit
     >>> app = Emit()
 
-    Create a instance of ``Emit`` and link to a project named
+    Create a instance of Emit and link to a project named
     ``"projectname"``. If this project does not exist, create one with
     this name.
 
     >>> app = Emit(projectname)
 
-    Create an instance of ``Emit`` and link to a design named
+    Create an instance of Emit and link to a design named
     ``"designname"`` in a project named ``"projectname"``.
     
     >>> app = Emit(projectname,designame)
 
-    Create an instance of ``Emit`` and open the specified project.
+    Create an instance of Emit and open the specified project.
 
     >>> app = Emit("myfile.aedt")
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -49,7 +49,8 @@ class Hfss(FieldAnalysis3D, object):
         Whether to release AEDT on exit. The default is ``False``.
         Whether to release AEDT on exit. The default is ``True``.
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is 
+        ``False``.
 
     Examples
     --------
@@ -677,7 +678,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Port name when successful, ``False`` otherwise.
+            Name of port created when successful, ``False`` otherwise.
 
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
@@ -724,7 +725,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of name when successful, ``False`` otherwise.
+            Name of port created when successful, ``False`` otherwise.
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
                 endobject):
@@ -769,7 +770,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-           Source name when successful, ``False`` otherwise.
+           Name of source created when successful, ``False`` otherwise.
 
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
@@ -811,7 +812,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Source name when successful, ``False`` otherwise.
+            Name of source created when successful, ``False`` otherwise.
 
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
@@ -1117,8 +1118,8 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        bool
-            ``True`` when successful, ``False`` when failed.
+        :class:`pyaedt.hfss.SARSetup`
+            SARSetup object.
 
         """
         self.odesign.SARSetup(TissueMass, MaterialDensity, Tissue_object_List_ID, voxel_size, Average_SAR_method)
@@ -1397,7 +1398,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         list
-            List of names for the created ports when successful, ``False`` otherwise.
+            List of names for the ports created when successful, ``False`` otherwise.
         
         """
         sheet = self.modeler.convert_to_selections(sheet, True)
@@ -1451,7 +1452,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of port when succesful, ``False`` otherwise.
+            Name of the port created when succesful, ``False`` otherwise.
         """
 
         if self.solution_type in ["DrivenModal", "DrivenTerminal", "Transient Network"]:
@@ -1501,7 +1502,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of the source when successful, ``False`` otherwise.
+            Name of the source created when successful, ``False`` otherwise.
         
         """
 
@@ -1534,7 +1535,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of the source when successful, ``False`` otherwise.
+            Name of the source created when successful, ``False`` otherwise.
         
         """
 
@@ -1632,7 +1633,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of the Perfect H when successful, ``False`` otherwise.
+            Name of the Perfect H created when successful, ``False`` otherwise.
 
         """
 
@@ -1684,7 +1685,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of the impedence when successful; ``False`` otherwise.
+            Name of the impedence created when successful; ``False`` otherwise.
         
         """
 
@@ -1731,7 +1732,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of the port when successful, ``False`` otherwise.
+            Name of the port created when successful, ``False`` otherwise.
 
         """
         edge_list = [edge_signal, edge_gnd]

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -13,7 +13,7 @@ from .application.DataHandlers import random_string
 class Hfss(FieldAnalysis3D, object):
     """HFSS application interface.
 
-    This class allows you to create an interactive instance of `Hfss` and
+    This class allows you to create an interactive instance of HfSS and
     connect to an existing HFSS design or create a new HFSS design if
     one does not exist.
 
@@ -54,34 +54,34 @@ class Hfss(FieldAnalysis3D, object):
     Examples
     --------
 
-    Create an instance of `Hfss` and connect to an existing HFSS
+    Create an instance of HFSS and connect to an existing HFSS
     design or create a new HFSS design if one does not exist.
 
     >>> from pyaedt import Hfss
     >>> hfss = Hfss()
 
-    Create an instance of `Hfss` and link to a project named
+    Create an instance of HFSS and link to a project named
     ``projectname``. If this project does not exist, create one with
     this name.
 
     >>> hfss = Hfss(projectname)
 
-    Create an instance of `Hfss` and link to a design named
+    Create an instance of HFSS and link to a design named
     ``"designname"`` in a project named ``"projectname"``.
 
     >>> hfss = Hfss(projectname,designame)
 
-    Create an instance of `Hfss` and open the specified project,
+    Create an instance of HFSS and open the specified project,
     which is named ``"myfile.aedt"``.
 
     >>> hfss = Hfss("myfile.aedt")
 
-    Create an instance of `Hfss` using the 2021 R1 release and open
+    Create an instance of HFSS using the 2021 R1 release and open
     the specified project, which is named ``"myfile.aedt"``.
 
     >>> hfss = Hfss(specified_version="2021.1", projectname="myfile.aedt")
 
-    Create an instance of ``Hfss`` using the 2021 R2 student version and open
+    Create an instance of HFSS using the 2021 R2 student version and open
     the specified project, which is named ``"myfile.aedt"``.
 
     >>> hfss = Hfss(specified_version="2021.2", projectname="myfile.aedt", student_version=True)
@@ -109,7 +109,7 @@ class Hfss(FieldAnalysis3D, object):
             exception_to_desktop(self, ex_value, ex_traceback)
 
     class BoundaryType(object):
-        """Boundary class.
+        """Creates and manages boundaries.
 
         Parameters
         ----------
@@ -139,8 +139,9 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        type
-            Boundary created.
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object.
+        
         """
 
         bound = BoundaryObject(self, name, props, boundary_type)
@@ -293,7 +294,7 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
 
         Examples
@@ -618,6 +619,7 @@ class Hfss(FieldAnalysis3D, object):
         -------
         SweepHFSS
             Sweep object.
+        
         """
         if sweepname is None:
             sweepname = generate_unique_name("Sweep")
@@ -675,7 +677,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Port name.
+            Port name when successful, ``False`` otherwise.
 
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
@@ -722,7 +724,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Port name.
+            Name of name when successful, ``False`` otherwise.
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
                 endobject):
@@ -767,7 +769,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-           Source name.
+           Source name when successful, ``False`` otherwise.
 
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
@@ -809,7 +811,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Source name.
+            Source name when successful, ``False`` otherwise.
 
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
@@ -850,9 +852,10 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object.
 
         """
-
         props = OrderedDict({"Objects": [sheet_name],
                              "Direction": OrderedDict({"Start": point1, "End": point2})})
         return self._create_boundary(sourcename, props, sourcetype)
@@ -890,8 +893,9 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
+        
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
                 endobject):
@@ -974,8 +978,8 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
-            Port object.
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object.
 
         Examples
         --------
@@ -1035,7 +1039,7 @@ class Hfss(FieldAnalysis3D, object):
         
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
 
         """
@@ -1075,7 +1079,7 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
 
         """
@@ -1189,9 +1193,9 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
-
+        
         """
         if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
                 endobject):
@@ -1258,7 +1262,7 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
 
         """
@@ -1299,8 +1303,9 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
+        
         """
 
         props = {}
@@ -1392,7 +1397,8 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         list
-            List of objects created.
+            List of names for the created ports when successful, ``False`` otherwise.
+        
         """
         sheet = self.modeler.convert_to_selections(sheet, True)
         portnames = []
@@ -1445,7 +1451,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Object name.
+            Name of port when succesful, ``False`` otherwise.
         """
 
         if self.solution_type in ["DrivenModal", "DrivenTerminal", "Transient Network"]:
@@ -1495,7 +1501,8 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Object name
+            Name of the source when successful, ``False`` otherwise.
+        
         """
 
         if self.solution_type in ["DrivenModal", "DrivenTerminal", "Transient Network"]:
@@ -1527,7 +1534,8 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Object name
+            Name of the source when successful, ``False`` otherwise.
+        
         """
 
         if self.solution_type in ["DrivenModal", "DrivenTerminal", "Transient Network"]:
@@ -1556,7 +1564,7 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
 
         """
@@ -1581,7 +1589,7 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
 
         """
@@ -1624,7 +1632,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Object name.
+            Name of the Perfect H when successful, ``False`` otherwise.
 
         """
 
@@ -1676,7 +1684,8 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Object name
+            Name of the impedence when successful; ``False`` otherwise.
+        
         """
 
         if self.solution_type in ["DrivenModal", "DrivenTerminal", "Transient Network"]:
@@ -1721,8 +1730,8 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        bool
-            ``True`` when successful, ``False`` when failed.
+        str
+            Name of the port when successful, ``False`` otherwise.
 
         """
         edge_list = [edge_signal, edge_gnd]
@@ -1754,6 +1763,7 @@ class Hfss(FieldAnalysis3D, object):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         self._messenger.add_info_message("Setting Up Power to Eigemode " + powerin + "Watt")
         if self.solution_type != "Eigenmode":
@@ -1783,7 +1793,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         type
-            IDs of ports.
+            IDs of the ports.
 
         """
         tol = 1e-6
@@ -2055,8 +2065,8 @@ class Hfss(FieldAnalysis3D, object):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+            
         """
-
         Families = ["Freq:=", ["All"]]
         if variations:
             Families += variations
@@ -2128,6 +2138,7 @@ class Hfss(FieldAnalysis3D, object):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         npath = os.path.normpath(project_dir)
 
@@ -2217,8 +2228,8 @@ class Hfss(FieldAnalysis3D, object):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
-
         settings = []
         if activate:
             settings.append("NAME:Design Settings Data")
@@ -2246,6 +2257,8 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object.
 
         """
         object_list = self.modeler.convert_to_selections(obj_names, return_list=True)

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1685,7 +1685,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of the impedance created when successful; ``False`` otherwise.
+            Name of the impedance created when successful, ``False`` otherwise.
         
         """
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1452,7 +1452,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of the port created when succesful, ``False`` otherwise.
+            Name of the port created when successful, ``False`` otherwise.
         """
 
         if self.solution_type in ["DrivenModal", "DrivenTerminal", "Transient Network"]:
@@ -1685,7 +1685,7 @@ class Hfss(FieldAnalysis3D, object):
         Returns
         -------
         str
-            Name of the impedence created when successful; ``False`` otherwise.
+            Name of the impedance created when successful; ``False`` otherwise.
         
         """
 

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -103,7 +103,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional
-        Whether to laumch AEDT in the non-graphical mode. The default 
+        Whether to launch AEDT in the non-graphical mode. The default 
         is``False``, which launches AEDT in the graphical mode.  
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -11,10 +11,9 @@ from .generic.general_methods import generate_unique_name, aedt_exception_handle
 
 
 class SweepString(object):
-    """SweepString class.
+    """Generates a sweep string.
     
-    This class allows you to generate a sweep string like in this example: 
-    ``"LIN 10GHz 20GHz 0.05GHz LINC 20GHz 30GHz 10 DEC 30GHz 40GHz 10 40GHz``
+    For example, ``"LIN 10GHz 20GHz 0.05GHz LINC 20GHz 30GHz 10 DEC 30GHz 40GHz 10 40GHz``.
     
     Parameters
     ----------
@@ -79,8 +78,7 @@ class SweepString(object):
 class Hfss3dLayout(FieldAnalysis3DLayout):
     """HFSS 3D Layout instance interface.
 
-    This class contains all HFSS 3D Layout functionalities. It
-    inherits all objects that belong to HFSS 3D Layout, including EDB
+    Inherits all objects that belong to HFSS 3D Layout, including EDB
     API queries.
 
     Parameters

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -78,7 +78,7 @@ class SweepString(object):
 class Hfss3dLayout(FieldAnalysis3DLayout):
     """HFSS 3D Layout instance interface.
 
-    Inherits all objects that belong to HFSS 3D Layout, including EDB
+    This class inherits all objects that belong to HFSS 3D Layout, including EDB
     API queries.
 
     Parameters
@@ -100,19 +100,19 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         ``None``, in which case the active setup is used or 
         nothing is used.
     specified_version: str, optional
-        Version of AEDT  to use. The default is ``None``, in which case
+        Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default 
+        Whether to laumch AEDT in the non-graphical mode. The default 
         is``False``, which launches AEDT in the graphical mode.  
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
         another instance of the ``specified_version`` is active on the
-        machine.  The default is ``True``.
+        machine. The default is ``True``.
     release_on_exit : bool, optional
         Whether to release AEDT on exit. 
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
@@ -141,8 +141,8 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
     `Hfss3dLayout` object and open the specified project.
 
     >>> aedtapp = Hfss3dLayout(specified_version="2021.1", projectname="myfile.aedt")
+    
     """
-
     def __init__(self, projectname=None, designname=None, solution_type=None, setup_name=None,
                  specified_version=None, NG=False, AlwaysNew=False, release_on_exit=False, student_version=False):
         FieldAnalysis3DLayout.__init__(self, "HFSS 3D Layout Design", projectname, designname, solution_type,
@@ -152,7 +152,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         return self
 
     def __exit__(self, ex_type, ex_value, ex_traceback):
-        ''' Push exit up to parent object Design '''
+        """Push exit up to parent object Design."""
         if ex_type:
             exception_to_desktop(self, ex_value, ex_traceback)
 
@@ -172,7 +172,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         Returns
         -------
         type
-            Port name
+            Name of the port when successful, ``False`` when failed.
 
         """
         listp = self.port_list
@@ -215,6 +215,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         -------
         str
             Name of the port when successful, ``False`` when failed.
+        
         """
         listp = self.port_list
         if type(layer) is str:
@@ -234,7 +235,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
 
     @aedt_exception_handler
     def create_pin_port(self,name,xpos=0, ypos=0, rotation=0, top_layer=None, bot_layer=None):
-        """Create a new pin port.
+        """Create a pin port.
 
         Parameters
         ----------
@@ -257,6 +258,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         self.modeler.layers.refresh_all_layers()
         layers = self.modeler.layers.all_signal_layers
@@ -296,6 +298,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         self.oexcitation.Delete(portname)
         return True
@@ -307,12 +310,13 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         Parameters
         ----------
         edb_full_path : str
-            Full path to the EDB.
+            Full path to EDB.
             
         Returns
         -------
         bool
             ``True`` when successful, ``False`` when failed. 
+        
         """
         oTool = self.odesktop.GetTool("ImportExport")
         oTool.ImportEDB(edb_full_path)
@@ -419,7 +423,6 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
     @aedt_exception_handler
     def create_scattering(self, plot_name="S Parameter Plot Nominal", sweep_name=None, port_names=None, port_excited=None, variations=None):
         """Create a scattering report.
-        
 
         Parameters
         ----------
@@ -438,6 +441,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         Families = ["Freq:=", ["All"]]
         if variations:
@@ -494,6 +498,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         # normalize the save path
         if not filename:
@@ -545,6 +550,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         settings = []
         if activate:
@@ -572,7 +578,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         ----------
         setupname : str
             Name of the setup that is attached to the sweep.
-        unit :
+        unit : str
             Units, such as ``"MHz"`` or ``"GHz"``.
         freqstart : float
             Starting frequency of the sweep.
@@ -580,10 +586,11 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
             Stopping frequency of the sweep.
         num_of_freq_points : int
             Number of frequency points in the range.
-        sweepname : str
+        sweepname : str, optional
             Name of the sweep. The default is ``None``.
         sweeptype : str, optional
-            Type of the sweep. Options are ``"Fast"``, ``"Interpolating"``, and ``"Discrete"``. The default is ``"Interpolating``.
+            Type of the sweep. Options are ``"Fast"``, ``"Interpolating"``, and ``"Discrete"``. 
+            The default is ``"Interpolating"``.
         interpolation_tol_percent : float, optional
             Error tolerance threshold for the interpolation process. The default is ``0.5``.
         interpolation_max_solutions : int, optional
@@ -598,7 +605,8 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         Returns
         -------
         str
-            Setup name if operation is successful.
+            Name of the setup when successful, ``False`` otherwise.
+        
         """
         if sweepname is None:
             sweepname = generate_unique_name("Sweep")
@@ -672,16 +680,16 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
 
     @aedt_exception_handler
     def import_gds(self, gds_path, aedb_path=None, xml_path=None, set_as_active=True, close_active_project=False):
-        """Import grounds into HFSS 3D Layout and assign the stackup from an XML file if present.
+        """Import grounds into the HFSS 3D Layout and assign the stackup from an XML file if present.
 
         Parameters
         ----------
         gds_path : str
             Full path to the GDS file.
         aedb_path : str, optional
-            Full path to the AEDB file
+            Full path to the AEDB file.
         xml_path : str, optional
-            Path to the XML file with stackup information. The default is ``None``, in 
+            Path to the XML file with the stackup information. The default is ``None``, in 
             which case the stackup is not edited.
         set_as_active : bool, optional
             Whether to set the GDS file as active. The default is ``True``.
@@ -692,6 +700,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         active_project = self.project_name
         project_name = os.path.basename(gds_path)[:-4]

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -37,10 +37,10 @@ class Icepak(FieldAnalysisIcepak):
         ``None``, in which case the active setup is used or 
         nothing is used.
     specified_version: str, optional
-        Version of AEDT  to use. The default is ``None``, in which case
+        Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is  used.
     NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default 
+        Whether to launch AEDT in the non-graphical mode. The default 
         is``False``, which launches AEDT in the graphical mode.  
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
@@ -49,23 +49,23 @@ class Icepak(FieldAnalysisIcepak):
     release_on_exit : bool, optional
         Whether to release AEDT on exit. 
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
-    Create an instance of `Icepak` and connect to an existing Icepak
+    Create an instance of Icepak and connect to an existing Icepak
     design or create a new Icepak design if one does not exist.
 
     >>> from pyaedt import Icepak
     >>> aedtapp = Icepak()
 
-    Create an instance of `Icepak` and link to a project named
+    Create an instance of Icepak and link to a project named
     ``projectname``. If this project does not exist, create one with
     this name.
 
     >>> aedtapp = Icepak(projectname)
 
-    Create an instance of `Icepak` and link to a design named
+    Create an instance of Icepak and link to a design named
     ``designname`` in a project named ``projectname``.
 
     >>> aedtapp = Icepak(projectname,designame)
@@ -75,7 +75,7 @@ class Icepak(FieldAnalysisIcepak):
 
     >>> aedtapp = Icepak("myfile.aedt")
 
-    Create an instance of `Icepak` using the 2021 R1 release and
+    Create an instance of Icepak using the 2021 R1 release and
     open the specified project, which is ``myfile.aedt``.
 
     >>> aedtapp = Icepak(specified_version="2021.1", projectname="myfile.aedt")
@@ -91,7 +91,7 @@ class Icepak(FieldAnalysisIcepak):
         return self
 
     def __exit__(self, ex_type, ex_value, ex_traceback):
-        ''' Push exit up to parent object Design '''
+        """Push exit up to parent object Design."""
         if ex_type:
             exception_to_desktop(self, ex_value, ex_traceback)
 
@@ -124,10 +124,9 @@ class Icepak(FieldAnalysisIcepak):
         Returns
         -------
         type
-            Bound object when successful or ``None`` when failed.
+            Bound object when successful, ``None`` when failed.
 
         """
-
         boundary_name = generate_unique_name("Opening")
         self.modeler.create_face_list(air_faces, "boundary_faces")
         props = {}
@@ -147,7 +146,7 @@ class Icepak(FieldAnalysisIcepak):
 
     @aedt_exception_handler
     def assign_2way_coupling(self,setup_name=None, number_of_iterations=2, continue_ipk_iterations=True, ipk_iterations_per_coupling=20):
-        """Assign two-way coupling to a specific setup.
+        """Assign two-way coupling to a setup.
 
         Parameters
         ----------
@@ -166,7 +165,6 @@ class Icepak(FieldAnalysisIcepak):
             ``True`` when successful, ``False`` when failed.
 
         """
-
         if not setup_name:
             if self.setups:
                 setup_name =self.setups[0].name
@@ -181,14 +179,14 @@ class Icepak(FieldAnalysisIcepak):
 
     @aedt_exception_handler
     def create_source_blocks_from_list(self, list_powers, assign_material=True, default_material="Ceramic_material"):
-        """Assign to a box in Icepak the sources that coming from the CSV file. 
+        """Assign to a box in Icepak the sources that come from the CSV file. 
         
         Assignment is made by name.
 
         Parameters
         ----------
         list_powers : list
-            List of input powers. It is a list of list like in this examples: 
+            List of input powers. It is a list of lists. For example, 
             ``[["Obj1", 1], ["Obj2", 3]]``. The list can contain multiple 
             columns for power inputs.
         assign_material : bool, optional
@@ -283,10 +281,12 @@ class Icepak(FieldAnalysisIcepak):
             Whether to enable radiation. The default is ``False``.
         source_name : str, optional
             Name of the source. The default is ``None``.
+        
         Returns
         -------
-        BoundaryObject
-            Boundary object when successful or ``None`` when failed.
+        :class:`pyaedt.modules.Bounary.BoundaryObject`
+            Boundary object.
+        
         """
         if not source_name:
             source_name = generate_unique_name("Source")
@@ -330,8 +330,9 @@ class Icepak(FieldAnalysisIcepak):
 
         Returns
         -------
-        type
-            Bounding object when successful.
+        :class:`pyaedt.modules.Bounary.BoundaryObject`
+            Boundary object.
+        
         """
         if object_name in self.modeler.primitives.object_names:
             faces = self.modeler.primitives.get_object_faces(object_name)
@@ -385,12 +386,12 @@ class Icepak(FieldAnalysisIcepak):
         Parameters
         ----------
         input_list : list
-            List of sources with inputs  ``rjc``,  ``rjb``, and ``power``. 
-            For example: ``[[Objname1, rjc, rjb, power1,power2....],[Objname2, rjc2, rbj2, power1, power2...]]``.
+            List of sources with inputs ``rjc``,  ``rjb``, and ``power``. 
+            For example, ``[[Objname1, rjc, rjb, power1,power2....],[Objname2, rjc2, rbj2, power1, power2...]]``.
         gravity_dir : int
             Gravity direction from -X to +Z. Options are ``0`` to ``5``.
         top :
-            Board bounding value in mm of the top face.
+            Board bounding value in millimeters of the top face.
         assign_material : bool, optional
             Whether to assign a material. The default is ``True``.
         default_material : str, optional
@@ -400,6 +401,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         type
             Networks boundary objects.
+        
         """
         objs = self.modeler.primitives.solid_names
         countpow = len(input_list[0])-3
@@ -440,6 +442,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         if not monitor_name:
             monitor_name = generate_unique_name("Monitor")
@@ -465,6 +468,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         point_name = generate_unique_name("Point")
         self.modeler.oeditor.CreatePoint(
@@ -492,6 +496,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         type
             Total power applied.
+        
         """
         with open(csv_name) as csvfile:
             csv_input = csv.reader(csvfile)
@@ -545,6 +550,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
              ``True`` when successful, ``False`` when failed.     
+        
         """
         temp_log = os.path.join(self.project_path, "validation.log")
         validate = self.odesign.ValidateDesign(temp_log)
@@ -580,6 +586,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         float
             Top position
+        
         """
         dirs = ["-X", "+X", "-Y", "+Y", "-Z", "+Z"]
         for dir in dirs:
@@ -645,6 +652,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         all_objs = self.modeler.primitives.object_names
         self['FinPitch'] = self.modeler.primitives._arg_with_dim(pitch)
@@ -766,9 +774,9 @@ class Icepak(FieldAnalysisIcepak):
         ambtemp : optional 
             Ambient temperature. The default is ``22``.
         performvalidation : bool, optional
-            Whether to enable validation. The default is ``False``.
+            Whether to perform validation. The default is ``False``.
         CheckLevel : optional
-            Level of check during validation. The default is ``None``.
+            Level of check to perform during validation. The default is ``None``.
         defaultfluid : str, optional
             Default fluid material. The default is ``"air"``.
         defaultsolid : str, optional
@@ -778,6 +786,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         AmbientTemp = str(ambtemp)+"cel"
         #
@@ -828,6 +837,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         self._messenger.add_info_message("Mapping HFSS EM Lossess")
         oName = self.project_name
@@ -870,7 +880,7 @@ class Icepak(FieldAnalysisIcepak):
         bound = BoundaryObject(self, name, props, "EMLoss")
         if bound.create():
             self.boundaries.append(bound)
-            self._messenger.add_info_message('EM losses Mapped from design {}'.format(designname))
+            self._messenger.add_info_message('EM losses mapped from design {}.'.format(designname))
             return bound
         return False
 
@@ -901,6 +911,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         str
             Name of the file.
+        
         """
         name=generate_unique_name(quantity_name)
         self.modeler.create_face_list(faces_list,name )
@@ -952,6 +963,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         str
            Name of the file.
+        
         """
         if not savedir:
             savedir = self.project_path
@@ -991,6 +1003,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         newfilename = os.path.join(savedir, proj_icepak + "_HTCAndTemp.csv")
         newfilelines = []
@@ -1057,6 +1070,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         all_objs = list(self.modeler.oeditor.GetObjectsInGroup("Solids"))
         all_objs_NonModeled = list(self.modeler.oeditor.GetObjectsInGroup("Non Model"))
@@ -1106,8 +1120,7 @@ class Icepak(FieldAnalysisIcepak):
             * ``"Nothing"``
             * ``"Low"``
             * ``"High"``
-            * ``"Both"``
-            
+            * ``"Both"``   
 
         Returns
         -------
@@ -1146,6 +1159,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         list
             List containing the requested link data.
+        
         """
         if linkData[0] is None:
             project_name = "This Project*"
@@ -1191,7 +1205,7 @@ class Icepak(FieldAnalysisIcepak):
         rad : str, optional
             Radiating faces. The default is ``"Nothing"``.
         extenttype : str, optional
-            Type of the extent. Options are ``"Bounding Box"`` or ``"Polygon"``.  
+            Type of the extent. Options are ``"Bounding Box"`` and ``"Polygon"``.  
             The default is ``"Bounding Box"``.
         outlinepolygon : str, optional
             Name of the polygon if ``extentype="Polygon"``. The default is ``""``.
@@ -1202,6 +1216,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
              ``True`` when successful, ``False`` when failed.
+        
         """
         lowRad, highRad = self.get_radiation_settings(rad)
         hfssLinkInfo = self.get_link_data(setupLinkInfo)
@@ -1278,7 +1293,9 @@ class Icepak(FieldAnalysisIcepak):
     def create_pcb_from_3dlayout(self, component_name, project_name, design_name, resolution=2,
                                  extenttype="Bounding Box", outlinepolygon="", close_linked_project_after_import=True,
                                  custom_x_resolution=None, custom_y_resolution=None):
-        """Create a PCB component in Icepak that is linked to an HFSS 3D Layout object linking only to the geometry file (no solution linked)
+        """Create a PCB component in Icepak that is linked to an HFSS 3D Layout object linking only to the geometry file.
+        
+        No solution is linked.
 
         Parameters
         ----------
@@ -1291,7 +1308,7 @@ class Icepak(FieldAnalysisIcepak):
         resolution : optional
             Resolution of the mapping. The default is `2`.
         extenttype :
-            Type of the extent. Options are ``"Polygon"`` or ``"Bounding Box"``. The default is ``"Bounding Box"``.
+            Type of the extent. Options are ``"Polygon"`` and ``"Bounding Box"``. The default is ``"Bounding Box"``.
         outlinepolygon : str, optional
             Name of the outline polygon if ``extentyype="Polygon"``. The default is ``""``.
         close_linked_project_after_import : bool, optional
@@ -1301,6 +1318,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         if project_name == self.project_name:
             project_name = "This Project*"
@@ -1334,6 +1352,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         oName = self.project_name
         if sourceProject == oName or sourceProject is None:
@@ -1372,6 +1391,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         if not object_list:
             allObjects = self.modeler.primitives.object_names
@@ -1428,6 +1448,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         oModule = self.odesign.GetModule("MeshRegion")
 
@@ -1478,6 +1499,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         tuple
             Tuple containing the ``(x, y, z)`` distances of the region.
+        
         """
         self.modeler.edit_region_dimensions([0,0,0,0,0,0])
 
@@ -1530,6 +1552,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
              ``True`` when successful, ``False`` when failed.
+        
         """
         arg1 = ["NAME:PointParameters",
                "PointX:="		, point_coord[0],
@@ -1552,7 +1575,7 @@ class Icepak(FieldAnalysisIcepak):
 
     @aedt_exception_handler
     def delete_em_losses(self, bound_name):
-        """Delete EM losses boundary.
+        """Delete the EM losses boundary.
 
         Parameters
         ----------
@@ -1563,8 +1586,8 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
-
         self.oboundary.DeleteBoundaries([bound_name])
         return True
 
@@ -1581,6 +1604,7 @@ class Icepak(FieldAnalysisIcepak):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         arg = ["NAME:Selections",
                "Selections:="		, comp_name]

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -387,7 +387,7 @@ class Icepak(FieldAnalysisIcepak):
         ----------
         input_list : list
             List of sources with inputs ``rjc``,  ``rjb``, and ``power``. 
-            For example, ``[[Objname1, rjc, rjb, power1,power2....],[Objname2, rjc2, rbj2, power1, power2...]]``.
+            For example, ``[[Objname1, rjc, rjb, power1, power2, ...], [Objname2, rjc2, rbj2, power1, power2, ...]]``.
         gravity_dir : int
             Gravity direction from -X to +Z. Options are ``0`` to ``5``.
         top :
@@ -1295,7 +1295,8 @@ class Icepak(FieldAnalysisIcepak):
                                  custom_x_resolution=None, custom_y_resolution=None):
         """Create a PCB component in Icepak that is linked to an HFSS 3D Layout object linking only to the geometry file.
         
-        No solution is linked.
+        .. note::
+           No solution is linked.
 
         Parameters
         ----------

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -41,7 +41,7 @@ class Icepak(FieldAnalysisIcepak):
         the active version or latest installed version is  used.
     NG : bool, optional
         Whether to launch AEDT in the non-graphical mode. The default 
-        is``False``, which launches AEDT in the graphical mode.  
+        is ``False``, which launches AEDT in the graphical mode.  
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
         another instance of the ``specified_version`` is active on the

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -284,7 +284,7 @@ class Icepak(FieldAnalysisIcepak):
         
         Returns
         -------
-        :class:`pyaedt.modules.Bounary.BoundaryObject`
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
         
         """
@@ -330,7 +330,7 @@ class Icepak(FieldAnalysisIcepak):
 
         Returns
         -------
-        :class:`pyaedt.modules.Bounary.BoundaryObject`
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
         
         """

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -57,11 +57,12 @@ with Desktop() as d:
 
 
 def float_units(val_str, units=""):
-    """
+    """Retrieve units for a value.
 
     Parameters
     ----------
     val_str : str
+        Name of the float  
         
     units : str, optional
          The default is ``""``.
@@ -86,10 +87,7 @@ def float_units(val_str, units=""):
 
 
 class Maxwell(object):
-    """Maxwell class.
-    
-    .. note::
-       This class contains all methods that are common to Maxwell 2D and Maxwell 3D.
+    """Contains all methods that are common to both Maxwell 2D and Maxwell 3D.
 
     Parameters
     ----------
@@ -113,7 +111,7 @@ class Maxwell(object):
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default
+        Whether to launch AEDT in the non-graphical mode. The default
         is ``False``, in which case AEDT launches in the graphical mode.
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
@@ -121,9 +119,8 @@ class Maxwell(object):
         machine. The default is ``True``.
     release_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``False``.
-
-    Returns
-    -------
+    student_version : bool, optional
+        Whether to open the AEDT student veresion. The default is ``False``.
 
     """
 
@@ -192,7 +189,6 @@ class Maxwell(object):
         -------
         bool
             ``True`` when successful and ``False`` when failed.
-
         """
 
         self._py_file = setupname + ".py"
@@ -253,7 +249,9 @@ class Maxwell(object):
 
         Returns
         -------
-
+        bool
+            ``True`` when successful and ``False`` when failed.
+        
         """
         EddyVector = ["NAME:EddyEffectVector"]
         for obj in object_list:
@@ -289,11 +287,10 @@ class Maxwell(object):
 
         Returns
         -------
-        BoundaryObject
-            Boundary object
-            
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object.
+           
         """
-
         amplitude = str(amplitude) + "A"
 
         if not name:
@@ -327,9 +324,9 @@ class Maxwell(object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
-
+        
         """
 
         amplitude = str(amplitude) + "mV"
@@ -364,9 +361,8 @@ class Maxwell(object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
-
         """
 
         amplitude = str(amplitude) + "mV"
@@ -410,9 +406,8 @@ class Maxwell(object):
 
         Returns
         -------
-        BoundaryObject
-            Bounding object for the winding; otherwise only the bounding object.
-
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object for the winding; otherwise only the bounding object.
         """
 
         if not name:
@@ -515,8 +510,7 @@ class Maxwell(object):
 
     @aedt_exception_handler
     def assign_force(self, input_object, reference_cs="Global", is_virtual=True, force_name=None):
-        """
-        Assign a force to one or more objects.
+        """Assign a force to one or more objects.
 
         Parameters
         ----------
@@ -535,7 +529,6 @@ class Maxwell(object):
             ``True`` when successful, ``False`` when failed.
         
         """
-
         input_object = self.modeler._convert_list_to_ids(input_object, True)
         if not force_name:
             force_name = generate_unique_name("Force")
@@ -558,8 +551,7 @@ class Maxwell(object):
 
     @aedt_exception_handler
     def assign_torque(self, input_object, reference_cs="Global", is_positive=True, is_virtual=True, axis="Z", torque_name=None):
-        """
-        Assign a torque to one or more objects.
+        """Assign a torque to one or more objects.
 
         Parameters
         ----------
@@ -582,7 +574,6 @@ class Maxwell(object):
             ``True`` when successful, ``False`` when failed.
         
         """
-
         input_object = self.modeler._convert_list_to_ids(input_object, True)
         if not torque_name:
             torque_name = generate_unique_name("Torque")
@@ -616,7 +607,6 @@ class Maxwell(object):
             ``True`` when successful, ``False`` when failed.
         
         """
-
         input_object = self.modeler._convert_list_to_ids(input_object, True)
         if not force_name:
             force_name = generate_unique_name("Force")
@@ -642,14 +632,23 @@ class Maxwell(object):
 
         Returns
         -------
-
+        bool
+            ``True`` when successful, ``False`` when failed.
+            
         """
         self.modeler.primitives[name].solve_inside = activate
         return True
 
     @aedt_exception_handler
     def analyse_from_zero(self):
-        """Analyze from zero."""
+        """Analyze from zero.
+        
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+        
+        """
         self.oanalysis.ResetSetupToTimeZero(self._setup)
         self.analyse_nominal()
         return True
@@ -667,6 +666,8 @@ class Maxwell(object):
 
         Returns
         -------
+        bool
+            ``True`` when successful, ``False`` when failed.
 
         """
         self.odesign.ChangeProperty(

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -727,7 +727,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default
+        Whether to launch AEDT in the non-graphical mode. The default
         is ``False``, in which case AEDT is launched in the graphical mode.
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
@@ -736,17 +736,17 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
     release_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``False``.
      student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
-    Create an instance of `Maxwell3d` and open the specified
+    Create an instance of Maxwell 3D and open the specified
     project, which is named ``myfile.aedt``.
 
     >>> from pyaedt import Maxwell3d
     >>> aedtapp = Maxwell3d("myfile.aedt")
 
-    Create an instance of `Maxwell3d` using the 2021 R1 release and open
+    Create an instance of Maxwell 3D using the 2021 R1 release and open
     the specified project, which is named ``myfile.aedt``.
 
     >>> aedtapp = Maxwell3d(specified_version="2021.1", projectname="myfile.aedt")
@@ -771,7 +771,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
 class Maxwell2d(Maxwell, FieldAnalysis2D, object):
     """Maxwell 2D application interface.
 
-    Allows you to connect to an existing Maxwell 2D design or create a
+    This class allows you to connect to an existing Maxwell 2D design or create a
     new Maxwell 2D design if one does not exist.
 
     Parameters
@@ -796,7 +796,7 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default
+        Whether to launch AEDT in the non-graphical mode. The default
         is ``False``, in which case AEDT is launched in the graphical mode.
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
@@ -805,24 +805,24 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
     release_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``False``.
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
-    Create an instance of `Maxwell2d` and connect to an existing
+    Create an instance of Maxwell 2D and connect to an existing
     Maxwell 2D design or create a new Maxwell 2D design if one does
     not exist.
 
     >>> from pyaedt import Maxwell2d
     >>> aedtapp = Maxwell2d()
 
-    Create an instance of `Maxwell2d` and link to a project named
+    Create an instance of Maxwell 2D and link to a project named
     ``projectname``. If this project does not exist, create one with
     this name.
 
     >>> aedtapp = Maxwell2d(projectname)
 
-    Create an instance of `Maxwell2d` and link to a design named
+    Create an instance of Maxwell 2D and link to a design named
     ``designname`` in a project named ``projectname``.
 
     >>> aedtapp = Maxwell2d(projectname,designame)
@@ -925,7 +925,14 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
 
     @aedt_exception_handler
     def read_design_data(self):
-        """Read back the design data as a dictionary."""
+        """Read back the design data as a dictionary.
+        
+        Return
+        ------
+        dict
+            Dictionary of design data.
+        
+        """
         design_file = os.path.join(self.working_directory, "design_data.json")
         with open(design_file, 'r') as fps:
             design_data = json.load(fps)
@@ -944,7 +951,7 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
 
         Returns
         -------
-        BoundaryObject
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
 
         """
@@ -977,8 +984,8 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
 
         Returns
         -------
-        BoundaryObject
-            Vector Potential Object
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object.
 
         """
         input_edge= self.modeler._convert_list_to_ids(input_edge)

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -927,8 +927,8 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
     def read_design_data(self):
         """Read back the design data as a dictionary.
         
-        Return
-        ------
+        Returns
+        -------
         dict
             Dictionary of design data.
         

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -120,7 +120,7 @@ class Maxwell(object):
     release_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``False``.
     student_version : bool, optional
-        Whether to open the AEDT student veresion. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     """
 

--- a/pyaedt/mechanical.py
+++ b/pyaedt/mechanical.py
@@ -12,8 +12,6 @@ from collections import OrderedDict
 class Mechanical(FieldAnalysis3D, object):
     """Mechanical application interface.
 
-    This class exposes features from the Mechanical application.
-
     Parameters
     ----------
     projectname : str, optional
@@ -27,46 +25,46 @@ class Mechanical(FieldAnalysis3D, object):
         designs are present, an empty design is created.
     solution_type : str, optional
         Solution type to apply to the design. The default is
-        ``None``, which applies the default type.
+        ``None``, in which case the default type is applied.
     setup_name : str, optional
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
     specified_version: str, optional
-        Version of AEDT  to use. The default is ``None``, in which case
-        the active version or latest installed version is  used.
+        Version of AEDT to use. The default is ``None``, in which case
+        the active version or latest installed version is used.
     NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default
+        Whether to launch AEDT in the non-graphical mode. The default
         is``False``, which launches AEDT in the graphical mode.
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
         another instance of the ``specified_version`` is active on the
-        machine.  The default is ``True``.
+        machine. The default is ``True``.
     release_on_exit : bool, optional
         Whether to release AEDT on exit.
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
-    Create an instance of `Mechanical` and connect to an existing
+    Create an instance of Mechanical and connect to an existing
     HFSS design or create a new HFSS design if one does not exist.
 
     >>> from pyaedt import Mechanical
     >>> aedtapp = Mechanical()
 
-    Create an instance of `Mechanical` and link to a project named
+    Create an instance of Mechanical and link to a project named
     ``"projectname"``. If this project does not exist, create one with
     this name.
 
     >>> aedtapp = Mechanical(projectname)
 
-    Create an instance of `Mechanical` and link to a design named
+    Create an instance of Mechanical and link to a design named
     ``"designname"`` in a project named ``projectname``.
 
     >>> aedtapp = Mechanical(projectname,designame)
 
-    Create an instance of `Mechanical` and open the specified
+    Create an instance of Mechanical and open the specified
     project, which is named ``myfile.aedt``.
 
     >>> aedtapp = Mechanical("myfile.aedt")
@@ -88,7 +86,7 @@ class Mechanical(FieldAnalysis3D, object):
         return self
 
     def __exit__(self, ex_type, ex_value, ex_traceback):
-        """ Push exit up to parent object Design """
+        """Push exit up to parent object Design."""
         if ex_type:
             exception_to_desktop(self, ex_value, ex_traceback)
 
@@ -112,7 +110,7 @@ class Mechanical(FieldAnalysis3D, object):
             List objects in the source that are metals. The default is ``[]``.
         source_project_name : str, optional
             Name of the source project. The default is ``None``, in which case
-	      the source from the same project is used.
+	    the source from the same project is used.
         paramlist : list, optional
             List of all parameters in the EM to map. The default is ``[]``.
         object_list : list, optional
@@ -162,7 +160,7 @@ class Mechanical(FieldAnalysis3D, object):
         bound = BoundaryObject(self, name, props, "EMLoss")
         if bound.create():
             self.boundaries.append(bound)
-            self._messenger.add_info_message('EM losses mapped from design {}'.format(designname))
+            self._messenger.add_info_message('EM losses mapped from design {}.'.format(designname))
             return bound
         return False
 
@@ -194,7 +192,8 @@ class Mechanical(FieldAnalysis3D, object):
 
         Returns
         -------
-
+	:class:`aedt.modules.Boundary.Boundary object
+	    Boundary object.
         """
 
         assert self.solution_type == "Structural", "This method works only in a Mechanical structural solution."
@@ -237,7 +236,7 @@ class Mechanical(FieldAnalysis3D, object):
     @aedt_exception_handler
     def assign_uniform_convection(self, objects_list, convection_value, convection_unit="w_per_m2kel",
                                   temperature="AmbientTemp", boundary_name=""):
-        """Assign uniform convection to the face list.
+        """Assign a uniform convection to the face list.
 
         Parameters
         ----------
@@ -254,8 +253,8 @@ class Mechanical(FieldAnalysis3D, object):
 
         Returns
         -------
-        type
-            Boundary Object
+        :class:`aedt.modules.Boundary.Boundary object
+	    Boundary object.
 
         """
         assert self.solution_type == "Thermal", "This method works only in a Mechanical structural solution."
@@ -299,8 +298,8 @@ class Mechanical(FieldAnalysis3D, object):
 
         Returns
         -------
-        type
-            Boundary Object
+        :class:`aedt.modules.Boundary.Boundary object
+	    Boundary object.
 
         """
         assert self.solution_type == "Thermal", "This method works only in a Mechanical structural analysis."
@@ -341,8 +340,8 @@ class Mechanical(FieldAnalysis3D, object):
 
         Returns
         -------
-        type
-            boundary object
+        :class:`aedt.modules.Boundary.Boundary object
+	    Boundary object.
 
         """
 
@@ -383,8 +382,8 @@ class Mechanical(FieldAnalysis3D, object):
 
         Returns
         -------
-        type
-            boundary object
+        :class:`aedt.modules.Boundary.Boundary object
+	    Boundary object.
 
         """
         if not (self.solution_type == "Structural" or self.solution_type == "Modal"):
@@ -409,12 +408,10 @@ class Mechanical(FieldAnalysis3D, object):
     def existing_analysis_sweeps(self):
         """List of existing analysis setups in the Mechanical design.
 
-
         Returns
         -------
         list
             List of existing analysis setups.
-
 
         """
         setup_list = self.existing_analysis_setups

--- a/pyaedt/mechanical.py
+++ b/pyaedt/mechanical.py
@@ -110,7 +110,7 @@ class Mechanical(FieldAnalysis3D, object):
             List objects in the source that are metals. The default is ``[]``.
         source_project_name : str, optional
             Name of the source project. The default is ``None``, in which case
-	    the source from the same project is used.
+	      the source from the same project is used.
         paramlist : list, optional
             List of all parameters in the EM to map. The default is ``[]``.
         object_list : list, optional
@@ -192,8 +192,8 @@ class Mechanical(FieldAnalysis3D, object):
 
         Returns
         -------
-	:class:`aedt.modules.Boundary.Boundary object
-	    Boundary object.
+	  :class:`aedt.modules.Boundary.Boundary object
+	      Boundary object.
         """
 
         assert self.solution_type == "Structural", "This method works only in a Mechanical structural solution."
@@ -254,7 +254,7 @@ class Mechanical(FieldAnalysis3D, object):
         Returns
         -------
         :class:`aedt.modules.Boundary.Boundary object
-	    Boundary object.
+	      Boundary object.
 
         """
         assert self.solution_type == "Thermal", "This method works only in a Mechanical structural solution."
@@ -299,7 +299,7 @@ class Mechanical(FieldAnalysis3D, object):
         Returns
         -------
         :class:`aedt.modules.Boundary.Boundary object
-	    Boundary object.
+	      Boundary object.
 
         """
         assert self.solution_type == "Thermal", "This method works only in a Mechanical structural analysis."
@@ -341,7 +341,7 @@ class Mechanical(FieldAnalysis3D, object):
         Returns
         -------
         :class:`aedt.modules.Boundary.Boundary object
-	    Boundary object.
+	      Boundary object.
 
         """
 
@@ -383,7 +383,7 @@ class Mechanical(FieldAnalysis3D, object):
         Returns
         -------
         :class:`aedt.modules.Boundary.Boundary object
-	    Boundary object.
+	      Boundary object.
 
         """
         if not (self.solution_type == "Structural" or self.solution_type == "Modal"):

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -11,42 +11,16 @@ import os
 
 
 class QExtractor(FieldAnalysis3D, FieldAnalysis2D, object):
-    """
+    """Extracts a 2D or 3D fielld analysis.
+    
     Parameters
     ----------
-     Q3DType :
+    FieldAnalysis3D :
+    
+    FieldAnalysis2D :
+    
+    object :
 
-     projectname : str, optional
-        Name of the project to select or the full path to the project
-        or AEDTZ archive to open. The default is ``None``, in which
-        case an attempt is made to get an active project. If no
-        projects are present, an empty project is created.
-    designname : str, optional
-        Name of the design to select. The default is ``None``, in
-        which case an attempt is made to get an active design. If no
-        designs are present, an empty design is created.
-    solution_type : str, optional
-        Solution type to apply to the design. The default is
-        ``None``, in which case the default type is applied.
-    setup_name : str, optional
-        Name of the setup to use as the nominal. The default is
-        ``None``, in which case the active setup is used or
-        nothing is used.
-    specified_version: str, optional
-        Version of AEDT  to use. The default is ``None``, in which case
-        the active version or latest installed version is used.
-    NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default
-        is ``False``, which launches AEDT in the graphical mode.
-    AlwaysNew : bool, optional
-        Whether to launch an instance of AEDT in a new thread, even if
-        another instance of the ``specified_version`` is active on the
-        machine. The default is ``True``.
-    release_on_exit : bool, optional
-        Whether to release AEDT on exit. The default is ``False``.
-
-    Returns
-    -------
 
     """
     @property
@@ -93,7 +67,7 @@ class QExtractor(FieldAnalysis3D, FieldAnalysis2D, object):
 class Q3d(QExtractor, object):
     """Q3D application interface.
 
-    This class allows you to create an instance of `Q3D` and link to an
+    This class allows you to create an instance of Q3D and link to an
     existing project or create a new one.
 
     Parameters
@@ -112,32 +86,31 @@ class Q3d(QExtractor, object):
         ``None``, in which case the default type is applied.
     setup_name : str, optional
         Name of the setup to use as the nominal. The default is
-        ``None``. If ``None``, the active setup is used or nothing is
-        used.
+        ``None``, in which case the active setup is used or nothing 
+        is used.
     specified_version: str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default
+        Whether to launch AEDT in the non-graphical mode. The default
         is ``False``, which launches AEDT in the graphical mode.
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
         another instance of the ``specified_version`` is active on the
         machine. The default is ``True``.
     release_on_exit : bool, optional
-        Whether to release  AEDT on exit. The default is ``False``.
+        Whether to release AEDT on exit. The default is ``False``.
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
-        ``None``, in which case the active setup is used or
-        nothing is used.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
-    Create an instance of ``Q3d`` and connect to an existing Q3D
+    Create an instance of Q3D and connect to an existing Q3D
     design or create a new Q3D design if one does not exist.
 
     >>> from pyaedt import Q3d
     >>> app = Q3d()
+    
     """
     def __init__(self, projectname=None, designname=None, solution_type=None, setup_name=None,
                  specified_version=None, NG=False, AlwaysNew=False, release_on_exit=False, student_version=True):
@@ -152,6 +125,7 @@ class Q3d(QExtractor, object):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         self.oboundary.AutoIdentifyNets()
         return True
@@ -160,8 +134,8 @@ class Q3d(QExtractor, object):
     def assign_source_to_objectface(self, object_name, axisdir=0, source_name=None, net_name=None):
         """Generate a source on a face ID of an object. 
         
-        The face ID is selected based on ``axisdir``. It will 
-        be the face that has the maximum/minimum in this axis direction.
+        The face ID is selected based on ``axisdir``. It is the face that 
+        has the maximum/minimum in this axis direction.
 
         Parameters
         ----------
@@ -176,8 +150,9 @@ class Q3d(QExtractor, object):
 
         Returns
         -------
-        BoundaryObject
-            Source object.
+        :class: `pyaedt.modules.boundary.BoundaryObject`
+            Boundary object.
+        
         """
         a = self.modeler._get_faceid_on_axis(object_name, axisdir)
 
@@ -199,7 +174,7 @@ class Q3d(QExtractor, object):
     def assign_source_to_sheet(self, sheetname, objectname=None, netname=None, sourcename=None):
         """Generate a source on an object.
 
-        It will be the face that has the maximum/minimum in this axis.
+        It is the face that has the maximum/minimum in this axis direction.
 
         Parameters
         ----------
@@ -214,8 +189,9 @@ class Q3d(QExtractor, object):
 
         Returns
         -------
-        BoundaryObject
-            Source object.
+        :class: `pyaedt.modules.boundary.BoundaryObject`
+            Boundary object.
+        
         """
         if not sourcename:
             sourcename = generate_unique_name("Source")
@@ -237,8 +213,8 @@ class Q3d(QExtractor, object):
     def assign_sink_to_objectface(self, object_name, axisdir=0, sink_name=None, net_name=None):
         """Generate a sink on a face ID of an object.
         
-        The face ID is selected based on ``axisdir``. It will 
-        be the face that has the maximum/minimum in this axis direction.
+        The face ID is selected based on ``axisdir``. It is the face that has 
+        the maximum/minimum in this axis direction.
 
         Parameters
         ----------
@@ -253,8 +229,9 @@ class Q3d(QExtractor, object):
 
         Returns
         -------
-        BoundaryObject
-            Sink object.
+        :class: `pyaedt.modules.boundary.BoundaryObject`
+            Boundary object.
+        
         """
         a = self.modeler._get_faceid_on_axis(object_name, axisdir)
 
@@ -275,7 +252,7 @@ class Q3d(QExtractor, object):
     def assign_sink_to_sheet(self, sheetname, objectname=None, netname=None, sinkname=None):
         """Generate a sink on an object.  
         
-        It will be the face that has the maximum/minimum in this axis direction.
+        It is the face that has the maximum/minimum in this axis direction.
 
         Parameters
         ----------
@@ -290,8 +267,9 @@ class Q3d(QExtractor, object):
 
         Returns
         -------
-        BoundaryObject
-            Source object.
+        :class: `pyaedt.modules.boundary.BoundaryObject`
+            Boundary object.
+        
         """
         if not sinkname:
             sinkname = generate_unique_name("Source")
@@ -333,6 +311,7 @@ class Q3d(QExtractor, object):
         -------
         bool
             ``True`` when successful, ``False`` when failed.
+        
         """
         if sweepname is None:
             sweepname = generate_unique_name("Sweep")
@@ -427,7 +406,7 @@ class Q3d(QExtractor, object):
 class Q2d(QExtractor, object):
     """Q2D application interface.
 
-    This class allows you to create an instance of `Q2D` and link to an
+    This class allows you to create an instance of Q2D and link to an
     existing project or create a new one.
 
     Parameters
@@ -452,30 +431,32 @@ class Q2d(QExtractor, object):
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional
-        Whether to run AEDT in the non-graphical mode. The default
+        Whether to launch AEDT in the non-graphical mode. The default
         is ``False``, which launches AEDT in the graphical mode.
     AlwaysNew : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
         another instance of the ``specified_version`` is active on the
         machine. The default is ``True``.
     release_on_exit : bool, optional
-        Whether to release  AEDT on exit. The default is ``False``.
+        Whether to release AEDT on exit. The default is ``False``.
+    student_version : bool, optional
+        Whether to open the AEDT student version.
 
     Examples
     --------
-    Create an instance of `Q2d` and link to a project named
+    Create an instance of Q2D and link to a project named
     ``projectname``. If this project does not exist, create one with
     this name.
 
     >>> from pyaedt import Q2d
     >>> app = Q2d(projectname)
 
-    Create an instance of `Q2d` and link to a design named
+    Create an instance of Q2D and link to a design named
     ``designname`` in a project named ``projectname``.
 
     >>> app = Q2d(projectname,designame)
 
-    Create an instance of `Q2d` and open the specified project,
+    Create an instance of Q2D and open the specified project,
     which is named ``myfile.aedt``.
 
     >>> app = Q2d("myfile.aedt")

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -11,7 +11,7 @@ import os
 
 
 class QExtractor(FieldAnalysis3D, FieldAnalysis2D, object):
-    """Extracts a 2D or 3D fielld analysis.
+    """Extracts a 2D or 3D field analysis.
     
     Parameters
     ----------

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -229,7 +229,7 @@ class Q3d(QExtractor, object):
 
         Returns
         -------
-        :class: `pyaedt.modules.boundary.BoundaryObject`
+        :class:`pyaedt.modules.boundary.BoundaryObject`
             Boundary object.
         
         """
@@ -267,7 +267,7 @@ class Q3d(QExtractor, object):
 
         Returns
         -------
-        :class: `pyaedt.modules.boundary.BoundaryObject`
+        :class:`pyaedt.modules.boundary.BoundaryObject`
             Boundary object.
         
         """

--- a/pyaedt/rmxprt.py
+++ b/pyaedt/rmxprt.py
@@ -13,7 +13,7 @@ class RMXprtModule(object):
 
     @aedt_exception_handler
     def get_prop_server(self, parameter_name):
-        """
+        """Retrieve the properties of a paraemter.
 
         Parameters
         ----------
@@ -44,18 +44,19 @@ class RMXprtModule(object):
 
     @aedt_exception_handler
     def set_rmxprt_parameter(self, parameter_name, value):
-        """
+        """Modify a parameter value.
 
         Parameters
         ----------
         parameter_name : str
             Name of the parameter.  
         value :
-            Value to assign to the parameter.
-            
+            Value to assign to the parameter.   
 
         Returns
         -------
+        bool
+            ``True`` when successful, ``False`` when failed
 
         """
         prop_server = self.get_prop_server(parameter_name)
@@ -82,7 +83,7 @@ class RMXprtModule(object):
 
 
 class Stator(RMXprtModule):
-    """ """
+    """Stator class."""
     component = "Stator"
     prop_servers = {"":        ["Outer Diameter", "Inner Diameter", "Length", "Stacking Factor"
                                 "Steel Type", "Number of Slots", "Slot Type", "Lamination Sectors",
@@ -92,7 +93,7 @@ class Stator(RMXprtModule):
 
 
 class Rotor(RMXprtModule):
-    """ """
+    """Rotor class."""
     component = "Rotor"
     prop_servers = {"":        ["Outer Diameter"],
                     "Slot":    [],
@@ -102,13 +103,11 @@ class Rotor(RMXprtModule):
 class Rmxprt(FieldAnalysisRMxprt):
     """RMxprt application interface.
 
-    This class exposes functionality from RMxprt.
-
     Parameters
     ----------
     projectname : str, optional
         Name of the project to select or the full path to the project
-        or AEDTZ archive to open.  The default is ``None``, in which
+        or AEDTZ archive to open. The default is ``None``, in which
         case an attempt is made to get an active project. If no 
         projects are present, an empty project is created.
     designname : str, optional
@@ -117,7 +116,7 @@ class Rmxprt(FieldAnalysisRMxprt):
         designs are present, an empty design is created.
     solution_type : str, optional
         Solution type to apply to the design. The default is
-        ``None``, which applies the default type.
+        ``None``, in which ase the default type is applied.
     model_units : str, optional
         Model units.
     setup_name : str, optional
@@ -125,7 +124,7 @@ class Rmxprt(FieldAnalysisRMxprt):
         ``None``, in which case the active setup is used or 
         nothing is used.
     specified_version : str, optional
-        Version of AEDT to use. The default is ``None``. If ``None``,
+        Version of AEDT to use. The default is ``None``, in which case
         the active setup is used or the latest installed version is
         used.
     NG : bool, optional
@@ -138,28 +137,28 @@ class Rmxprt(FieldAnalysisRMxprt):
     release_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``True``.
     student_version : bool, optional
-        Whether open AEDT Student Version. The default is ``False``.
+        Whether to open the AEDT student version. The default is ``False``.
 
     Examples
     --------
-    Create an instance of `Rmxprt` and connect to an existing RMxprt
+    Create an instance of Rmxprt and connect to an existing RMxprt
     design or create a new RMxprt design if one does not exist.
 
     >>> from pyaedt import Rmxprt
     >>> app = Rmxprt()
 
-    Create an instance of `Rmxprt` and link to a project named
+    Create an instance of Rmxprt and link to a project named
     ``"projectname"``. If this project does not exist, create one with
     this name.
 
     >>> app = Rmxprt(projectname)
 
-    Create an instance of `RMxprt` and link to a design named
+    Create an instance of RMxprt and link to a design named
     ``"designname"`` in a project named ``"projectname"``.
 
     >>> app = Rmxprt(projectname,designame)
 
-    Create an instance of `RMxprt` and open the specified project,
+    Create an instance of RMxprt and open the specified project,
     which is ``myfile.aedt``.
 
     >>> app = Rmxprt("myfile.aedt")
@@ -183,7 +182,7 @@ class Rmxprt(FieldAnalysisRMxprt):
         self.rotor = Rotor(self.modeler.oeditor)
 
     def __exit__(self, ex_type, ex_value, ex_traceback):
-        """ Push exit up to parent object Design """
+        """Push exit up to parent object Design."""
         Design.__exit__(self, ex_type, ex_value, ex_traceback)
 
     def __enter__(self):


### PR DESCRIPTION
In examples, remove the single back tick and use the proper product name for improved readability.
Edit all PY files in the pyaedt folder since they are visible under "Application" heading.
Put in class directories for BoundaryObjects and others that I know.