### PR TITLE
Organize module imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 exclude = venv, __init__.py, doc/_build
-select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E301, E303, E501, F401
+select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E301, E303, E501
 count = True
 max-complexity = 10
 max-line-length = 120

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 exclude = venv, __init__.py, doc/_build
-select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E301, E303, E501
+select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E301, E303, E501, F401
 count = True
 max-complexity = 10
 max-line-length = 120

--- a/pyaedt/application/AEDT_File_Management.py
+++ b/pyaedt/application/AEDT_File_Management.py
@@ -1,8 +1,9 @@
 import csv
-import re
 import os
+import re
 import shutil
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
+
+from ..generic.general_methods import aedt_exception_handler
 
 
 @aedt_exception_handler

--- a/pyaedt/application/AnalsyisEmit.py
+++ b/pyaedt/application/AnalsyisEmit.py
@@ -1,10 +1,6 @@
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
-from .Analysis import Analysis
-from .Design import solutions_settings, Design
 from ..modeler.Circuit import ModelerEmit
 from ..modules.PostProcessor import PostProcessor
-from ..modules.SetupTemplates import SetupKeys
-from ..modules.SolveSetup import SetupCircuit
+from .Design import Design
 
 
 class FieldAnalysisEmit(Design):

--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -5,32 +5,30 @@ It includes common classes for file management and messaging and all
 calls to AEDT modules like the modeler, mesh, postprocessing, and setup.
 """
 from __future__ import absolute_import
+
 import os
-import itertools
-import threading
 import shutil
+import threading
 import warnings
 from collections import OrderedDict
 
-from ..modeler.modeler_constants import CoordinateSystemPlane, CoordinateSystemAxis, GravityDirection, Plane
-from ..modules.SolveSetup import Setup
-from ..modules.SolutionType import SolutionType, SetupTypes
-from ..modules.SetupTemplates import SetupKeys
+from .. import is_ironpython
+from ..generic.general_methods import aedt_exception_handler
+from ..modeler.modeler_constants import CoordinateSystemAxis, CoordinateSystemPlane, GravityDirection, Plane
 from ..modules.Boundary import NativeComponentObject
 from ..modules.DesignXPloration import (
     DOESetups,
     DXSetups,
+    OptimizationSetups,
     ParametericsSetups,
     SensitivitySetups,
     StatisticalSetups,
-    OptimizationSetups,
 )
-from .Design import Design
 from ..modules.MaterialLib import Materials
-from ..generic.general_methods import aedt_exception_handler
-from ..desktop import _pythonver
-from .. import is_ironpython
-import sys
+from ..modules.SetupTemplates import SetupKeys
+from ..modules.SolutionType import SetupTypes, SolutionType
+from ..modules.SolveSetup import Setup
+from .Design import Design
 
 if is_ironpython:
     from ..modules.PostProcessor import PostProcessor

--- a/pyaedt/application/Analysis2D.py
+++ b/pyaedt/application/Analysis2D.py
@@ -3,7 +3,7 @@ import warnings
 from .Analysis import Analysis
 from ..modeler.Model2D import Modeler2D
 from ..modules.Mesh import Mesh
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
+from ..generic.general_methods import aedt_exception_handler
 
 
 class FieldAnalysis2D(Analysis):

--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -1,11 +1,11 @@
-import os
 import ntpath
+import os
 import warnings
 
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name, retry_ntimes
-from .Analysis import Analysis
+from ..generic.general_methods import aedt_exception_handler, retry_ntimes
 from ..modeler.Model3D import Modeler3D
 from ..modules.Mesh import Mesh
+from .Analysis import Analysis
 
 
 class FieldAnalysis3D(Analysis, object):

--- a/pyaedt/application/Analysis3DLayout.py
+++ b/pyaedt/application/Analysis3DLayout.py
@@ -1,9 +1,9 @@
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
-from .Analysis import Analysis
+from ..generic.general_methods import aedt_exception_handler
 from ..modeler.Model3DLayout import Modeler3DLayout
+from ..modules.Mesh3DLayout import Mesh
 from ..modules.SetupTemplates import SetupKeys
 from ..modules.SolveSetup import Setup3DLayout
-from ..modules.Mesh3DLayout import Mesh
+from .Analysis import Analysis
 
 
 class FieldAnalysis3DLayout(Analysis):

--- a/pyaedt/application/AnalysisNexxim.py
+++ b/pyaedt/application/AnalysisNexxim.py
@@ -1,10 +1,9 @@
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
+from ..generic.general_methods import aedt_exception_handler
+from ..modeler.Circuit import ModelerNexxim
+from ..modules.PostProcessor import CircuitPostProcessor
+from ..modules.SolveSetup import SetupCircuit
 from .Analysis import Analysis
 from .Design import solutions_settings
-from ..modeler.Circuit import ModelerNexxim
-from ..modules.SetupTemplates import SetupKeys
-from ..modules.SolveSetup import SetupCircuit
-from ..modules.PostProcessor import CircuitPostProcessor
 
 
 class FieldAnalysisCircuit(Analysis):

--- a/pyaedt/application/AnalysisRMxprt.py
+++ b/pyaedt/application/AnalysisRMxprt.py
@@ -1,7 +1,7 @@
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
+from ..generic.general_methods import aedt_exception_handler
+from ..modeler.Model2D import ModelerRMxprt
 from .Analysis import Analysis
 from .Design import design_solutions
-from ..modeler.Model2D import ModelerRMxprt
 
 
 class FieldAnalysisRMxprt(Analysis):

--- a/pyaedt/application/AnalysisSimplorer.py
+++ b/pyaedt/application/AnalysisSimplorer.py
@@ -1,10 +1,9 @@
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
-from .Analysis import Analysis
-from .Design import solutions_settings
+from ..generic.general_methods import aedt_exception_handler
 from ..modeler.Circuit import ModelerSimplorer
 from ..modules.PostProcessor import PostProcessor
-from ..modules.SetupTemplates import SetupKeys
 from ..modules.SolveSetup import SetupCircuit
+from .Analysis import Analysis
+from .Design import solutions_settings
 
 
 class FieldAnalysisSimplorer(Analysis):

--- a/pyaedt/application/MessageManager.py
+++ b/pyaedt/application/MessageManager.py
@@ -6,10 +6,11 @@ This module provides all functionalities for logging errors and messages
 in both AEDT and the log file.
 """
 
-import sys
 import logging
 import os
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
+import sys
+
+from ..generic.general_methods import aedt_exception_handler
 
 message_levels = {"Global": 0, "Project": 1, "Design": 2}
 

--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -13,10 +13,11 @@ Examples
 
 """
 from __future__ import absolute_import
+
 import math
-import re
-import numbers
 import os
+import re
+
 from .. import aedt_exception_handler
 from ..generic.general_methods import is_number
 

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -2,10 +2,10 @@
 """This module contains the `Circuit` class."""
 
 from __future__ import absolute_import
+
 import math
-import warnings
-import re
 import os
+import re
 
 from .application.AnalysisNexxim import FieldAnalysisCircuit
 from .desktop import exception_to_desktop

--- a/pyaedt/conftest.py
+++ b/pyaedt/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from pyaedt import Desktop
-from pyaedt.doctest_fixtures import *
+from pyaedt.doctest_fixtures import * # noqa: F401
 
 # Import fixtures from other files
 pytest_plugins = [

--- a/pyaedt/conftest.py
+++ b/pyaedt/conftest.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from pyaedt import Desktop
-from pyaedt.doctest_fixtures import * # noqa: F401
+from pyaedt.doctest_fixtures import *  # noqa: F401
 
 # Import fixtures from other files
 pytest_plugins = [

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -3,12 +3,24 @@
 This module is implicitily loaded in HFSS 3D Layout when launched.
 
 """
+import gc
 import os
 import sys
+import time
 import traceback
 import warnings
-import gc
-import time
+
+from pyaedt import inside_desktop, is_ironpython
+from pyaedt.application.MessageManager import EDBMessageManager
+from pyaedt.edb_core import *
+from pyaedt.generic.general_methods import (
+    aedt_exception_handler,
+    env_path,
+    env_path_student,
+    env_value,
+    generate_unique_name,
+)
+from pyaedt.generic.process import SiwaveSolve
 
 if os.name == "posix":
     try:
@@ -19,11 +31,7 @@ else:
     import subprocess
 try:
     import clr
-    from System.Collections.Generic import List, Dictionary
-    from System import Convert, String
-    import System
-    from System import Double, Array
-    from System.Collections.Generic import List
+    from System import Convert
 
     edb_initialized = True
 except ImportError:
@@ -31,14 +39,6 @@ except ImportError:
         "The clr is missing. Install Python.NET or use an IronPython version if you want to use the EDB module."
     )
     edb_initialized = False
-
-from pyaedt import is_ironpython, inside_desktop
-from pyaedt.application.MessageManager import EDBMessageManager
-from pyaedt.edb_core import *
-
-from pyaedt.generic.general_methods import env_path, env_value, env_path_student
-from pyaedt.generic.general_methods import generate_unique_name, aedt_exception_handler
-from pyaedt.generic.process import SiwaveSolve
 
 
 class Edb(object):

--- a/pyaedt/edb_core/EDB_Data.py
+++ b/pyaedt/edb_core/EDB_Data.py
@@ -1,19 +1,14 @@
-import warnings
-import sys
 import time
+import warnings
 from collections import OrderedDict, defaultdict
-from .general import (
-    convert_py_list_to_net_list,
-    convert_net_list_to_py_list,
-    convert_pydict_to_netdict,
-    convert_netdict_to_pydict,
-)
-from ..generic.general_methods import aedt_exception_handler
+
 from pyaedt import is_ironpython
 
+from ..generic.general_methods import aedt_exception_handler
+from .general import convert_py_list_to_net_list
+
 try:
-    import clr
-    from System import Double, Array
+    from System import Array
     from System.Collections.Generic import List
 except ImportError:
     warnings.warn(

--- a/pyaedt/edb_core/components.py
+++ b/pyaedt/edb_core/components.py
@@ -1,26 +1,22 @@
 """This module contains the `Components` class.
 
 """
-import re
 import random
+import re
 
-import pyaedt.edb_core.EDB_Data
-from .EDB_Data import EDBComponent
-
-from .general import *
-from ..generic.general_methods import get_filename_without_extension
 from pyaedt import is_ironpython
+
+from ..generic.general_methods import get_filename_without_extension
+from .EDB_Data import EDBComponent
+from .general import *
 
 try:
     import clr
 
     clr.AddReference("System")
-    from System import Convert, String
-    from System import Double, Array
-    from System.Collections.Generic import List
+    from System import String
 except ImportError:
     warnings.warn("This module requires PythonNet.")
-from collections import defaultdict
 
 
 def resistor_value_parser(RValue):
@@ -722,9 +718,7 @@ class Components(object):
         else:
             self._messenger.add_warning_message(
                 "Component {} has not been assigned because either it is not present in the layout "
-                "or it contains a number of pins not equal to 2".format(
-                    componentname
-                )
+                "or it contains a number of pins not equal to 2".format(componentname)
             )
             return False
         self._messenger.add_warning_message("RLC properties for Component {} has been assigned.".format(componentname))

--- a/pyaedt/edb_core/general.py
+++ b/pyaedt/edb_core/general.py
@@ -3,30 +3,21 @@ This module contains EDB general methods and related methods.
 
 """
 from __future__ import absolute_import
+
+import logging
 import warnings
 
+from ..generic.general_methods import aedt_exception_handler
 
 try:
     import clr
 
     clr.AddReference("System.Collections")
     from System.Collections.Generic import List
-    from System import Int32
 except ImportError:
     warnings.warn("This module requires pythonnet.")
 
-
-import inspect
-import itertools
-import sys
-import traceback
-from collections import OrderedDict
-from functools import wraps
-import logging
-
 logger = logging.getLogger(__name__)
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name
-from pyaedt import is_ironpython
 
 
 @aedt_exception_handler

--- a/pyaedt/edb_core/hfss.py
+++ b/pyaedt/edb_core/hfss.py
@@ -1,21 +1,10 @@
 """
 This module contains the `Edb3DLayout` class.
 """
-
-import warnings
-import os
-from .general import *
-from ..generic.general_methods import get_filename_without_extension, generate_unique_name
-
-try:
-    import clr
-    from System import Convert, String
-    from System import Double, Array
-    from System.Collections.Generic import List
-except ImportError:
-    warnings.warn("This module requires pythonnet.")
-
 from pyaedt import is_ironpython
+
+from ..generic.general_methods import generate_unique_name
+from .general import *
 
 
 class Edb3DLayout(object):

--- a/pyaedt/edb_core/layout.py
+++ b/pyaedt/edb_core/layout.py
@@ -2,16 +2,13 @@
 This module contains these classes: `EdbLayout` and `Shape`.
 """
 
-import warnings
-from .general import *
-from ..generic.general_methods import get_filename_without_extension, generate_unique_name
 import math
+import warnings
+
+from .general import *
 
 try:
-    import clr
-    from System import Convert, String, Tuple
-    from System import Double, Array
-    from System.Collections.Generic import List
+    from System import Tuple
 except ImportError:
     warnings.warn('This module requires the "pythonnet" package.')
 

--- a/pyaedt/edb_core/nets.py
+++ b/pyaedt/edb_core/nets.py
@@ -1,15 +1,6 @@
 from __future__ import absolute_import
-import warnings
-from .general import *
-from ..generic.general_methods import get_filename_without_extension, generate_unique_name
 
-try:
-    import clr
-    from System import Convert, String
-    from System import Double, Array
-    from System.Collections.Generic import List
-except ImportError:
-    warnings.warn("This module requires pythonnet.")
+from .general import *
 
 
 class EdbNets(object):

--- a/pyaedt/edb_core/padstack.py
+++ b/pyaedt/edb_core/padstack.py
@@ -3,15 +3,13 @@ This module contains the `EdbPadstacks` class.
 """
 
 import warnings
-from .general import *
-from ..generic.general_methods import get_filename_without_extension, generate_unique_name
+
+from ..generic.general_methods import generate_unique_name
 from .EDB_Data import EDBPadstack
+from .general import *
 
 try:
-    import clr
-    from System import Convert, String
-    from System import Double, Array
-    from System.Collections.Generic import List
+    from System import Array
 except ImportError:
     warnings.warn('This module requires the "pythonnet" package.')
 

--- a/pyaedt/edb_core/siwave.py
+++ b/pyaedt/edb_core/siwave.py
@@ -3,18 +3,18 @@ This module contains these clases: `CircuitPort`, `CurrentSource`, `EdbSiwave`,
 `PinGroup`, `ResistorSource`, `Source`, `SourceType`, and `VoltageSource`.
 """
 
-import warnings
 import os
 import time
-from .general import *
-from ..generic.general_methods import get_filename_without_extension, generate_unique_name, retry_ntimes
+import warnings
+
 from pyaedt import is_ironpython
 
+from ..generic.general_methods import generate_unique_name, retry_ntimes
+from .general import *
+
 try:
-    import clr
-    from System import Convert, String
-    from System import Double, Array
-    from System.Collections.Generic import List, Dictionary
+    from System import String
+    from System.Collections.Generic import Dictionary
 except ImportError:
     warnings.warn("This module requires pythonnet.")
 

--- a/pyaedt/edb_core/stackup.py
+++ b/pyaedt/edb_core/stackup.py
@@ -3,17 +3,16 @@ This module contains the `EdbStackup` class.
 
 """
 from __future__ import absolute_import
+
 import warnings
+
+from .EDB_Data import EDBLayers
 from .general import *
 
 try:
     from System import Double
-    from System.Collections.Generic import List
 except ImportError:
     warnings.warn('This module requires the "pythonnet" package.')
-
-
-from .EDB_Data import EDBLayers, EDBLayer
 
 
 class EdbStackup(object):

--- a/pyaedt/edb_core/stackup.py
+++ b/pyaedt/edb_core/stackup.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import
 
 import warnings
 
+from pyaedt import is_ironpython
+
 from .EDB_Data import EDBLayers
 from .general import *
 

--- a/pyaedt/emit.py
+++ b/pyaedt/emit.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import
 
-import numbers
-
 from .application.AnalsyisEmit import FieldAnalysisEmit
-from .application.Variables import Variable
 from .desktop import exception_to_desktop
-from .generic.general_methods import aedt_exception_handler, generate_unique_name
 
 
 class Emit(FieldAnalysisEmit, object):

--- a/pyaedt/examples/downloads.py
+++ b/pyaedt/examples/downloads.py
@@ -1,8 +1,8 @@
 """Download example datasets from https://github.com/pyansys/example-data"""
-import shutil
 import os
-import sys
-import zipfile, os.path
+import os.path
+import shutil
+import zipfile
 
 from pyaedt import is_ironpython
 
@@ -10,14 +10,13 @@ if is_ironpython:
     import urllib
 else:
     import urllib.request
-from pyaedt.generic.general_methods import generate_unique_name
 
-EXAMPLE_REPO = "https://github.com/pyansys/example-data/raw/master/pyaedt/"
 if os.name == "posix":
     tmpfold = os.environ["TMPDIR"]
 else:
     tmpfold = os.environ["TEMP"]
 
+EXAMPLE_REPO = "https://github.com/pyansys/example-data/raw/master/pyaedt/"
 EXAMPLES_PATH = os.path.join(tmpfold, "PyAEDTExamples")
 
 

--- a/pyaedt/generic/DataHandlers.py
+++ b/pyaedt/generic/DataHandlers.py
@@ -9,8 +9,7 @@ from collections import OrderedDict
 from decimal import Decimal
 
 from pyaedt.generic.general_methods import aedt_exception_handler
-from pyaedt.modeler.Object3d import (EdgePrimitive, FacePrimitive,
-                                     VertexPrimitive)
+from pyaedt.modeler.Object3d import EdgePrimitive, FacePrimitive, VertexPrimitive
 
 try:
     import clr

--- a/pyaedt/generic/DataHandlers.py
+++ b/pyaedt/generic/DataHandlers.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 import json
 import math
-import re
-import warnings
 import random
+import re
 import string
+import warnings
 from collections import OrderedDict
 from decimal import Decimal
-from pyaedt.generic.general_methods import aedt_exception_handler, generate_unique_name
-from pyaedt.modeler.Object3d import EdgePrimitive, FacePrimitive, VertexPrimitive
+
+from pyaedt.generic.general_methods import aedt_exception_handler
+from pyaedt.modeler.Object3d import (EdgePrimitive, FacePrimitive,
+                                     VertexPrimitive)
 
 try:
     import clr
@@ -17,7 +19,7 @@ try:
     from System.Collections.Generic import List
 
     clr.AddReference("System")
-    from System import Double, Array
+    from System import Double
 except ImportError:
     warnings.warn("Pythonnet is needed to run pyaedt")
 

--- a/pyaedt/generic/TouchstoneParser.py
+++ b/pyaedt/generic/TouchstoneParser.py
@@ -1,9 +1,8 @@
-import re
-import os
-from datetime import datetime
 import math
-import cmath
-from .general_methods import generate_unique_name, aedt_exception_handler
+import os
+import re
+
+from .general_methods import aedt_exception_handler
 
 REAL_IMAG = "RI"
 MAG_ANGLE = "MA"

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -12,11 +12,6 @@ import inspect
 import itertools
 
 logger = logging.getLogger(__name__)
-import pkgutil
-
-modules = [tup[1] for tup in pkgutil.iter_modules()]
-if "clr" in modules:
-    import clr
 
 
 class MethodNotSupportedError(Exception):

--- a/pyaedt/generic/process.py
+++ b/pyaedt/generic/process.py
@@ -1,10 +1,8 @@
-import time
-from threading import Thread
-
 import os
-import warnings
 import os.path
+import warnings
 
+from .general_methods import env_path
 
 if os.name == "posix":
     try:
@@ -13,13 +11,6 @@ if os.name == "posix":
         warnings.warn("Pythonnet is needed to run pyaedt within Linux")
 else:
     import subprocess
-
-try:
-    import clr
-except ImportError:
-    warnings.warn("Pythonnet is needed to run pyaedt")
-
-from .general_methods import env_path, env_value
 
 
 class AedtSolve(object):

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -1,12 +1,12 @@
 """This module contains these classes: `Hfss3dLayout`."""
 
 from __future__ import absolute_import
+
 import os
 
 from .application.Analysis3DLayout import FieldAnalysis3DLayout
 from .desktop import exception_to_desktop
-from .modules.SolveSetup import Setup3DLayout
-from .generic.general_methods import generate_unique_name, aedt_exception_handler
+from .generic.general_methods import aedt_exception_handler, generate_unique_name
 
 
 class Hfss3dLayout(FieldAnalysis3DLayout):

--- a/pyaedt/modeler/Circuit.py
+++ b/pyaedt/modeler/Circuit.py
@@ -1,14 +1,10 @@
-import os
-
-from ..generic.general_methods import generate_unique_name, aedt_exception_handler, retry_ntimes
 from ..application.Variables import AEDT_units
-from ..edb import Edb
-from .Modeler import Modeler
-from .PrimitivesSimplorer import SimplorerComponents
-from .PrimitivesNexxim import NexximComponents
-from .Primitives3DLayout import Primitives3DLayout
+from ..generic.general_methods import aedt_exception_handler, retry_ntimes
 from ..modules.LayerStackup import Layers
-import sys
+from .Modeler import Modeler
+from .Primitives3DLayout import Primitives3DLayout
+from .PrimitivesNexxim import NexximComponents
+from .PrimitivesSimplorer import SimplorerComponents
 
 
 class ModelerCircuit(Modeler):

--- a/pyaedt/modeler/Model3DLayout.py
+++ b/pyaedt/modeler/Model3DLayout.py
@@ -1,13 +1,13 @@
 import os
 
-from ..generic.general_methods import retry_ntimes, aedt_exception_handler
+from pyaedt import _pythonver
+
 from ..application.Variables import AEDT_units
 from ..edb import Edb
-from .Modeler import Modeler
-from .Primitives3DLayout import Primitives3DLayout, Geometries3DLayout
+from ..generic.general_methods import aedt_exception_handler, retry_ntimes
 from ..modules.LayerStackup import Layers
-from pyaedt import _pythonver
-import sys
+from .Modeler import Modeler
+from .Primitives3DLayout import Geometries3DLayout, Primitives3DLayout
 
 
 class Modeler3DLayout(Modeler):

--- a/pyaedt/modeler/MultiPartComponent.py
+++ b/pyaedt/modeler/MultiPartComponent.py
@@ -1,10 +1,9 @@
 import os
-import math
-import sys
+
 from ..generic.DataHandlers import json_to_dict
 from ..generic.filesystem import get_json_files
-from .GeometryOperators import GeometryOperators
 from ..generic.general_methods import aedt_exception_handler
+from .GeometryOperators import GeometryOperators
 
 
 def read_actors(fn, actor_lib):

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -15,10 +15,9 @@ from __future__ import absolute_import
 import random
 import string
 from collections import defaultdict
-from .. import generate_unique_name, retry_ntimes, aedt_exception_handler
-from .GeometryOperators import GeometryOperators
-from ..generic.general_methods import time_fn
 
+from .. import aedt_exception_handler, retry_ntimes
+from .GeometryOperators import GeometryOperators
 
 clamp = lambda n, minn, maxn: max(min(maxn, n), minn)
 

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -2,19 +2,17 @@
 This module contains these Primitives classes: `Polyline` and `Primitives`.
 """
 from __future__ import absolute_import
-import sys
-from collections import defaultdict
+
 import math
-import time
-import numbers
 import os
+import time
+from collections import OrderedDict, defaultdict
 from copy import copy
-from .GeometryOperators import GeometryOperators
-from .Object3d import Object3d, EdgePrimitive, FacePrimitive, VertexPrimitive, _dim_arg, _uname
-from ..generic.general_methods import aedt_exception_handler, retry_ntimes, is_number
+
 from ..application.Variables import Variable
-from collections import OrderedDict
-from pyaedt import is_ironpython
+from ..generic.general_methods import aedt_exception_handler, is_number, retry_ntimes
+from .GeometryOperators import GeometryOperators
+from .Object3d import EdgePrimitive, FacePrimitive, Object3d, _dim_arg, _uname
 
 default_materials = {
     "Icepak": "air",

--- a/pyaedt/modeler/Primitives2D.py
+++ b/pyaedt/modeler/Primitives2D.py
@@ -1,6 +1,5 @@
 from ..generic.general_methods import aedt_exception_handler, is_number
 from .Primitives import Primitives
-import numbers
 
 
 class Primitives2D(Primitives, object):

--- a/pyaedt/modeler/Primitives3D.py
+++ b/pyaedt/modeler/Primitives3D.py
@@ -1,11 +1,9 @@
 import os
-from ..generic.general_methods import aedt_exception_handler
-from .Primitives import Primitives
+
+from ..generic.general_methods import aedt_exception_handler, retry_ntimes
 from .GeometryOperators import GeometryOperators
-from ..application.Analysis import CoordinateSystemAxis
-from .Object3d import Object3d
-from .MultiPartComponent import Person, Bird, Vehicle, Antenna, Radar, Environment, MultiPartComponent
-from ..generic.general_methods import retry_ntimes
+from .MultiPartComponent import Bird, Environment, MultiPartComponent, Person, Vehicle
+from .Primitives import Primitives
 
 
 class Primitives3D(Primitives, object):

--- a/pyaedt/modules/AdvancedPostProcessing.py
+++ b/pyaedt/modules/AdvancedPostProcessing.py
@@ -4,13 +4,14 @@ This module contains the `PostProcessor` class.
 It contains all advanced postprocessing functionalities that require Python 3.x packages like NumPy and Matplotlib.
 """
 from __future__ import absolute_import
-import os
 
-from .PostProcessor import PostProcessor as Post
-from ..generic.general_methods import aedt_exception_handler
-import time
 import math
+import os
+import time
 import warnings
+
+from ..generic.general_methods import aedt_exception_handler
+from .PostProcessor import PostProcessor as Post
 
 try:
     import numpy as np
@@ -31,7 +32,7 @@ except ImportError:
     )
 
 try:
-    from IPython.display import Image, display
+    from IPython.display import Image
 
     ipython_available = True
 except ImportError:

--- a/pyaedt/modules/MaterialLib.py
+++ b/pyaedt/modules/MaterialLib.py
@@ -2,12 +2,12 @@
 This module contains the `Materials` class.
 """
 from __future__ import absolute_import
-import os
-import xml.etree.ElementTree as ET
-from .Material import *
-from ..generic.general_methods import aedt_exception_handler, retry_ntimes
-from ..generic.DataHandlers import arg2dict
+
 import json
+
+from ..generic.DataHandlers import arg2dict
+from ..generic.general_methods import aedt_exception_handler, retry_ntimes
+from .Material import *
 
 
 class Materials(object):

--- a/pyaedt/modules/PostProcessor.py
+++ b/pyaedt/modules/PostProcessor.py
@@ -5,19 +5,19 @@ This module provides all functionalities for creating and editing plots in the 3
 
 """
 from __future__ import absolute_import
+
+import itertools
+import math
 import os
-import shutil
 import random
 import string
 import time
-import math
-import itertools
-from collections import OrderedDict
-from ..modeler.Modeler import CoordinateSystem
-from ..generic.general_methods import aedt_exception_handler, generate_unique_name, retry_ntimes
-from ..generic.filesystem import Scratch
-from ..application.Variables import AEDT_units
 import warnings
+from collections import OrderedDict
+
+from ..application.Variables import AEDT_units
+from ..generic.filesystem import Scratch
+from ..generic.general_methods import aedt_exception_handler, generate_unique_name, retry_ntimes
 
 report_type = {
     "DrivenModal": "Modal Solution Data",

--- a/pyaedt/rmxprt.py
+++ b/pyaedt/rmxprt.py
@@ -1,8 +1,9 @@
 """This module contains these classes: `RMXprtModule` and `Rmxprt`."""
 from __future__ import absolute_import
-from .application.Design import Design
+
 from .application.AnalysisRMxprt import FieldAnalysisRMxprt
-from .generic.general_methods import aedt_exception_handler, generate_unique_name
+from .application.Design import Design
+from .generic.general_methods import aedt_exception_handler
 
 
 class RMXprtModule(object):

--- a/pyaedt/simplorer.py
+++ b/pyaedt/simplorer.py
@@ -2,12 +2,10 @@
 
 from __future__ import absolute_import
 
-import numbers
-
 from .application.AnalysisSimplorer import FieldAnalysisSimplorer
 from .application.Variables import Variable
 from .desktop import exception_to_desktop
-from .generic.general_methods import aedt_exception_handler, generate_unique_name, is_number
+from .generic.general_methods import aedt_exception_handler, is_number
 
 
 class Simplorer(FieldAnalysisSimplorer, object):

--- a/pyaedt/siwave.py
+++ b/pyaedt/siwave.py
@@ -22,7 +22,7 @@ if is_ironpython:
 elif os.name == "nt":
     modules = [tup[1] for tup in pkgutil.iter_modules()]
     if "clr" in modules:
-        import clr # noqa: F401
+        import clr  # noqa: F401
         import win32com.client
 
         _com = "pythonnet_v3"
@@ -111,7 +111,7 @@ class Siwave:
             if _com == "pythonnet":
                 self._main.oSiwave = System.Activator.CreateInstance(System.Type.GetTypeFromProgID(version))
 
-            elif (_com == "pythonnet_v3"):
+            elif _com == "pythonnet_v3":
                 # TODO check if possible to use pythonnet. at the moment the tool open AEDt
                 # but doesn't return the wrapper of oApp
                 print("Launching AEDT with Module win32com")

--- a/pyaedt/siwave.py
+++ b/pyaedt/siwave.py
@@ -6,7 +6,7 @@ automatically initialized by an app to the latest installed AEDT version.
 
 """
 from __future__ import absolute_import
-from .generic.general_methods import aedt_exception_handler, generate_unique_name
+from .generic.general_methods import aedt_exception_handler
 import os
 import sys
 import pkgutil
@@ -22,7 +22,7 @@ if is_ironpython:
 elif os.name == "nt":
     modules = [tup[1] for tup in pkgutil.iter_modules()]
     if "clr" in modules:
-        import clr
+        import clr # noqa: F401
         import win32com.client
 
         _com = "pythonnet_v3"


### PR DESCRIPTION
Organize module imports and remove unused imports with the hopes of adding this check to the flake8 config once all refactoring is complete.