### PR TITLE
Apply flake8 policy for unused imports

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 exclude = venv, __init__.py, doc/_build
-select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E301, E303, E501
+select = W191, W291, W293, W391, E115, E117, E122, E124, E125, E301, E303, E501, F401
 count = True
 max-complexity = 10
 max-line-length = 120

--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -1,19 +1,18 @@
 # standard imports
-import os
 import gc
-
-# Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path, desktop_version, new_thread, non_graphical
+import os
 
 # Import required modules
 from pyaedt import Hfss
-from pyaedt.application.Design import DesignCache
 from pyaedt.generic.filesystem import Scratch
 
+# Setup paths for module imports
+from _unittest.conftest import desktop_version, local_path, new_thread, non_graphical, scratch_path
+
 try:
-    import pytest
+    import pytest  # noqa: F401
 except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 test_project_name = "Coax_HFSS"
 example_project = os.path.join(local_path, "example_models", test_project_name + ".aedt")

--- a/_unittest/test_02_2D_modeler.py
+++ b/_unittest/test_02_2D_modeler.py
@@ -1,15 +1,16 @@
 # standard imports
 import math
 
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
+from pyaedt.generic.general_methods import isclose
+from pyaedt.maxwell import Maxwell2d
 
 # Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path, BasisTest, pyaedt_unittest_check_desktop_error
-from pyaedt.maxwell import Maxwell2d
-from pyaedt.generic.general_methods import isclose
+from _unittest.conftest import BasisTest
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 
 class TestClass(BasisTest):

--- a/_unittest/test_02_3D_modeler.py
+++ b/_unittest/test_02_3D_modeler.py
@@ -1,11 +1,10 @@
-# standard imports
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
-
 # Setup paths for module imports
 from _unittest.conftest import BasisTest, pyaedt_unittest_check_desktop_error
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 
 class TestClass(BasisTest):

--- a/_unittest/test_05_Mesh.py
+++ b/_unittest/test_05_Mesh.py
@@ -1,17 +1,16 @@
-import os
-
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
-
 # Setup paths for module imports
-from _unittest.conftest import scratch_path
 import gc
 
 # Import required modules
 from pyaedt import Hfss, Maxwell3d
 from pyaedt.generic.filesystem import Scratch
+
+from _unittest.conftest import scratch_path
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 test_project_name = "coax_HFSS"
 

--- a/_unittest/test_06_MessageManager.py
+++ b/_unittest/test_06_MessageManager.py
@@ -1,21 +1,18 @@
+# Setup paths for module imports
+import gc
+import logging
+
+from pyaedt.application.MessageManager import AEDTMessageManager
+from pyaedt.generic.filesystem import Scratch
+from pyaedt.hfss import Hfss
+
+# Import required modules
+from _unittest.conftest import config, scratch_path
+
 try:
     import pytest
 except ImportError:
     import _unittest_ironpython.conf_unittest as pytest
-
-# Setup paths for module imports
-import gc
-import math
-import os
-
-# Import required modules
-from _unittest.conftest import local_path, scratch_path, config
-from pyaedt.hfss import Hfss
-from pyaedt.application.MessageManager import AEDTMessageManager
-from pyaedt.application.Variables import Variable
-from pyaedt.generic.filesystem import Scratch
-
-import logging
 
 LOGGER = logging.getLogger(__name__)
 

--- a/_unittest/test_07_Object3D.py
+++ b/_unittest/test_07_Object3D.py
@@ -1,16 +1,15 @@
 # standard imports
-import os
+import gc
 import math
-
-from _unittest.conftest import local_path, scratch_path
+import os
 
 # Import required modules
 from pyaedt import Hfss
 from pyaedt.generic.filesystem import Scratch
-from pyaedt.generic.general_methods import time_fn, isclose
-from pyaedt.modeler.Object3d import _to_boolean, FacePrimitive, EdgeTypePrimitive, Object3d, _uname
+from pyaedt.generic.general_methods import isclose, time_fn
+from pyaedt.modeler.Object3d import FacePrimitive, _to_boolean, _uname
 
-import gc
+from _unittest.conftest import scratch_path
 
 
 class TestClass:

--- a/_unittest/test_09_Primitives2D.py
+++ b/_unittest/test_09_Primitives2D.py
@@ -1,21 +1,15 @@
 #!/ekm/software/anaconda3/bin/python
-
-import os
-
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
-
-# Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path, BasisTest, pyaedt_unittest_check_desktop_error
-
-
 # Import required modules
 from pyaedt import Maxwell2d
-from pyaedt.generic.filesystem import Scratch
 from pyaedt.modeler.Primitives import Polyline
-import gc
+
+# Setup paths for module imports
+from _unittest.conftest import BasisTest, pyaedt_unittest_check_desktop_error
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 
 class TestClass(BasisTest):

--- a/_unittest/test_09_VariableManager.py
+++ b/_unittest/test_09_VariableManager.py
@@ -1,18 +1,19 @@
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
-
 # Setup paths for module imports
 import gc
 import math
 
-# Import required modules
-from _unittest.conftest import local_path, scratch_path
-from pyaedt.hfss import Hfss
 from pyaedt.application.Variables import Variable
 from pyaedt.generic.filesystem import Scratch
 from pyaedt.generic.general_methods import isclose
+from pyaedt.hfss import Hfss
+
+# Import required modules
+from _unittest.conftest import scratch_path
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 
 class TestClass:

--- a/_unittest/test_3dlayout_modeler.py
+++ b/_unittest/test_3dlayout_modeler.py
@@ -1,18 +1,18 @@
+import gc
 import os
 import time
-
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
-
-# Setup paths for module imports
-from _unittest.conftest import scratch_path
-import gc
 
 # Import required modules
 from pyaedt import Hfss3dLayout
 from pyaedt.generic.filesystem import Scratch
+
+# Setup paths for module imports
+from _unittest.conftest import scratch_path
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 # Input Data and version for the test
 

--- a/_unittest/test_Circuit.py
+++ b/_unittest/test_Circuit.py
@@ -1,19 +1,19 @@
-import os
-
-# Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path, config
 import gc
-
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
+import os
 import time
 
 # Import required modules
 from pyaedt import Circuit
 from pyaedt.generic.filesystem import Scratch
-from pyaedt.generic.TouchstoneParser import read_touchstone
+
+# Setup paths for module imports
+from _unittest.conftest import local_path, scratch_path
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
+
 
 test_project_name = "Galileo"
 netlist1 = "netlist_small.cir"

--- a/_unittest/test_GeometryOperators.py
+++ b/_unittest/test_GeometryOperators.py
@@ -1,16 +1,17 @@
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
 import math
-from pyaedt.modeler.GeometryOperators import GeometryOperators as go
+
 import clr
+from pyaedt.modeler.GeometryOperators import GeometryOperators as go
 
 clr.AddReference("System.Collections")
-from System.Collections.Generic import List
+from pyaedt.modeler.modeler_constants import CoordinateSystemAxis, CoordinateSystemPlane, SweepDraftType
 from System import Double
-from pyaedt.modeler.modeler_constants import CoordinateSystemPlane, CoordinateSystemAxis, SweepDraftType
+from System.Collections.Generic import List
 
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 tol = 1e-12
 

--- a/_unittest/test_Icepak.py
+++ b/_unittest/test_Icepak.py
@@ -1,19 +1,19 @@
 # standard imports
+import gc
 import os
 import time
-
-# Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path, config
 
 # Import required modules
 from pyaedt import Icepak
 from pyaedt.generic.filesystem import Scratch
-import gc
+
+# Setup paths for module imports
+from _unittest.conftest import local_path, scratch_path
 
 try:
-    import pytest
+    import pytest  # noqa: F401
 except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 # Access the desktop
 

--- a/_unittest/test_Materials.py
+++ b/_unittest/test_Materials.py
@@ -1,20 +1,19 @@
 # standard imports
-import os
 import gc
-
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
-
-# Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path, desktop_version, new_thread, non_graphical
+import os
 
 # Import required modules
 from pyaedt import Hfss, Icepak
 from pyaedt.generic.filesystem import Scratch
-
 from pyaedt.modules.Material import MatProperties, SurfMatProperties
+
+# Setup paths for module imports
+from _unittest.conftest import desktop_version, local_path, new_thread, non_graphical, scratch_path
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 
 class TestClass:

--- a/_unittest/test_Maxwell2D.py
+++ b/_unittest/test_Maxwell2D.py
@@ -1,20 +1,14 @@
 #!/ekm/software/anaconda3/bin/python
 
-import os
-
-try:
-    import pytest
-except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
-# Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path, BasisTest, pyaedt_unittest_check_desktop_error
-
-
 # Import required modules
 from pyaedt import Maxwell2d
-from pyaedt.generic.filesystem import Scratch
-from pyaedt.modeler.Primitives import Polyline
-import gc
+
+from _unittest.conftest import BasisTest, pyaedt_unittest_check_desktop_error
+
+try:
+    import pytest  # noqa: F401
+except ImportError:
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 
 class TestClass(BasisTest):

--- a/_unittest/test_PostProcessing.py
+++ b/_unittest/test_PostProcessing.py
@@ -1,29 +1,28 @@
 # standard imports
+import gc
 import os
-import sys
+
+# Import required modules
+from pyaedt import Hfss, is_ironpython
+from pyaedt.generic.filesystem import Scratch
+
+# Setup paths for module imports
+from _unittest.conftest import config, local_path, scratch_path
 
 try:
     import pytest
 except ImportError:
     import _unittest_ironpython.conf_unittest as pytest
-# Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path, config
-
-# Import required modules
-from pyaedt import is_ironpython
-from pyaedt import Hfss
-from pyaedt.generic.filesystem import Scratch
-import gc
-
-test_project_name = "coax_setup_solved"
-test_field_name = "Potter_Horn"
 
 try:
-    from IPython.display import Image, display
+    from IPython.display import Image
 
     ipython_available = True
 except ImportError:
     ipython_available = False
+
+test_project_name = "coax_setup_solved"
+test_field_name = "Potter_Horn"
 
 
 class TestClass:

--- a/_unittest/test_SBR.py
+++ b/_unittest/test_SBR.py
@@ -1,17 +1,17 @@
-import os
-
-# Setup paths for module imports
-from _unittest.conftest import scratch_path, local_path
 import gc
+import os
 
 # Import required modules
 from pyaedt import Hfss
 from pyaedt.generic.filesystem import Scratch
 
+# Setup paths for module imports
+from _unittest.conftest import local_path, scratch_path
+
 try:
-    import pytest
+    import pytest  # noqa: F401
 except ImportError:
-    import _unittest_ironpython.conf_unittest as pytest
+    import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
 test_project_name = "Cassegrain"
 

--- a/_unittest/test_downloads.py
+++ b/_unittest/test_downloads.py
@@ -1,13 +1,8 @@
 # standard imports
-import os
-
-# Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path
+import gc
 
 # Import required modules
 from pyaedt.examples import downloads
-from pyaedt.generic.filesystem import Scratch
-import gc
 
 
 class TestClass:

--- a/_unittest/test_emit.py
+++ b/_unittest/test_emit.py
@@ -1,11 +1,11 @@
 # Setup paths for module imports
-from _unittest.conftest import local_path, scratch_path
+import gc
 
 # Import required modules
 from pyaedt import Emit
 from pyaedt.generic.filesystem import Scratch
-import gc
-import os
+
+from _unittest.conftest import scratch_path
 
 
 class TestClass:

--- a/_unittest_ironpython/run_unittests.py
+++ b/_unittest_ironpython/run_unittests.py
@@ -1,8 +1,7 @@
-import unittest
 import os
 import sys
+import unittest
 from datetime import datetime
-import time
 
 sys.path.append(os.path.join(os.environ["ANSYSEM_ROOT211"], "PythonFiles", "DesktopPlugin"))
 path_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "..")

--- a/_unittest_ironpython/run_unittests_batchmode.cmd
+++ b/_unittest_ironpython/run_unittests_batchmode.cmd
@@ -1,2 +1,2 @@
 set ANSYSEM_FEATURE_SF6694_NON_GRAPHICAL_COMMAND_EXECUTION_ENABLE=1
-"C:\Program Files\AnsysEM\AnsysEM21.1\Win64\ansysedt.exe" -ng -RunScriptAndExit "_unittest_ironpython\run_unittests.py"
+"D:\EBUInstallation\AnsysEM21.1\Win64\ansysedt.exe" -ng -RunScriptAndExit "_unittest_ironpython\run_unittests.py"

--- a/_unittest_ironpython/run_unittests_batchmode.cmd
+++ b/_unittest_ironpython/run_unittests_batchmode.cmd
@@ -1,2 +1,2 @@
 set ANSYSEM_FEATURE_SF6694_NON_GRAPHICAL_COMMAND_EXECUTION_ENABLE=1
-"D:\EBUInstallation\AnsysEM21.1\Win64\ansysedt.exe" -ng -RunScriptAndExit "_unittest_ironpython\run_unittests.py"
+"C:\Program Files\AnsysEM\AnsysEM21.1\Win64\ansysedt.exe" -ng -RunScriptAndExit "_unittest_ironpython\run_unittests.py"

--- a/_unittest_ironpython/test_00EDB.py
+++ b/_unittest_ironpython/test_00EDB.py
@@ -1,6 +1,6 @@
-from conf_unittest import test_generator, PytestMockup
 import os
-import time
+
+from conf_unittest import PytestMockup, test_generator
 
 test_filter = "test_"
 

--- a/examples/00-basic-examples/Create_Netlist.py
+++ b/examples/00-basic-examples/Create_Netlist.py
@@ -6,7 +6,6 @@ Netlist Example Analysis
 # partially, Mentor.
 """
 
-import sys
 import os
 
 ###############################################################################

--- a/examples/00-basic-examples/Polyline_Primitives.py
+++ b/examples/00-basic-examples/Polyline_Primitives.py
@@ -11,7 +11,7 @@ This example shows how you can use PyAEDT to create and manipulate polylines.
 
 import os
 from pyaedt.maxwell import Maxwell3d
-from pyaedt.modeler.Primitives import Polyline, PolylineSegment
+from pyaedt.modeler.Primitives import PolylineSegment
 
 ###############################################################################
 # Create a Maxwell 3D Object and Set the Unit Type

--- a/examples/00-basic-examples/SBR_Doppler_Example.py
+++ b/examples/00-basic-examples/SBR_Doppler_Example.py
@@ -11,8 +11,7 @@ This example shows how you can use PyAEDT to create a Multipart Scenario in SBR+
 # This examples launches AEDT 2021.1 in graphical mode.
 import os
 import pyaedt
-import sys
-from pyaedt import examples, generate_unique_name, Hfss
+from pyaedt import examples, generate_unique_name
 
 # Start Electronics Desktop
 aedt_version = "2021.1"

--- a/examples/01-advanced-postprocessing/Advanced_Far_Field.py
+++ b/examples/01-advanced-postprocessing/Advanced_Far_Field.py
@@ -36,8 +36,6 @@ from pyaedt import Hfss
 import numpy as np
 import matplotlib.pyplot as plt
 import math
-import ipywidgets as widgets
-from ipywidgets import interact, interact_manual
 
 ###############################################################################
 # Launch AEDT in Non-Graphical Mode

--- a/examples/01-advanced-postprocessing/Touchstone_Management.py
+++ b/examples/01-advanced-postprocessing/Touchstone_Management.py
@@ -9,11 +9,9 @@ must be installed on the machine.
 This example runs only on Windows using CPython.
 """
 
-import sys
 import os
 import pathlib
-import shutil
-import time
+import sys
 
 local_path = os.path.abspath("")
 module_path = pathlib.Path(local_path)
@@ -30,9 +28,9 @@ example_path = examples.download_touchstone()
 
 ###############################################################################
 
-from pyaedt.generic.TouchstoneParser import *
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+from pyaedt.generic.TouchstoneParser import *
 
 ###############################################################################
 


### PR DESCRIPTION
Final refactor to unit test files to conform to unused module import policy. In the case when modules absolutely need to be imported but unused, the comment ` # noqa: F401 ` can be added at the end of that line to make it exempt from the policy. This is used in several places due to the need to import pytest in some cases for Iron Python.

The flake8 configuration is also updated to have this policy checked in the CI.

The style check CI for this PR will not pass until #448 is merged.