### PR TITLE
Shorten method names in the API Reference

### DIFF
--- a/doc/source/_templates/autosummary/base.rst
+++ b/doc/source/_templates/autosummary/base.rst
@@ -1,0 +1,5 @@
+{{ name | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}


### PR DESCRIPTION
The method links in the left sidebar are often so long that the method name itself isn't visible without scrolling; this is undesired behavior.  This PR shortens the displayed links to just the method by overriding the `autosummary/base.rst` template.

### Before
![broken](https://user-images.githubusercontent.com/11981631/126084301-11476c66-0016-447d-87d9-c495f2e30eb2.png)


### After
![fixed](https://user-images.githubusercontent.com/11981631/126084302-83d4b574-9c70-474b-b2f7-01e5ac91b522.png)
