### PR TITLE
Fix the typo regarding the name of the method called assign_voltage_s…

### DIFF
--- a/_unittest/test_10_HFSS.py
+++ b/_unittest/test_10_HFSS.py
@@ -278,7 +278,7 @@ class TestClass:
     def test_20_create_voltage_on_sheet(self):
         rect = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.CoordinateSystemPlane.XYPlane, [0, 0, 0],
                                                                 [10, 2], name="lump_volt", matname="Copper")
-        port = self.aedtapp.assig_voltage_source_to_sheet(rect.name, self.aedtapp.AxisDir.XNeg,  "LumpVolt1")
+        port = self.aedtapp.assign_voltage_source_to_sheet(rect.name, self.aedtapp.AxisDir.XNeg,  "LumpVolt1")
         assert port in self.aedtapp.modeler.get_excitations_name()
         assert self.aedtapp.get_property_value("BoundarySetup:LumpVolt1", "VoltageMag", "Excitation") == "1V"
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1719,7 +1719,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        warnings.warn('`assig_voltage_source_to_sheet is deprecated`. Use `assign_voltage_source_to_sheet` instead',
+        warnings.warn('`assig_voltage_source_to_sheet is deprecated`. Use `assign_voltage_source_to_sheet` instead.',
                       DeprecationWarning)
         self.assign_voltage_source_to_sheet(sheet_name, axisdir=0, sourcename=None)
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1710,7 +1710,7 @@ class Hfss(FieldAnalysis3D, object):
         return False
 
     @aedt_exception_handler
-    def assig_voltage_source_to_sheet(self, sheet_name, axisdir=0, sourcename=None):
+    def assign_voltage_source_to_sheet(self, sheet_name, axisdir=0, sourcename=None):
         """Create a voltage source taking one sheet.
 
         Parameters
@@ -1737,7 +1737,7 @@ class Hfss(FieldAnalysis3D, object):
         >>> sheet = hfss.modeler.primitives.create_rectangle(hfss.CoordinateSystemPlane.XYPlane,
         ...                                                  [0, 0, -70], [10, 2], name="VoltageSheet",
         ...                                                  matname="copper")
-        >>> hfss.assig_voltage_source_to_sheet(sheet.name, hfss.AxisDir.XNeg, "VoltageSheetExample")
+        >>> hfss.assign_voltage_source_to_sheet(sheet.name, hfss.AxisDir.XNeg, "VoltageSheetExample")
         'VoltageSheetExample'
 
         """

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1718,7 +1718,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        warnings.warn('assig_voltage_source_to_sheet is deprecated. Use assign_voltage_source_to_sheet instead',
+        warnings.warn('`assig_voltage_source_to_sheet is deprecated`. Use `assign_voltage_source_to_sheet` instead',
                       DeprecationWarning)
         self.assign_voltage_source_to_sheet(sheet_name, axisdir=0, sourcename=None)
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1710,6 +1710,19 @@ class Hfss(FieldAnalysis3D, object):
         return False
 
     @aedt_exception_handler
+    def assig_voltage_source_to_sheet(self, sheet_name, axisdir=0, sourcename=None):
+        """Create a voltage source taking one sheet.
+
+        .. deprecated:: 0.4.0
+           Use :func:`Hfss.assign_voltage_source_to_sheet` instead.
+
+        """
+
+        warnings.warn('assig_voltage_source_to_sheet is deprecated. Use assign_voltage_source_to_sheet instead',
+                      DeprecationWarning)
+        self.assign_voltage_source_to_sheet(sheet_name, axisdir=0, sourcename=None)
+
+    @aedt_exception_handler
     def assign_voltage_source_to_sheet(self, sheet_name, axisdir=0, sourcename=None):
         """Create a voltage source taking one sheet.
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1,6 +1,7 @@
 """This module contains these classes: `Hfss` and 'BoundaryType`."""
 from __future__ import absolute_import
 import os
+import warnings
 from .application.Analysis3D import FieldAnalysis3D
 from .desktop import exception_to_desktop
 from .modeler.GeometryOperators import GeometryOperators


### PR DESCRIPTION
Fix #342 
Correct the typo in the name of the method `assign_voltage_source_to_sheet`