### PR TITLE
Fixed axisdir default value for create_circuit_port_between_objects method.

### DIFF
--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -957,7 +957,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1020,7 +1020,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1091,7 +1091,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1152,7 +1152,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1243,7 +1243,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1343,7 +1343,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line. This is typically the reference plane.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1420,7 +1420,7 @@ class Hfss(FieldAnalysis3D, object):
             First object (starting object for integration line)
         endobject :
             Second object (ending object for integration line)
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1478,7 +1478,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1596,7 +1596,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1684,7 +1684,7 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1835,7 +1835,7 @@ class Hfss(FieldAnalysis3D, object):
             List of input sheets to create the waveport from.
         deemb : float, optional
             Deembedding value distance in model units. The default is ``0``.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1907,7 +1907,7 @@ class Hfss(FieldAnalysis3D, object):
         ----------
         sheet_name : str
             Name of the sheet.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -1994,7 +1994,7 @@ class Hfss(FieldAnalysis3D, object):
         ----------
         sheet_name : str
             Name of the sheet to apply the boundary to.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -2039,7 +2039,7 @@ class Hfss(FieldAnalysis3D, object):
         ----------
         sheet_name : str
             Name of the sheet to apply the boundary to.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.
@@ -2161,7 +2161,7 @@ class Hfss(FieldAnalysis3D, object):
         ----------
         sheet_name : str
             Name of the sheet to apply the boundary to.
-        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analysis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
             which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
             The default is ``Application.AxisDir.XNeg``.

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -947,7 +947,7 @@ class Hfss(FieldAnalysis3D, object):
         return False
 
     @aedt_exception_handler
-    def create_circuit_port_between_objects(self, startobj, endobject, axisdir="XYNeg", impedance=50, portname=None,
+    def create_circuit_port_between_objects(self, startobj, endobject, axisdir=0, impedance=50, portname=None,
                                             renorm=True, renorm_impedance=50, deemb=False):
         """Create a circuit port taking the closest edges of two objects.
 
@@ -957,10 +957,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : str, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"XYNeg"``.
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         impedance : float, optional
             Port impedance. The default is ``50``.
         portname : str, optional
@@ -1020,9 +1020,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir :
-            Position of the port. It should be one of the values for ``Application.AxisDir``, which are:
-            ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``. The default is ``"0"``.
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+            Position of the port. It should be one of the values for ``Application.AxisDir``,
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         impedance : float, optional
             Port impedance. The default is ``50``.
         portname : str, optional
@@ -1090,10 +1091,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : str, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default value is ``"0"``.
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Name of the source. The default is ``None``.
         source_on_plane : bool, optional
@@ -1151,9 +1152,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : optional
-            Position of the current source. It should be one of the values for ``Application.AxisDir``, which are:
-            ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``. The default is ``"0"``.
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+            Position of the port. It should be one of the values for ``Application.AxisDir``,
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Name of the source. The default is ``None``.
         source_on_plane : bool, optional
@@ -1241,10 +1243,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : str, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         impedance : float, optional
             Port impedance. The default is ``50``.
         nummodes : int, optional
@@ -1341,11 +1343,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line. This is typically the reference plane.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : int, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``0`` for ``"XNeg"``,``1`` for ``"YNeg"``,``2`` for ``"ZNeg"``, ``3`` for``"XPos"``,
-            ``4`` for``"YPos"``, and ``5`` for``"ZPos"``.
-            The default is ``0``.
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         impedance : float, optional
             Port impedance. The default is ``50``.
         nummodes : int, optional
@@ -1419,10 +1420,10 @@ class Hfss(FieldAnalysis3D, object):
             First object (starting object for integration line)
         endobject :
             Second object (ending object for integration line)
-        axisdir : str, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Perfect E name. The default is ``None``.
         is_infinite_gnd : bool, optional
@@ -1477,10 +1478,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : str, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Perfect H name. The default is ``None``.
         bound_on_plane : bool, optional
@@ -1595,10 +1596,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : str, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Perfect H name. The default is ``None``.
         rlctype : str, optional
@@ -1683,11 +1684,10 @@ class Hfss(FieldAnalysis3D, object):
             First (starting) object for the integration line.
         endobject :
             Second (ending) object for the integration line.
-        axisdir : str, optional
-            Position of the impedance. It should be one of the values
-            for ``Application.AxisDir``, which are: ``"XNeg"``,
-            ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and
-            ``"ZPos"``.  The default is ``"0"``.
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+            Position of the port. It should be one of the values for ``Application.AxisDir``,
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Name of the impedance. The default is ``None``.
         resistance : float, optional
@@ -1835,10 +1835,10 @@ class Hfss(FieldAnalysis3D, object):
             List of input sheets to create the waveport from.
         deemb : float, optional
             Deembedding value distance in model units. The default is ``0``.
-        axisdir : str, optional
-            Position of the reference object. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+            Position of the port. It should be one of the values for ``Application.AxisDir``,
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         impedance : float, optional
             Port impedance. The default is ``50``.
         nummodes : int, optional
@@ -1907,10 +1907,10 @@ class Hfss(FieldAnalysis3D, object):
         ----------
         sheet_name : str
             Name of the sheet.
-        axisdir : optional
-            Direction of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+            Position of the port. It should be one of the values for ``Application.AxisDir``,
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         impedance : float, optional
             Port impedance. The default is ``50``.
         portname : str, optional
@@ -1994,10 +1994,10 @@ class Hfss(FieldAnalysis3D, object):
         ----------
         sheet_name : str
             Name of the sheet to apply the boundary to.
-        axisdir : str, optional
-            Position of the voltage source. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+            Position of the port. It should be one of the values for ``Application.AxisDir``,
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Name of the source. The default is ``None``.
 
@@ -2039,10 +2039,10 @@ class Hfss(FieldAnalysis3D, object):
         ----------
         sheet_name : str
             Name of the sheet to apply the boundary to.
-        axisdir : str, optional
-            Position of the current source. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
+            Position of the port. It should be one of the values for ``Application.AxisDir``,
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Name of the source. The default is ``None``.
 
@@ -2161,10 +2161,10 @@ class Hfss(FieldAnalysis3D, object):
         ----------
         sheet_name : str
             Name of the sheet to apply the boundary to.
-        axisdir : str, optional
+        axisdir : int or :class: `pyaedt.application.Analysis.Analyis.AxisDir`, optional
             Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``"XNeg"``, ``"YNeg"``, ``"ZNeg"``, ``"XPos"``, ``"YPos"``, and ``"ZPos"``.
-            The default is ``"0"``.
+            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
+            The default is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Lumped RLC name. The default is ``None``.
         rlctype : str, optional


### PR DESCRIPTION
Fixed ``axisdir`` default value for ``create_circuit_port_between_objects`` method.
Corrected all docstrings for ``axisdir``.
