### PR TITLE
Doc/hfss sweep examples

### DIFF
--- a/pyaedt/conftest.py
+++ b/pyaedt/conftest.py
@@ -15,7 +15,7 @@ pytest_plugins = [
 
 @pytest.fixture(autouse=True, scope="session")
 def start_aedt():
-    desktop = Desktop("2021.1", NG=True)
+    desktop = Desktop("2021.1", NG=False)
     desktop.disable_autosave()
 
     # Wait to run doctest on docstrings

--- a/pyaedt/conftest.py
+++ b/pyaedt/conftest.py
@@ -15,7 +15,7 @@ pytest_plugins = [
 
 @pytest.fixture(autouse=True, scope="session")
 def start_aedt():
-    desktop = Desktop("2021.1", NG=False)
+    desktop = Desktop("2021.1", NG=True)
     desktop.disable_autosave()
 
     # Wait to run doctest on docstrings

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -389,17 +389,17 @@ class Hfss(FieldAnalysis3D, object):
         Examples
         --------
 
-        Create a setup named ``'MySetup'``.
+        Create a setup named ``'FrequencySweepSetup'``.
         Create a fast frequency sweep named ``'MySweepFast'`` for the analysis
         setup created above.
 
-        >>> setup = hfss.create_setup("MySetup")
+        >>> setup = hfss.create_setup("FrequencySweepSetup")
         >>> setup.props["Frequency"] = "1GHz"
         >>> setup.props["BasisOrder"] = 2
         >>> setup.props["MaximumPasses"] = 1
-        >>> frequency_sweep = hfss.create_frequency_sweep(setupname="MySetup", sweepname="MySweepFast", unit="MHz",
-        ...                                               freqstart=1.1e3, freqstop=1200.1, num_of_freq_points=1234,
-        ...                                               sweeptype="Fast")
+        >>> frequency_sweep = hfss.create_frequency_sweep(setupname="FrequencySweepSetup", sweepname="MySweepFast",
+        ...                                               unit="MHz", freqstart=1.1e3, freqstop=1200.1,
+        ...                                               num_of_freq_points=1234, sweeptype="Fast")
         >>> type(frequency_sweep)
         <class 'pyaedt.modules.SetupTemplates.SweepHFSS'>
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -389,9 +389,8 @@ class Hfss(FieldAnalysis3D, object):
         Examples
         --------
 
-        Create a setup named ``'FrequencySweepSetup'``.
-        Create a fast frequency sweep named ``'MySweepFast'`` for the analysis
-        setup created above.
+        Create a setup named ``'FrequencySweepSetup'`` and use it in a frequency sweep
+        named ``'MySweepFast'``.
 
         >>> setup = hfss.create_setup("FrequencySweepSetup")
         >>> setup.props["Frequency"] = "1GHz"
@@ -466,9 +465,8 @@ class Hfss(FieldAnalysis3D, object):
         Examples
         --------
 
-        Create a setup named ``'LinearCountSetup'``.
-        Create a linear count sweep named ``'LinearCountSweep'`` for the analysis setup
-        created above.
+        Create a setup named ``'LinearCountSetup'`` and use it in a linear count sweep
+        named ``'LinearCountSweep'``.
 
         >>> setup = hfss.create_setup("LinearCountSetup")
         >>> linear_count_sweep = hfss.create_linear_count_sweep(setupname="LinearCountSetup",
@@ -538,9 +536,8 @@ class Hfss(FieldAnalysis3D, object):
         Examples
         --------
 
-        Create a setup named ``'LinearStepSetup'``.
-        Create a linear step sweep named ``'LinearStepSweep'`` for the analysis setup
-        created above.
+        Create a setup named ``'LinearStepSetup'`` and use it in a linear step sweep
+        named ``'LinearStepSweep'``.
 
         >>> setup = hfss.create_setup("LinearStepSetup")
         >>> linear_step_sweep = hfss.create_linear_step_sweep(setupname="LinearStepSetup",

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -390,7 +390,8 @@ class Hfss(FieldAnalysis3D, object):
         --------
 
         Create a setup named ``'MySetup'``.
-        Create a fast frequency sweep named ``'MySweepFast'`` for the analysis setup created above.
+        Create a fast frequency sweep named ``'MySweepFast'`` for the analysis
+        setup created above.
 
         >>> setup = hfss.create_setup("MySetup")
         >>> setup.props["Frequency"] = "1GHz"
@@ -445,7 +446,7 @@ class Hfss(FieldAnalysis3D, object):
         unit : str
             Unit of the frequency. For example, ``"MHz`` or ``"GHz"``. The default is ``"GHz"``.
         freqstart : float
-            Starting frequency of the sweep,  such as ``1``.
+            Starting frequency of the sweep, such as ``1``.
         freqstop : float
             Stopping frequency of the sweep.
         num_of_freq_points : int
@@ -459,8 +460,24 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        SweepHFSS
-            Sweep object.
+        :class:`pyaedt.modules.SetupTemplates.SweepHFSS` or bool
+            Sweep object if successful. ``False`` if unsuccessful.
+
+        Examples
+        --------
+
+        Create a setup named ``'LinearCountSetup'``.
+        Create a linear count sweep named ``'LinearCountSweep'`` for the analysis setup
+        created above.
+
+        >>> setup = hfss.create_setup("LinearCountSetup")
+        >>> linear_count_sweep = hfss.create_linear_count_sweep(setupname="LinearCountSetup",
+        ...                                                     sweepname="LinearCountSweep",
+        ...                                                     unit="MHz", freqstart=1.1e3,
+        ...                                                     freqstop=1200.1, num_of_freq_points=1658)
+        >>> type(linear_count_sweep)
+        <class 'pyaedt.modules.SetupTemplates.SweepHFSS'>
+
         """
 
         if sweepname is None:
@@ -515,10 +532,26 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        SweepHFSS
-            Sweep object.
+        :class:`pyaedt.modules.SetupTemplates.SweepHFSS` or bool
+            Sweep object if successful. ``False`` if unsuccessful.
+
+        Examples
+        --------
+
+        Create a setup named ``'LinearStepSetup'``.
+        Create a linear step sweep named ``'LinearStepSweep'`` for the analysis setup
+        created above.
+
+        >>> setup = hfss.create_setup("LinearStepSetup")
+        >>> linear_step_sweep = hfss.create_linear_step_sweep(setupname="LinearStepSetup",
+        ...                                                   sweepname="LinearStepSweep",
+        ...                                                   unit="MHz", freqstart=1.1e3,
+        ...                                                   freqstop=1200.1, step_size=153.8)
+        >>> type(linear_step_sweep)
+        <class 'pyaedt.modules.SetupTemplates.SweepHFSS'>
 
         """
+
         if sweepname is None:
             sweepname = generate_unique_name("Sweep")
 


### PR DESCRIPTION
Rename the setup for the test `create_frequency_sweep`.
This will avoid confusion with the other tests as every test will have its own _Setup_ under _Analysis_.

Add examples for the following Hfss methods:
`create_linear_count_sweep()`
`create_linear_step_sweep()`