### PR TITLE
Reintroduced assign_material in Analysis3D, plus several bug fixes!

### DIFF
--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -94,8 +94,8 @@ class TestClass():
         print(self.aedtapp.variable_manager)
         print(self.aedtapp.materials)
 
-    def test_09_add_workbench_link(self):
-        assert self.aedtapp.modeler.add_workbench_link(["inner"], "25")
+    def test_09_set_objects_deformation(self):
+        assert self.aedtapp.modeler.set_objects_deformation(["inner"])
 
     def test_09_set_objects_temperature(self):
         ambient_temp = 22

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -18,9 +18,6 @@ from pyaedt.application.Analysis import CoordinateSystemAxis
 
 test = sys.modules.keys()
 
-
-
-
 scdoc = "input.scdoc"
 step = "input.stp"
 
@@ -839,7 +836,6 @@ class TestClass(BasisTest):
         eq_xsection = self.aedtapp.modeler.primitives.create_equationbased_curve(x_t="_t", y_t="_t*2", xsection_type="Circle")
         assert eq_xsection.name in self.aedtapp.modeler.primitives.solid_names
 
-
     def test_create_3dcomponent(self):
         self.aedtapp['l_dipole'] = "13.5cm"
 
@@ -848,3 +844,24 @@ class TestClass(BasisTest):
         geometryparams['dipole_length'] = "l_dipole"
         name = self.aedtapp.modeler.primitives.insert_3d_component(compfile, geometryparams)
         assert isinstance(name, str)
+
+    @pyaedt_unittest_check_desktop_error
+    def test_assign_material(self):
+        box1 = self.aedtapp.modeler.primitives.create_box([60, 60, 60], [4, 5, 5])
+        box2 = self.aedtapp.modeler.primitives.create_box([50, 50, 50], [2, 3, 4])
+        cyl1 = self.aedtapp.modeler.primitives.create_cylinder(cs_axis="X", position=[50, 0, 0], radius=1, height=20)
+        cyl2 = self.aedtapp.modeler.primitives.create_cylinder(cs_axis="Z", position=[0, 0, 50], radius=1, height=10)
+
+        objects_list = [box1, box2, cyl1, cyl2]
+        self.aedtapp.assign_material(objects_list, "copper")
+        assert self.aedtapp.modeler.primitives[box1].material_name == "copper"
+        assert self.aedtapp.modeler.primitives[box2].material_name == "copper"
+        assert self.aedtapp.modeler.primitives[cyl1].material_name == "copper"
+        assert self.aedtapp.modeler.primitives[cyl2].material_name == "copper"
+
+        obj_names_list = [box1.name, box2.name, cyl1.name, cyl2.name]
+        self.aedtapp.assign_material(obj_names_list, "aluminum")
+        assert self.aedtapp.modeler.primitives[box1].material_name == "aluminum"
+        assert self.aedtapp.modeler.primitives[box2].material_name == "aluminum"
+        assert self.aedtapp.modeler.primitives[cyl1].material_name == "aluminum"
+        assert self.aedtapp.modeler.primitives[cyl2].material_name == "aluminum"

--- a/_unittest/test_09_Primitives2D.py
+++ b/_unittest/test_09_Primitives2D.py
@@ -83,5 +83,5 @@ class TestMaxwell2DXY(BasisTest):
                                           "steel_stainless"])  # material already in library
     @pyaedt_unittest_check_desktop_error
     def test_07_assign_material(self, material):
-        self.aedtapp.assignmaterial(["Rectangle1"], material)
+        self.aedtapp.assign_material(["Rectangle1"], material)
         assert self.aedtapp.modeler.primitives["Rectangle1"].material_name == material

--- a/examples/01-advanced-postprocessing/Hfss_Icepak_Coupling.py
+++ b/examples/01-advanced-postprocessing/Hfss_Icepak_Coupling.py
@@ -83,7 +83,7 @@ aedtapp["inner"] = "3mm"
 # Create the Coaxial, 3 Cylinders.
 # Parameters can be applied directly to create_cylinder method,
 # also material can be assigned directly to the object creation action.
-# Alternatively the material can be assigned usign assignmaterial function
+# Alternatively the material can be assigned using assign_material function
 
 #TODO: how does this work when two true-surfaces are defined ??
 o1 = aedtapp.modeler.primitives.create_cylinder(aedtapp.CoordinateSystemPlane.XYPlane, udp, "inner", "$coax_dimension",

--- a/pyaedt/application/Analysis2D.py
+++ b/pyaedt/application/Analysis2D.py
@@ -74,7 +74,7 @@ class FieldAnalysis2D(Analysis):
     #     return self._post
 
     @aedt_exception_handler
-    def assignmaterial(self, obj, mat):
+    def assign_material(self, obj, mat):
         """Assign a material to one or more objects. 
 
         Parameters

--- a/pyaedt/application/Analysis2D.py
+++ b/pyaedt/application/Analysis2D.py
@@ -1,3 +1,5 @@
+import warnings
+
 from .Analysis import Analysis
 from ..modeler.Model2D import Modeler2D
 from ..modules.Mesh import Mesh
@@ -72,6 +74,19 @@ class FieldAnalysis2D(Analysis):
     # @property
     # def post(self):
     #     return self._post
+
+    @aedt_exception_handler
+    def assignmaterial(self, obj, mat):
+        """Assign a material to one or more objects.
+
+        .. deprecated:: 0.3.1
+           Use :func:`FieldAnalysis2D.assign_material` instead.
+
+        """
+        # raise a DeprecationWarning.  User won't have to change anything
+        warnings.warn('assignmaterial is deprecated.  Please use assign_material instead.',
+                      DeprecationWarning)
+        self.assign_material(obj, mat)
 
     @aedt_exception_handler
     def assign_material(self, obj, mat):

--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -233,9 +233,9 @@ class FieldAnalysis3D(Analysis, object):
             ``True`` when successful, ``False`` when failed.
             
         """
-        body_list = design.modeler.solid_bodies
+        body_list = design.modeler.primitives.solid_names
         if include_sheets:
-            body_list += design.modeler.primitives.get_all_sheets_names()
+            body_list += design.modeler.primitives.sheet_names
         selection_list = []
         material_properties = design.modeler.primitives.objects
         for body in body_list:

--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -1,6 +1,7 @@
-import glob
 import os
 import ntpath
+import warnings
+
 from ..generic.general_methods import aedt_exception_handler, generate_unique_name
 from .Analysis import Analysis
 from ..modeler.Model3D import Modeler3D
@@ -292,6 +293,18 @@ class FieldAnalysis3D(Analysis, object):
         return True
 
     @aedt_exception_handler
+    def assignmaterial(self, obj, mat):
+        """Assign a material to one or more objects.
+
+        .. deprecated:: 0.3.1
+           Use :func:`FieldAnalysis3D.assign_material` instead.
+
+        """
+        warnings.warn('assignmaterial is deprecated.  Please use assign_material instead.',
+                      DeprecationWarning)
+        self.assign_material(obj, mat)
+
+    @aedt_exception_handler
     def assign_material(self, obj, mat):
         """Assign a material to one or more objects.
 
@@ -308,6 +321,18 @@ class FieldAnalysis3D(Analysis, object):
         bool
             ``True`` when successful, ``False`` when failed.
 
+        Examples
+        --------
+        The method assign_material is useful to assign a material to a list of objects.
+
+        >>> from pyaedt import Hfss
+        >>> hfss = Hfss()
+        >>> box1 = hfss.modeler.primitives.create_box([10, 10, 10], [4, 5, 5])
+        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 0], [2, 3, 4])
+        >>> cylinder1 = hfss.modeler.primitives.create_cylinder(cs_axis="X", position=[5, 0, 0], radius=1, height=20)
+        >>> cylinder2 = hfss.modeler.primitives.create_cylinder(cs_axis="Z", position=[0, 0, 5], radius=1, height=10)
+        >>> objects_list = [box1.name, box2.name, cylinder1.nam, cylinder2.name]
+        >>> hfss.assign_material(objects_list, "copper")
         """
         mat = mat.lower()
         selections = self.modeler.convert_to_selections(obj)

--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -325,14 +325,24 @@ class FieldAnalysis3D(Analysis, object):
         --------
         The method assign_material is useful to assign a material to a list of objects.
 
+        Open a design and create the objects.
+
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> box1 = hfss.modeler.primitives.create_box([10, 10, 10], [4, 5, 5])
         >>> box2 = hfss.modeler.primitives.create_box([0, 0, 0], [2, 3, 4])
         >>> cylinder1 = hfss.modeler.primitives.create_cylinder(cs_axis="X", position=[5, 0, 0], radius=1, height=20)
         >>> cylinder2 = hfss.modeler.primitives.create_cylinder(cs_axis="Z", position=[0, 0, 5], radius=1, height=10)
-        >>> objects_list = [box1.name, box2.name, cylinder1.name, cylinder2.name]
+
+        Assign the material "copper" to all the objects.
+
+        >>> objects_list = [box1, box2, cylinder1, cylinder2]
         >>> hfss.assign_material(objects_list, "copper")
+
+        The method also accepts a list of object names.
+
+        >>> obj_names_list = [box1.name, box2.name, cylinder1.name, cylinder2.name]
+        >>> hfss.assign_material(obj_names_list, "aluminum")
         """
         mat = mat.lower()
         selections = self.modeler.convert_to_selections(obj)

--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -331,7 +331,7 @@ class FieldAnalysis3D(Analysis, object):
         >>> box2 = hfss.modeler.primitives.create_box([0, 0, 0], [2, 3, 4])
         >>> cylinder1 = hfss.modeler.primitives.create_cylinder(cs_axis="X", position=[5, 0, 0], radius=1, height=20)
         >>> cylinder2 = hfss.modeler.primitives.create_cylinder(cs_axis="Z", position=[0, 0, 5], radius=1, height=10)
-        >>> objects_list = [box1.name, box2.name, cylinder1.nam, cylinder2.name]
+        >>> objects_list = [box1.name, box2.name, cylinder1.name, cylinder2.name]
         >>> hfss.assign_material(objects_list, "copper")
         """
         mat = mat.lower()

--- a/pyaedt/application/AnalysisIcepak.py
+++ b/pyaedt/application/AnalysisIcepak.py
@@ -1,5 +1,6 @@
 import csv
 import re
+import warnings
 
 from ..generic.general_methods import aedt_exception_handler, generate_unique_name
 from ..application.Analysis import Analysis
@@ -220,6 +221,19 @@ class FieldAnalysisIcepak(Analysis, object):
         design.modeler.oeditor.Copy(["NAME:Selections", "Selections:=", ','.join(selection_list)])
         self.modeler.oeditor.Paste()
         return True
+
+    @aedt_exception_handler
+    def assignmaterial(self, obj, mat):
+        """Assign a material to one or more objects.
+
+        .. deprecated:: 0.3.1
+           Use :func:`FieldAnalysisIcepak.assign_material` instead.
+
+        """
+        # raise a DeprecationWarning.  User won't have to change anything
+        warnings.warn('assignmaterial is deprecated.  Please use assign_material instead.',
+                      DeprecationWarning)
+        self.assign_material(obj, mat)
 
     @aedt_exception_handler
     def assign_material(self, obj, mat):

--- a/pyaedt/application/AnalysisIcepak.py
+++ b/pyaedt/application/AnalysisIcepak.py
@@ -222,7 +222,7 @@ class FieldAnalysisIcepak(Analysis, object):
         return True
 
     @aedt_exception_handler
-    def assignmaterial(self, obj, mat):
+    def assign_material(self, obj, mat):
         """Assign a material to one or more objects. 
 
         Parameters
@@ -419,7 +419,7 @@ class FieldAnalysisIcepak(Analysis, object):
                     else:
                         value = material_data["Elastic Modulus"][i]
                         newmat.youngs_modulus = value
-                self.assignmaterial(list_mat_obj, mat)
+                self.assign_material(list_mat_obj, mat)
 
                 for obj_name in list_mat_obj:
                     if not self.modeler.primitives[obj_name].surface_material_name:

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -2035,18 +2035,16 @@ class Design(object):
             name = self.design_name
         self.oproject.DeleteDesign(name)
         try:
-            if fallback_design:
-                new_designname = fallback_design
-            else:
-                if not self._oproject.GetActiveDesign():
-                    new_designname = None
-                    self.odesign = None
-                else:
-                    new_designname = self._oproject.GetActiveDesign().GetName()
-            self.set_active_design(new_designname)
+            if not self._oproject.GetActiveDesign():
+                self.odesign = None
         except:
             pass
-
+        if fallback_design and (fallback_design in
+                                [x for i in list(self._oproject.GetDesigns()) for x in (i.GetName(), i.GetName()[2:])]):
+            try:
+                self.set_active_design(fallback_design)
+            except:
+                pass
         return True
 
 
@@ -2223,7 +2221,7 @@ class Design(object):
         else:
             return None
         # check if the requested design exists in the origin project
-        if design_name not in [i.GetName() for i in list(proj_from.GetDesigns())]:
+        if design_name not in [x for i in list(proj_from.GetDesigns()) for x in (i.GetName(), i.GetName()[2:])]:
             return None
         # copy the source design
         proj_from.CopyDesign(design_name)
@@ -2235,9 +2233,9 @@ class Design(object):
         # close the source project
         self._desktop.CloseProject(proj_from_name)
         # reset the active design (very important)
-        self._oproject.SetActiveDesign(active_design)
         self.save_project()
         self.__init__(self.project_name, new_designname)
+        self._oproject.SetActiveDesign(active_design)
 
         # return the pasted design name
         return new_designname

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -2034,17 +2034,16 @@ class Design(object):
         if not name:
             name = self.design_name
         self.oproject.DeleteDesign(name)
-        try:
-            if not self._oproject.GetActiveDesign():
-                self.odesign = None
-        except:
-            pass
+        if name != self.design_name:
+            return True
         if fallback_design and (fallback_design in
                                 [x for i in list(self._oproject.GetDesigns()) for x in (i.GetName(), i.GetName()[2:])]):
             try:
                 self.set_active_design(fallback_design)
             except:
-                pass
+                return False
+        else:
+            self.odesign = None
         return True
 
 

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -833,7 +833,7 @@ class GeometryModeler(Modeler, object):
         return True
 
     @aedt_exception_handler
-    def set_object_deformation(self, objects):
+    def set_objects_deformation(self, objects):
         """Assign Deformation Objects for WorkBench Link.
 
         Parameters

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -833,58 +833,27 @@ class GeometryModeler(Modeler, object):
         return True
 
     @aedt_exception_handler
-    def add_workbench_link(self, objects, ambient_temp=22, create_project_var=False, enable_deformation=True):
-        """Assign Temperature and Deformation Objects for WorkBench Link. From 2020R2 Material needs to have Thermal Modifier
+    def set_object_deformation(self, objects):
+        """Assign Deformation Objects for WorkBench Link.
 
         Parameters
         ----------
-        enable_deformation :
-            Boolean if True the deformation link is added (Default value = True)
-        create_project_var :
-            Boolean if True $AmbientTemp is created. (Default value = False)
-        ambient_temp :
-            ambient temperature default value
         objects :
             list of the object to be included
 
         Returns
         -------
-
+        bool
+            True if operation succeeded, False otherwise
         """
-        if enable_deformation:
-            self._messenger.add_debug_message("Set model temperature and enabling temperature and deformation feedback")
-        else:
-            self._messenger.add_debug_message("Set model temperature and enabling temperature feedback")
-        if create_project_var:
-            self._parent.variable_manager["$AmbientTemp"] = str(ambient_temp) + "cel"
-            var = "$AmbientTemp"
-        else:
-            var = str(ambient_temp) + "cel"
-        vargs1 = ["NAME:TemperatureSettings", "IncludeTemperatureDependence:=", True, "EnableFeedback:=", True,
-                  "Temperatures:="]
-        vargs2 = []
-        vdef = []
-        for obj in objects:
-            mat = self.primitives[obj].material_name
-            th = self._parent.materials.check_thermal_modifier(mat)
-            if th:
-                print("Material: " + mat)
-                vargs2.append(obj)
-                vargs2.append(var)
-        if not vargs2:
-            return False
-        else:
-            vargs1.append(vargs2)
+        self._messenger.add_debug_message("Enabling deformation feedback")
         try:
-            self.odesign.SetObjectTemperature(vargs1)
-            if enable_deformation:
-                self.odesign.SetObjectDeformation(["EnabledObjects:=", vdef])
+            self.odesign.SetObjectDeformation(["EnabledObjects:=", objects])
         except:
-            self._messenger.add_error_message("Failed to enable the temperature and deformation dependence")
+            self._messenger.add_error_message("Failed to enable the deformation dependence")
             return False
         else:
-            self._messenger.add_debug_message(
-                "Assigned objects temperature and enabled temperature and deformation feedback")
+            self._messenger.add_debug_message("Successfully enabled deformation feedback")
             return True
 
     @aedt_exception_handler
@@ -903,7 +872,8 @@ class GeometryModeler(Modeler, object):
 
         Returns
         -------
-
+        bool
+            True if operation succeeded, False otherwise
         """
         self._messenger.add_debug_message("Set model temperature and enabling Thermal Feedback")
         if create_project_var:

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -866,9 +866,9 @@ class GeometryModeler(Modeler, object):
         vdef = []
         for obj in objects:
             mat = self.primitives[obj].material_name
-            print("Material" + mat)
             th = self._parent.materials.check_thermal_modifier(mat)
             if th:
+                print("Material: " + mat)
                 vargs2.append(obj)
                 vargs2.append(var)
         if not vargs2:

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -1280,7 +1280,8 @@ class GeometryModeler(Modeler, object):
         all_objs = self.primitives.object_names
         objs_to_unmodel = [i for i in all_objs if i not in group_objs]
         if objs_to_unmodel:
-            self.set_object_model_state(objs_to_unmodel, False)
+            vArg1 = ["NAME:Model", "Value:=", False]
+            self.primitives._change_geometry_property(vArg1, objs_to_unmodel)
             bounding = self.get_model_bounding_box()
             self.odesign.Undo()
         else:

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -17,6 +17,8 @@ import sys
 import os
 import string
 import random
+import warnings
+
 from collections import OrderedDict
 from .Primitives2D import Primitives2D
 from .Primitives3D import Primitives3D
@@ -833,6 +835,38 @@ class GeometryModeler(Modeler, object):
         return True
 
     @aedt_exception_handler
+    def add_workbench_link(self, objects, ambient_temp=22, create_project_var=False, enable_deformation=True):
+        """Assign Temperature and Deformation Objects for WorkBench Link.
+
+        .. deprecated:: 0.3.1
+           Use :func:`GeometryModeler.set_objects_deformation` and :func:`GeometryModeler.set_objects_temperature`
+           instead.
+
+        Parameters
+        ----------
+        enable_deformation :
+            Boolean if True the deformation link is added (Default value = True)
+        create_project_var :
+            Boolean if True $AmbientTemp is created. (Default value = False)
+        ambient_temp :
+            ambient temperature default value
+        objects :
+            list of the object to be included
+
+        Returns
+        -------
+        bool
+            `True` if operation succeeded, `False` otherwise
+        """
+        warnings.warn('add_workbench_link is deprecated. '
+                      'Please use set_objects_temperature and set_objects_deformation instead.',
+                      DeprecationWarning)
+        self.set_objects_temperature(objects, ambient_temp, create_project_var)
+        if enable_deformation:
+            self.set_objects_deformation(objects)
+        return True
+
+    @aedt_exception_handler
     def set_objects_deformation(self, objects):
         """Assign Deformation Objects for WorkBench Link.
 
@@ -844,7 +878,7 @@ class GeometryModeler(Modeler, object):
         Returns
         -------
         bool
-            True if operation succeeded, False otherwise
+            `True` if operation succeeded, `False` otherwise
         """
         self._messenger.add_debug_message("Enabling deformation feedback")
         try:
@@ -873,7 +907,7 @@ class GeometryModeler(Modeler, object):
         Returns
         -------
         bool
-            True if operation succeeded, False otherwise
+            `True` if operation succeeded, `False` otherwise
         """
         self._messenger.add_debug_message("Set model temperature and enabling Thermal Feedback")
         if create_project_var:

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -2784,5 +2784,7 @@ class Primitives(object):
             return self.objects[partId]
         elif partId in self.object_id_dict:
             return self.objects[self.object_id_dict[partId]]
+        elif isinstance(partId, Object3d):
+            return partId
         return None
 


### PR DESCRIPTION
- Fixed `get_group_bounding_box`.
- Reintroduced `assignmaterial` in Analysis3D (still useful -and faster- in case of material assignment to a list of objects). 
- Renamed `assignmaterial` in `assign_material`.
- Refactored `add_workbench_link` --> `set_object_deformation`.
- Fixed bug in `delete_design` not working with 3DLayout. 
- Fixed bug in `copy_design_from` not working with 3DLayout.
- Fixed bug in `copy_design_from` not correctly setting back the active design.