### PR TITLE
Doc/hfss radiation example

### DIFF
--- a/_unittest/test_10_HFSS.py
+++ b/_unittest/test_10_HFSS.py
@@ -278,7 +278,7 @@ class TestClass:
     def test_20_create_voltage_on_sheet(self):
         rect = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.CoordinateSystemPlane.XYPlane, [0, 0, 0],
                                                                 [10, 2], name="lump_volt", matname="Copper")
-        port = self.aedtapp.assig_voltage_source_to_sheet(rect.name, self.aedtapp.AxisDir.XNeg,  "LumpVolt1")
+        port = self.aedtapp.assign_voltage_source_to_sheet(rect.name, self.aedtapp.AxisDir.XNeg,  "LumpVolt1")
         assert port in self.aedtapp.modeler.get_excitations_name()
         assert self.aedtapp.get_property_value("BoundarySetup:LumpVolt1", "VoltageMag", "Excitation") == "1V"
 

--- a/pyaedt/doctest_fixtures/hfss_fixtures.py
+++ b/pyaedt/doctest_fixtures/hfss_fixtures.py
@@ -19,7 +19,7 @@ def create_hfss(request, doctest_namespace):
     if request.module != hfss_module:
         return
 
-    # Use RadioBoardHfss.aedt project to test
+    # Use USB_Connector.aedt project to test
     project_path = os.path.join(doctest_namespace["projects_path"], "USB_Connector.aedt")
     doctest_namespace["hfss"] = Hfss(projectname=project_path, designname="HfssDesign1")
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -2633,7 +2633,7 @@ class Hfss(FieldAnalysis3D, object):
         Parameters
         ----------
         obj_names : str or list
-             One or more object names.       
+             One or more object names.
         boundary_name : str, optional
              Name of the boundary. The default is ``""``.
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -2611,7 +2611,19 @@ class Hfss(FieldAnalysis3D, object):
         :class:`pyaedt.modules.Boundary.BoundaryObject`
             Boundary object.
 
+        Examples
+        --------
+
+        Create a box and assign a radiation boundary to it.
+
+        >>> radiation_box = hfss.modeler.primitives.create_box([0, -200, -200], [200, 200, 200],
+        ...                                                    name="Radiation_box")
+        >>> radiation = hfss.assign_radiation_boundary_to_objects("Radiation_box")
+        >>> type(radiation)
+        <class 'pyaedt.modules.Boundary.BoundaryObject'>
+
         """
+
         object_list = self.modeler.convert_to_selections(obj_names, return_list=True)
         if boundary_name:
             rad_name = boundary_name
@@ -2621,7 +2633,7 @@ class Hfss(FieldAnalysis3D, object):
 
     @aedt_exception_handler
     def assign_radiation_boundary_to_faces(self, faces_id, boundary_name=""):
-        """Assign a radiation boundary to one or more objects (usually airbox objects).
+        """Assign a radiation boundary to one or more faces.
 
         Parameters
         ----------
@@ -2632,10 +2644,24 @@ class Hfss(FieldAnalysis3D, object):
 
         Returns
         -------
-        bool
-             ``True`` when successful, ``False`` when failed.
+        :class:`pyaedt.modules.Boundary.BoundaryObject`
+            Boundary object.
+
+        Examples
+        --------
+
+        Create a box. Select the faces of this box and assign a radiation
+        boundary to them.
+
+        >>> radiation_box = hfss.modeler.primitives.create_box([0 , -100, 0], [200, 200, 200],
+        ...                                                    name="RadiationForFaces")
+        >>> ids = [i.id for i in hfss.modeler.primitives["RadiationForFaces"].faces]
+        >>> radiation = hfss.assign_radiation_boundary_to_faces(ids)
+        >>> type(radiation)
+        <class 'pyaedt.modules.Boundary.BoundaryObject'>
 
         """
+
         if type(faces_id) is not list:
             faces_list = [int(faces_id)]
         else:

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -1,6 +1,7 @@
 """This module contains these classes: `Hfss` and 'BoundaryType`."""
 from __future__ import absolute_import
 import os
+import warnings
 from .application.Analysis3D import FieldAnalysis3D
 from .desktop import exception_to_desktop
 from .modeler.GeometryOperators import GeometryOperators
@@ -1713,6 +1714,19 @@ class Hfss(FieldAnalysis3D, object):
     def assig_voltage_source_to_sheet(self, sheet_name, axisdir=0, sourcename=None):
         """Create a voltage source taking one sheet.
 
+        .. deprecated:: 0.4.0
+           Use :func:`Hfss.assign_voltage_source_to_sheet` instead.
+
+        """
+
+        warnings.warn('`assig_voltage_source_to_sheet is deprecated`. Use `assign_voltage_source_to_sheet` instead.',
+                      DeprecationWarning)
+        self.assign_voltage_source_to_sheet(sheet_name, axisdir=0, sourcename=None)
+
+    @aedt_exception_handler
+    def assign_voltage_source_to_sheet(self, sheet_name, axisdir=0, sourcename=None):
+        """Create a voltage source taking one sheet.
+
         Parameters
         ----------
         sheet_name : str
@@ -1737,7 +1751,7 @@ class Hfss(FieldAnalysis3D, object):
         >>> sheet = hfss.modeler.primitives.create_rectangle(hfss.CoordinateSystemPlane.XYPlane,
         ...                                                  [0, 0, -70], [10, 2], name="VoltageSheet",
         ...                                                  matname="copper")
-        >>> hfss.assig_voltage_source_to_sheet(sheet.name, hfss.AxisDir.XNeg, "VoltageSheetExample")
+        >>> hfss.assign_voltage_source_to_sheet(sheet.name, hfss.AxisDir.XNeg, "VoltageSheetExample")
         'VoltageSheetExample'
 
         """

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -2158,12 +2158,12 @@ class Hfss(FieldAnalysis3D, object):
 
     @aedt_exception_handler
     def thicken_port_sheets(self, inputlist, value, internalExtr=True, internalvalue=1):
-        """Create thickened sheets over a list of input port faces.
+        """Create thickened sheets over a list of input port sheets.
        
         Parameters
         ----------
         inputlist : list
-            List of the faces to thicken.
+            List of the sheets to thicken.
         value :
             Value in millimeters for thickening the faces.
         internalExtr : bool, optional
@@ -2181,8 +2181,8 @@ class Hfss(FieldAnalysis3D, object):
         Examples
         --------
 
-        Create a rectangle sheet and use it to create a wave port.
-        Set up the thermal power for the port created above.
+        Create a circle sheet and use it to create a wave port.
+        Set the thickness of this circle sheet to ``"2 mm"``.
 
         >>> sheet_for_thickness = hfss.modeler.primitives.create_circle(hfss.CoordinateSystemPlane.YZPlane,
         ...                                                             [60, 60, 60], 10,
@@ -2192,6 +2192,7 @@ class Hfss(FieldAnalysis3D, object):
         >>> hfss.thicken_port_sheets(["SheetForThickness"], 2)
         pyaedt Info: done
         {}
+
         """
 
         tol = 1e-6

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -2132,7 +2132,7 @@ class Hfss(FieldAnalysis3D, object):
         Examples
         --------
 
-        Create a rectangle sheet and use it to create a wave port.
+        Create a circle sheet and use it to create a wave port.
         Set up the thermal power for the port created above.
 
         >>> sheet = hfss.modeler.primitives.create_circle(hfss.CoordinateSystemPlane.YZPlane,
@@ -2146,6 +2146,7 @@ class Hfss(FieldAnalysis3D, object):
         True
 
         """
+
         self._messenger.add_info_message("Setting up power to Eigenmode " + powerin + "Watt")
         if self.solution_type != "Eigenmode":
             self.osolution.EditSources([["IncludePortPostProcessing:=", True, "SpecifySystemPower:=", False],
@@ -2177,7 +2178,22 @@ class Hfss(FieldAnalysis3D, object):
         list
             List of the port IDs where thickened sheets were created.
 
+        Examples
+        --------
+
+        Create a rectangle sheet and use it to create a wave port.
+        Set up the thermal power for the port created above.
+
+        >>> sheet_for_thickness = hfss.modeler.primitives.create_circle(hfss.CoordinateSystemPlane.YZPlane,
+        ...                                                             [60, 60, 60], 10,
+        ...                                                             name="SheetForThickness")
+        >>> port_for_thickness = hfss.create_wave_port_from_sheet(sheet_for_thickness, 5, hfss.AxisDir.XNeg,
+        ...                                                       40, 2, "WavePortForThickness", True)
+        >>> hfss.thicken_port_sheets(["SheetForThickness"], 2)
+        pyaedt Info: done
+        {}
         """
+
         tol = 1e-6
         ports_ID = {}
         aedt_bounding_box = self.modeler.primitives.get_model_bounding_box()


### PR DESCRIPTION
Add examples for the HFFS method named radiation boundary.
Add example for the HFSS method named thicken_port_sheets.

Update a comment for the hfss fixture. The name of the aedt project was incorrect.