### PR TITLE
Refactored Hfss  and HfssedLayout sweep creation

### DIFF
--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -30,8 +30,7 @@ if is_ironpython:
 else:
     import pytest
 
-    if "UNITTEST_CURRENT_TEST" in os.environ:
-        os.environ.pop("UNITTEST_CURRENT_TEST")
+os.environ["PYAEDT_ERROR_HANDLER"] = "False"
 
 local_path = os.path.dirname(os.path.realpath(__file__))
 

--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -139,7 +139,7 @@ class TestClass:
             num_of_freq_points=1234,
             sweeptype="Fast",
         )
-        assert self.aedtapp.create_single_point_sweep("MySetup")
+        assert self.aedtapp.create_single_point_sweep(setupname="MySetup", freq=1, unit='GHz')
 
     def test_06B_setup_exists(self):
         assert self.aedtapp.analysis_setup is not None

--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -132,6 +132,15 @@ class TestClass:
         )
         assert self.aedtapp.create_linear_count_sweep(
             setupname="MySetup",
+            sweepname="MySweep",
+            unit="MHz",
+            freqstart=1.1e3,
+            freqstop=1200.1,
+            num_of_freq_points=1234,
+            sweep_type="Interpolating",
+        )
+        assert self.aedtapp.create_linear_count_sweep(
+            setupname="MySetup",
             sweepname="MySweepFast",
             unit="MHz",
             freqstart=1.1e3,
@@ -219,13 +228,15 @@ class TestClass:
             freq=[1.1e1, 1.2e1, 1.3e1],
             save_single_field=[True, False, True]
         )
-        with pytest.raises(AttributeError):
-            self.aedtapp.create_single_point_sweep(
+
+        os.environ["PYAEDT_ERROR_HANDLER"] = "True"
+        assert not self.aedtapp.create_single_point_sweep(
                 setupname="MySetup",
                 unit='GHz',
                 freq=[1, 2e2, 3.4],
                 save_single_field=[True, False]
             )
+        os.environ["PYAEDT_ERROR_HANDLER"] = "False"
 
     def test_06z_validate_setup(self):
         list, ok = self.aedtapp.validate_full_design(ports=5)

--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -113,39 +113,32 @@ class TestClass:
         assert ports[0].name in [i.name for i in self.aedtapp.boundaries]
         pass
 
-    def test_06a_create_sweep(self):
+    def test_06a_create_linear_count_sweep(self):
         setup = self.aedtapp.create_setup("MySetup")
         setup.props["Frequency"] = "1GHz"
         setup.props["BasisOrder"] = 2
         setup.props["MaximumPasses"] = 1
         assert setup.update()
-        assert self.aedtapp.create_frequency_sweep("MySetup", "GHz", 0.8, 1.2)
-        assert self.aedtapp.create_frequency_sweep("MySetup", "GHz", 0.8, 1.2)
-        assert self.aedtapp.create_frequency_sweep(
+        assert self.aedtapp.create_linear_count_sweep("MySetup", "GHz", 0.8, 1.2, 401)
+        assert self.aedtapp.create_linear_count_sweep("MySetup", "GHz", 0.8, 1.2, 401)
+        assert self.aedtapp.create_linear_count_sweep(
             setupname="MySetup",
             sweepname="MySweep",
             unit="MHz",
             freqstart=1.1e3,
             freqstop=1200.1,
             num_of_freq_points=1234,
-            sweeptype="Interpolating",
+            sweep_type="Interpolating",
         )
-        assert self.aedtapp.create_frequency_sweep(
+        assert self.aedtapp.create_linear_count_sweep(
             setupname="MySetup",
             sweepname="MySweepFast",
             unit="MHz",
             freqstart=1.1e3,
             freqstop=1200.1,
             num_of_freq_points=1234,
-            sweeptype="Fast",
+            sweep_type="Fast",
         )
-        assert self.aedtapp.create_single_point_sweep(setupname="MySetup", freq=1, unit='GHz')
-
-    def test_06B_setup_exists(self):
-        assert self.aedtapp.analysis_setup is not None
-        assert self.aedtapp.nominal_sweep is not None
-
-    def test_06b_create_linear_count_sweep(self):
         num_points = 1752
         freq_start = 1.1e3
         freq_stop = 1200.1
@@ -161,6 +154,11 @@ class TestClass:
         assert sweep.props["RangeCount"] == num_points
         assert sweep.props["RangeStart"] == str(freq_start) + units
         assert sweep.props["RangeEnd"] == str(freq_stop) + units
+        assert sweep.props["Type"] == "Discrete"
+
+    def test_06b_setup_exists(self):
+        assert self.aedtapp.analysis_setup is not None
+        assert self.aedtapp.nominal_sweep is not None
 
     def test_06c_create_linear_step_sweep(self):
         step_size = 153.8
@@ -178,6 +176,56 @@ class TestClass:
         assert sweep.props["RangeStep"] == str(step_size) + units
         assert sweep.props["RangeStart"] == str(freq_start) + units
         assert sweep.props["RangeEnd"] == str(freq_stop) + units
+        assert sweep.props["Type"] == "Discrete"
+
+        step_size = 53.8
+        freq_start = 1.2e3
+        freq_stop = 1305.1
+        units = "MHz"
+        sweep = self.aedtapp.create_linear_step_sweep(
+            setupname="MySetup",
+            sweepname="StepFast",
+            unit=units,
+            freqstart=freq_start,
+            freqstop=freq_stop,
+            step_size=step_size,
+            sweep_type="Fast"
+        )
+        assert sweep.props["RangeStep"] == str(step_size) + units
+        assert sweep.props["RangeStart"] == str(freq_start) + units
+        assert sweep.props["RangeEnd"] == str(freq_stop) + units
+        assert sweep.props["Type"] == "Fast"
+
+    def test_06d_create_single_point_sweep(self):
+        assert self.aedtapp.create_single_point_sweep(
+            setupname="MySetup",
+            unit='MHz',
+            freq=1.2e3,
+        )
+        assert self.aedtapp.create_single_point_sweep(
+            setupname="MySetup",
+            unit='GHz',
+            freq=1.2,
+            save_single_field=False,
+        )
+        assert self.aedtapp.create_single_point_sweep(
+            setupname="MySetup",
+            unit='GHz',
+            freq=[1.1, 1.2, 1.3],
+        )
+        assert self.aedtapp.create_single_point_sweep(
+            setupname="MySetup",
+            unit='GHz',
+            freq=[1.1e1, 1.2e1, 1.3e1],
+            save_single_field=[True, False, True]
+        )
+        with pytest.raises(AttributeError):
+            self.aedtapp.create_single_point_sweep(
+                setupname="MySetup",
+                unit='GHz',
+                freq=[1, 2e2, 3.4],
+                save_single_field=[True, False]
+            )
 
     def test_06z_validate_setup(self):
         list, ok = self.aedtapp.validate_full_design(ports=5)

--- a/_unittest/test_24_3dlayout_modeler.py
+++ b/_unittest/test_24_3dlayout_modeler.py
@@ -209,8 +209,13 @@ class TestClass:
         assert setup3.enable()
         sweep = setup3.add_sweep()
         assert sweep
-        assert sweep.change_range("LinearStep", "1Hz", "1GHz", "100MHz")
-        assert sweep.add_subrange("LinearCount", "1GHz", "1.5GHz", 21)
+        assert sweep.change_range("LinearStep", 1.1, 2.1, 0.4, "GHz")
+        assert sweep.add_subrange("LinearCount", 1, 1.5, 3, "MHz")
+        assert sweep.change_type("Discrete")
+        assert sweep.add_subrange("SinglePoint", 10.1e-1, "GHz")
+        assert sweep.add_subrange("SinglePoint", 10.2e-1, "GHz")
+        assert sweep.set_save_fields(True, True)
+        assert sweep.set_save_fields(False, False)
 
     def test_17_get_setup(self):
         setup4 = self.aedtapp.get_setup(self.aedtapp.existing_analysis_setups[0])
@@ -220,30 +225,30 @@ class TestClass:
         assert setup4.disable()
         assert setup4.enable()
 
-    def test_18_add_sweep(self):
+    def test_18a_create_linear_count_sweep(self):
         setup_name = "RFBoardSetup"
-        sweep1 = self.aedtapp.create_frequency_sweep(
+        sweep1 = self.aedtapp.create_linear_count_sweep(
             setupname=setup_name,
             unit="GHz",
             freqstart=1,
             freqstop=10,
             num_of_freq_points=1001,
             sweepname="RFBoardSweep1",
-            sweeptype="interpolating",
+            sweep_type="Interpolating",
             interpolation_tol_percent=0.2,
             interpolation_max_solutions=111,
             save_fields=False,
             use_q3d_for_dc=False,
         )
         assert sweep1.props["Sweeps"]["Data"] == "LINC 1GHz 10GHz 1001"
-        sweep2 = self.aedtapp.create_frequency_sweep(
+        sweep2 = self.aedtapp.create_linear_count_sweep(
             setupname=setup_name,
             unit="GHz",
             freqstart=1,
             freqstop=10,
             num_of_freq_points=12,
             sweepname="RFBoardSweep2",
-            sweeptype="discrete",
+            sweep_type="Discrete",
             interpolation_tol_percent=0.4,
             interpolation_max_solutions=255,
             save_fields=True,
@@ -251,6 +256,54 @@ class TestClass:
             use_q3d_for_dc=True,
         )
         assert sweep2.props["Sweeps"]["Data"] == "LINC 1GHz 10GHz 12"
+
+    def test_18b_create_linear_step_sweep(self):
+        setup_name = "RFBoardSetup"
+        sweep3 = self.aedtapp.create_linear_step_sweep(
+            setupname=setup_name,
+            unit="GHz",
+            freqstart=1,
+            freqstop=10,
+            step_size=0.2,
+            sweepname="RFBoardSweep3",
+            sweep_type="Interpolating",
+            interpolation_tol_percent=0.4,
+            interpolation_max_solutions=255,
+            save_fields=True,
+            save_rad_fields_only=True,
+            use_q3d_for_dc=True,
+        )
+        assert sweep3.props["Sweeps"]["Data"] == "LIN 1GHz 10GHz 0.2GHz"
+        sweep4 = self.aedtapp.create_linear_step_sweep(
+            setupname=setup_name,
+            unit="GHz",
+            freqstart=1,
+            freqstop=10,
+            step_size=0.12,
+            sweepname="RFBoardSweep4",
+            sweep_type="Discrete",
+            save_fields=True,
+        )
+        assert sweep4.props["Sweeps"]["Data"] == "LIN 1GHz 10GHz 0.12GHz"
+
+    def test_18c_create_single_point_sweep(self):
+        setup_name = "RFBoardSetup"
+        sweep5 = self.aedtapp.create_single_point_sweep(
+            setupname=setup_name,
+            unit="GHz",
+            freq=1.23,
+            sweepname="RFBoardSingle",
+            save_fields=True,
+        )
+        assert sweep5.props["Sweeps"]["Data"] == "1.23GHz"
+        sweep6 = self.aedtapp.create_single_point_sweep(
+            setupname=setup_name,
+            unit="GHz",
+            freq=[1, 2, 3, 4],
+            sweepname="RFBoardSingle",
+            save_fields=False,
+        )
+        assert sweep6.props["Sweeps"]["Data"] == '1GHz 2GHz 3GHz 4GHz'
 
     def test_19A_validate(self):
         assert self.aedtapp.validate_full_design()

--- a/examples/00-basic-examples/HFSS3DLayout_Via.py
+++ b/examples/00-basic-examples/HFSS3DLayout_Via.py
@@ -71,14 +71,14 @@ h3d.create_edge_port("microstrip", 2)
 # This example create a setup and sweep.
 
 setup = h3d.create_setup()
-h3d.create_frequency_sweep(
+h3d.create_linear_count_sweep(
     setupname=setup.name,
     unit="GHz",
     freqstart=3,
     freqstop=7,
     num_of_freq_points=1001,
     sweepname="sweep1",
-    sweeptype="interpolating",
+    sweep_type="Interpolating",
     interpolation_tol_percent=1,
     interpolation_max_solutions=255,
     save_fields=False,

--- a/examples/01-advanced-postprocessing/Hfss_Icepak_Coupling.py
+++ b/examples/01-advanced-postprocessing/Hfss_Icepak_Coupling.py
@@ -161,7 +161,7 @@ setup.update()
 # ~~~~~~~~~~~~~~~~
 # A sweep is created with default values.
 
-sweepname = aedtapp.create_frequency_sweep("MySetup", "GHz", 0.8, 1.2)
+sweepname = aedtapp.create_linear_count_sweep("MySetup", "GHz", 0.8, 1.2, 401)
 
 ################################################################################
 # Create an Icepak Model

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -155,7 +155,6 @@ def aedt_exception_handler(func):
         else:
             return func(*args, **kwargs)
 
-
     return inner_function
 
 

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -112,10 +112,7 @@ def aedt_exception_handler(func):
 
     @wraps(func)
     def inner_function(*args, **kwargs):
-        if "PYTEST_CURRENT_TEST" in os.environ or "UNITTEST_CURRENT_TEST" in os.environ:
-            # We are running under pytest or unittest, do not use the decorator
-            return func(*args, **kwargs)
-        else:
+        if os.getenv("PYAEDT_ERROR_HANDLER", "True").lower() in ("true", "1", "t"):
             try:
                 return func(*args, **kwargs)
             except TypeError:
@@ -155,6 +152,9 @@ def aedt_exception_handler(func):
             except BaseException:
                 _exception(sys.exc_info(), func, args, kwargs, "General or AEDT Error")
                 return False
+        else:
+            return func(*args, **kwargs)
+
 
     return inner_function
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -452,87 +452,28 @@ class Hfss(FieldAnalysis3D, object):
     ):
         """Create a frequency sweep.
 
-        Parameters
-        ----------
-        setupname : str
-            Name of the setup that is attached to the sweep.
-        unit : str, optional
-            Unit of the frequency. For example, ``"MHz"`` or
-            ``"GHz"``. The default is ``"GHz"``.
-        freqstart : float, optional
-            Starting frequency of the sweep. The default is ``1e-3``.
-        freqstop : float, optional
-            Stopping frequency of the sweep. The default is ``10``.
-        sweepname : str, optional
-            Name of the sweep. The default is ``None``.
-        num_of_freq_points : int, optional
-            Number of frequency points in the range. The default is ``451``.
-        sweeptype : str, optional
-            Type of the sweep. Options are ``"Fast"``, ``"Interpolating"``,
-            and ``"Discrete"``. The default is ``"Interpolating"``.
-        interpolation_tol : float, optional
-            Error tolerance threshold for the interpolation
-            process. The default is ``0.5``.
-        interpolation_max_solutions : int, optional
-            Maximum number of solutions evaluated for the interpolation process. The default is
-            ``250``.
-        save_fields : bool, optional
-            Whether to save the fields. The default is ``True``.
-        save_rad_fields : bool, optional
-            Whether to save the radiating fields. The default is ``False``.
-
-        Returns
-        -------
-        :class:`pyaedt.modules.SetupTemplates.SweepHFSS`, :class:`pyaedt.modules.SetupTemplates.SweepQ3D`, or bool
-            Sweep object if successful, ``False`` otherwise.
-
-        Examples
-        --------
-
-        Create a setup named ``'FrequencySweepSetup'`` and use it in a
-        frequency sweep named ``'MySweepFast'``.
-
-        >>> setup = hfss.create_setup("FrequencySweepSetup")
-        >>> setup.props["Frequency"] = "1GHz"
-        >>> setup.props["BasisOrder"] = 2
-        >>> setup.props["MaximumPasses"] = 1
-        >>> frequency_sweep = hfss.create_frequency_sweep(setupname="FrequencySweepSetup", sweepname="MySweepFast",
-        ...                                               unit="MHz", freqstart=1.1e3, freqstop=1200.1,
-        ...                                               num_of_freq_points=1234, sweeptype="Fast")
-        >>> type(frequency_sweep)
-        <class 'pyaedt.modules.SetupTemplates.SweepHFSS'>
+        .. deprecated:: 0.4.0
+           Use :func:`Hfss.create_linear_count_sweep` instead.
 
         """
+        warnings.warn(
+            "`create_frequency_sweep` is deprecated. Use `create_linear_count_sweep` instead.",
+            DeprecationWarning,
+        )
 
-        if sweepname is None:
-            sweepname = generate_unique_name("Sweep")
-
-        if setupname not in self.setup_names:
-            return False
-        for i in self.setups:
-            if i.name == setupname:
-                setupdata = i
-                for sw in setupdata.sweeps:
-                    if sweepname == sw.name:
-                        self._messenger.add_warning_message(
-                            "Sweep {} is already present. Rename and retry.".format(sweepname)
-                        )
-                        return False
-                sweepdata = setupdata.add_sweep(sweepname, sweeptype)
-                sweepdata.props["RangeStart"] = str(freqstart) + unit
-                sweepdata.props["RangeEnd"] = str(freqstop) + unit
-                sweepdata.props["RangeCount"] = num_of_freq_points
-                sweepdata.props["Type"] = sweeptype
-                if sweeptype == "Interpolating":
-                    sweepdata.props["InterpTolerance"] = interpolation_tol
-                    sweepdata.props["InterpMaxSolns"] = interpolation_max_solutions
-                    sweepdata.props["InterpMinSolns"] = 0
-                    sweepdata.props["InterpMinSubranges"] = 1
-                sweepdata.props["SaveFields"] = save_fields
-                sweepdata.props["SaveRadFields"] = save_rad_fields
-                sweepdata.update()
-                return sweepdata
-        return False
+        return self.create_linear_count_sweep(
+                setupname=setupname,
+                unit=unit,
+                freqstart=freqstart,
+                freqstop=freqstop,
+                num_of_freq_points=num_of_freq_points,
+                sweepname=sweepname,
+                save_fields=save_fields,
+                save_rad_fields=save_rad_fields,
+                sweep_type=sweeptype,
+                interpolation_tol=interpolation_tol,
+                interpolation_max_solutions=interpolation_max_solutions,
+        )
 
     @aedt_exception_handler
     def create_linear_count_sweep(
@@ -546,6 +487,8 @@ class Hfss(FieldAnalysis3D, object):
         save_fields=True,
         save_rad_fields=False,
         sweep_type="Discrete",
+        interpolation_tol=0.5,
+        interpolation_max_solutions=250,
     ):
         """Create a discrete sweep with the specified number of points.
 
@@ -554,7 +497,7 @@ class Hfss(FieldAnalysis3D, object):
         setupname : str
             Name of the setup.
         unit : str
-            Unit of the frequency. For example, ``"MHz`` or ``"GHz"``. The default is ``"GHz"``.
+            Unit of the frequency. For example, ``"MHz`` or ``"GHz"``.
         freqstart : float
             Starting frequency of the sweep, such as ``1``.
         freqstop : float
@@ -567,7 +510,15 @@ class Hfss(FieldAnalysis3D, object):
             Whether to save the fields. The default is ``True``.
         save_rad_fields : bool, optional
             Whether to save the radiating fields. The default is ``False``.
-        sweep_type: str, optional
+        sweep_type : str, optional
+            Type of the sweep. Options are ``"Fast"``, ``"Interpolating"``,
+            and ``"Discrete"``. The default is ``"Discrete"``.
+        interpolation_tol : float, optional
+            Error tolerance threshold for the interpolation
+            process. The default is ``0.5``.
+        interpolation_max_solutions : int, optional
+            Maximum number of solutions evaluated for the interpolation process.
+            The default is ``250``.
 
         Returns
         -------
@@ -592,19 +543,38 @@ class Hfss(FieldAnalysis3D, object):
         if sweep_type not in ["Discrete", "Interpolating", "Fast"]:
             self.add_error_message("Invalid in `sweep_type`. It has to either 'Discrete', 'Interpolating', or 'Fast'")
             return False
-        return self.create_frequency_sweep(
-            setupname,
-            unit,
-            freqstart,
-            freqstop,
-            sweepname,
-            num_of_freq_points,
-            sweep_type,
-            interpolation_tol=0.5,
-            interpolation_max_solutions=250,
-            save_fields=save_fields,
-            save_rad_fields=save_rad_fields,
-        )
+
+        if sweepname is None:
+            sweepname = generate_unique_name("Sweep")
+
+        if setupname not in self.setup_names:
+            return False
+        for i in self.setups:
+            if i.name == setupname:
+                setupdata = i
+                for sw in setupdata.sweeps:
+                    if sweepname == sw.name:
+                        self._messenger.add_warning_message(
+                            "Sweep {} is already present. Rename and retry.".format(sweepname)
+                        )
+                        return False
+                sweepdata = setupdata.add_sweep(sweepname, sweep_type)
+                sweepdata.props["RangeType"] = "LinearCount"
+                sweepdata.props["RangeStart"] = str(freqstart) + unit
+                sweepdata.props["RangeEnd"] = str(freqstop) + unit
+                sweepdata.props["RangeCount"] = num_of_freq_points
+                sweepdata.props["Type"] = sweep_type
+                if sweep_type == "Interpolating":
+                    sweepdata.props["InterpTolerance"] = interpolation_tol
+                    sweepdata.props["InterpMaxSolns"] = interpolation_max_solutions
+                    sweepdata.props["InterpMinSolns"] = 0
+                    sweepdata.props["InterpMinSubranges"] = 1
+                sweepdata.props["SaveFields"] = save_fields
+                sweepdata.props["SaveRadFields"] = save_rad_fields
+                sweepdata.update()
+                self.add_info_message("Linear count sweep {} has been correctly created".format(sweepname))
+                return sweepdata
+        return False
 
     @aedt_exception_handler
     def create_linear_step_sweep(
@@ -619,14 +589,14 @@ class Hfss(FieldAnalysis3D, object):
         save_rad_fields=False,
         sweep_type="Discrete",
     ):
-        """Create a Sweep with a specified number of points.
+        """Create a Sweep with a specified frequency step.
 
         Parameters
         ----------
         setupname : str
             Name of the setup.
         unit : str
-            Unit of the frequency. For example, ``"MHz`` or ``"GHz"``. The default is ``"GHz"``.
+            Unit of the frequency. For example, ``"MHz`` or ``"GHz"``.
         freqstart : float
             Starting frequency of the sweep.
         freqstop : float
@@ -680,6 +650,7 @@ class Hfss(FieldAnalysis3D, object):
                         )
                         return False
                 sweepdata = setupdata.add_sweep(sweepname, sweep_type)
+                sweepdata.props["RangeType"] = "LinearStep"
                 sweepdata.props["RangeStart"] = str(freqstart) + unit
                 sweepdata.props["RangeEnd"] = str(freqstop) + unit
                 sweepdata.props["RangeStep"] = str(step_size) + unit
@@ -687,13 +658,13 @@ class Hfss(FieldAnalysis3D, object):
                 sweepdata.props["SaveRadFields"] = save_rad_fields
                 sweepdata.props["ExtrapToDC"] = False
                 sweepdata.props["Type"] = sweep_type
-                sweepdata.props["RangeType"] = "LinearStep"
                 if sweep_type == "Interpolating":
                     sweepdata.props["InterpTolerance"] = 0.5
                     sweepdata.props["InterpMaxSolns"] = 250
                     sweepdata.props["InterpMinSolns"] = 0
                     sweepdata.props["InterpMinSubranges"] = 1
                 sweepdata.update()
+                self.add_info_message("Linear step sweep {} has been correctly created".format(sweepname))
                 return sweepdata
         return False
 
@@ -705,7 +676,7 @@ class Hfss(FieldAnalysis3D, object):
         freq,
         sweepname=None,
         save_single_field=True,
-        save_fields=True,
+        save_fields=False,
         save_rad_fields=False,
     ):
         """Create a Sweep with a single frequency point.
@@ -715,15 +686,16 @@ class Hfss(FieldAnalysis3D, object):
         setupname : str
             Name of the setup.
         unit : str
-            Unit of the frequency. For example, ``"MHz`` or ``"GHz"``. The default is ``"GHz"``.
-        freq : float
-            Frequency of the single point.
+            Unit of the frequency. For example, ``"MHz`` or ``"GHz"``.
+        freq : float, list
+            Frequency of the single point or list of frequencies to create distinct single points.
         sweepname : str, optional
             Name of the sweep. The default is ``None``.
-        save_single_field : bool, optional
+        save_single_field : bool, list, optional
             Whether to save the fields of the single point. The default is ``True``.
+            If a list is specified, the length must be the same as freq length.
         save_fields : bool, optional
-            Whether to save the fields for all points and subranges defined in the sweep. The default is ``True``.
+            Whether to save the fields for all points and subranges defined in the sweep. The default is ``False``.
         save_rad_fields : bool, optional
             Whether to save only the radiating fields. The default is ``False``.
 
@@ -749,6 +721,27 @@ class Hfss(FieldAnalysis3D, object):
         if sweepname is None:
             sweepname = generate_unique_name("SinglePoint")
 
+        if isinstance(save_single_field, list):
+            if not isinstance(freq, list) or len(save_single_field) != len(freq):
+                raise AttributeError("The length of save_single_field must be the same as freq length.")
+
+        add_subranges = False
+        if isinstance(freq, list):
+            if not freq:
+                raise AttributeError("Frequency list is empty! Specify at least one frequency point.")
+            freq0 = freq.pop(0)
+            if freq:
+                add_subranges = True
+        else:
+            freq0 = freq
+
+        if isinstance(save_single_field, list):
+            save0 = save_single_field.pop(0)
+        else:
+            save0 = save_single_field
+            if add_subranges:
+                save_single_field = [save0] * len(freq)
+
         if setupname not in self.setup_names:
             return False
         for i in self.setups:
@@ -762,13 +755,17 @@ class Hfss(FieldAnalysis3D, object):
                         return False
                 sweepdata = setupdata.add_sweep(sweepname, "Discrete")
                 sweepdata.props["RangeType"] = "SinglePoints"
-                sweepdata.props["RangeStart"] = str(freq) + unit
-                sweepdata.props["RangeEnd"] = str(freq) + unit
-                sweepdata.props["SaveSingleField"] = save_single_field
+                sweepdata.props["RangeStart"] = str(freq0) + unit
+                sweepdata.props["RangeEnd"] = str(freq0) + unit
+                sweepdata.props["SaveSingleField"] = save0
                 sweepdata.props["SaveFields"] = save_fields
                 sweepdata.props["SaveRadFields"] = save_rad_fields
                 sweepdata.props["SMatrixOnlySolveMode"] = "Auto"
+                if add_subranges:
+                    for f, s in zip(freq, save_single_field):
+                        sweepdata.add_subrange(rangetype="SinglePoints", start=f, unit=unit, save_single_fields=s)
                 sweepdata.update()
+                self.add_info_message("Single point sweep {} has been correctly created".format(sweepname))
                 return sweepdata
         return False
 
@@ -2415,7 +2412,7 @@ class Hfss(FieldAnalysis3D, object):
         """
 
         warnings.warn(
-            "`assig_voltage_source_to_sheet is deprecated`. Use `assign_voltage_source_to_sheet` instead.",
+            "`assig_voltage_source_to_sheet` is deprecated. Use `assign_voltage_source_to_sheet` instead.",
             DeprecationWarning,
         )
         self.assign_voltage_source_to_sheet(sheet_name, axisdir=0, sourcename=None)

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -813,7 +813,6 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
                 return sweep
         return False
 
-
     @aedt_exception_handler
     def create_single_point_sweep(
         self,

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import os
+import warnings
 
 from .application.Analysis3DLayout import FieldAnalysis3DLayout
 from .desktop import exception_to_desktop
@@ -591,6 +592,55 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
     ):
         """Create a frequency sweep.
 
+        .. deprecated:: 0.4.0
+           Use :func:`Hfss3dLayout.create_linear_count_sweep` instead.
+
+        """
+
+        warnings.warn(
+            "`create_frequency_sweep` is deprecated. Use `create_linear_count_sweep` instead.",
+            DeprecationWarning,
+        )
+        if sweeptype == "interpolating":
+            sweeptype = "Interpolating"
+        elif sweeptype == 'discrete':
+            sweeptype = "Discrete"
+        elif sweeptype == 'fast':
+            sweeptype = "Fast"
+
+        return self.create_linear_count_sweep(
+                setupname=setupname,
+                unit=unit,
+                freqstart=freqstart,
+                freqstop=freqstop,
+                num_of_freq_points=num_of_freq_points,
+                sweepname=sweepname,
+                save_fields=save_fields,
+                save_rad_fields_only=save_rad_fields_only,
+                sweep_type=sweeptype,
+                interpolation_tol_percent=interpolation_tol_percent,
+                interpolation_max_solutions=interpolation_max_solutions,
+                use_q3d_for_dc=use_q3d_for_dc,
+        )
+
+    @aedt_exception_handler
+    def create_linear_count_sweep(
+        self,
+        setupname,
+        unit,
+        freqstart,
+        freqstop,
+        num_of_freq_points,
+        sweepname=None,
+        save_fields=True,
+        save_rad_fields_only=False,
+        sweep_type="Interpolating",
+        interpolation_tol_percent=0.5,
+        interpolation_max_solutions=250,
+        use_q3d_for_dc=False,
+    ):
+        """Create a sweep with the specified number of points.
+
         Parameters
         ----------
         setupname : str
@@ -605,7 +655,13 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
             Number of frequency points in the range.
         sweepname : str, optional
             Name of the sweep. The default is ``None``.
-        sweeptype : str, optional
+        save_fields : bool, optional
+            Whether to save the fields for a discrete sweep only. The
+            default is ``True``.
+        save_rad_fields_only : bool, optional
+            Whether to save only the radiated fields if
+            ``save_fields=True``. The default is ``False``.
+        sweep_type : str, optional
             Type of the sweep. Options are ``"Fast"``,
             ``"Interpolating"``, and ``"Discrete"``.  The default is
             ``"Interpolating"``.
@@ -615,46 +671,216 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         interpolation_max_solutions : int, optional
             Maximum number of solutions evaluated for the
             interpolation process. The default is ``250``.
+        use_q3d_for_dc : bool, optional
+            Whether to use Q3D to solve the DC point. The default is ``False``.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.SetupTemplates.SweepHFSS3DLayout` or bool
+            Sweep object if successful, ``False`` otherwise.
+
+        """
+        if sweep_type not in ["Discrete", "Interpolating", "Fast"]:
+            raise AttributeError("Invalid in `sweep_type`. It has to be either 'Discrete', 'Interpolating', or 'Fast'")
+        if sweepname is None:
+            sweepname = generate_unique_name("Sweep")
+
+        interpolation = False
+        if sweep_type == "Interpolating":
+            interpolation = True
+            save_fields = False
+
+        if not save_fields:
+            save_rad_fields_only = False
+
+        interpolation_tol = interpolation_tol_percent / 100.0
+
+        for s in self.setups:
+            if s.name == setupname:
+                setupdata = s
+                if sweepname in [sweep.name for sweep in setupdata.sweeps]:
+                    oldname = sweepname
+                    sweepname = generate_unique_name(oldname)
+                    self._messenger.add_warning_message(
+                        "Sweep {} is already present. Sweep has been renamed in {}.".format(oldname, sweepname)
+                    )
+                sweep = setupdata.add_sweep(sweepname=sweepname)
+                sweep.change_range("LinearCount", freqstart, freqstop, num_of_freq_points, unit)
+                sweep.props["GenerateSurfaceCurrent"] = save_fields
+                sweep.props["SaveRadFieldsOnly"] = save_rad_fields_only
+                sweep.props["FastSweep"] = interpolation
+                sweep.props["SAbsError"] = interpolation_tol
+                sweep.props["EnforcePassivity"] = interpolation
+                sweep.props["UseQ3DForDC"] = use_q3d_for_dc
+                sweep.props["MaxSolutions"] = interpolation_max_solutions
+                sweep.update()
+                self.add_info_message("Linear count sweep {} has been correctly created".format(sweepname))
+                return sweep
+        return False
+
+    @aedt_exception_handler
+    def create_linear_step_sweep(
+        self,
+        setupname,
+        unit,
+        freqstart,
+        freqstop,
+        step_size,
+        sweepname=None,
+        save_fields=True,
+        save_rad_fields_only=False,
+        sweep_type="Interpolating",
+        interpolation_tol_percent=0.5,
+        interpolation_max_solutions=250,
+        use_q3d_for_dc=False,
+    ):
+        """Create a sweep with the specified frequency step.
+
+        Parameters
+        ----------
+        setupname : str
+            Name of the setup to attach to the sweep.
+        unit : str
+            Unit of the frequency, such as ``"MHz"`` or ``"GHz"``.
+        freqstart : float
+            Starting frequency of the sweep.
+        freqstop : float
+            Stopping frequency of the sweep.
+        step_size : float
+            Frequency size of the step.
+        sweepname : str, optional
+            Name of the sweep. The default is ``None``.
         save_fields : bool, optional
             Whether to save the fields for a discrete sweep only. The
             default is ``True``.
         save_rad_fields_only : bool, optional
             Whether to save only the radiated fields if
             ``save_fields=True``. The default is ``False``.
+        sweep_type : str, optional
+            Type of the sweep. Options are ``"Fast"``,
+            ``"Interpolating"``, and ``"Discrete"``.  The default is
+            ``"Interpolating"``.
+        interpolation_tol_percent : float, optional
+            Error tolerance threshold for the interpolation
+            process. The default is ``0.5``.
+        interpolation_max_solutions : int, optional
+            Maximum number of solutions evaluated for the
+            interpolation process. The default is ``250``.
         use_q3d_for_dc : bool, optional
             Whether to use Q3D to solve the DC point. The default is ``False``.
 
         Returns
         -------
-        str
-            Name of the setup when successful, ``False`` otherwise.
+        :class:`pyaedt.modules.SetupTemplates.SweepHFSS3DLayout` or bool
+            Sweep object if successful, ``False`` otherwise.
 
         """
+        if sweep_type not in ["Discrete", "Interpolating", "Fast"]:
+            raise AttributeError("Invalid in `sweep_type`. It has to be either 'Discrete', 'Interpolating', or 'Fast'")
         if sweepname is None:
             sweepname = generate_unique_name("Sweep")
+
         interpolation = False
-        if sweeptype == "interpolating":
+        if sweep_type == "Interpolating":
             interpolation = True
             save_fields = False
 
         if not save_fields:
             save_rad_fields_only = False
-        interpolation_tol = interpolation_tol_percent / 100.0
-        setup = self.get_setup(setupname)
-        if sweepname in [name.name for name in setup.sweeps]:
-            sweepname = generate_unique_name(sweepname)
-        sweep = setup.add_sweep(sweepname=sweepname)
-        sweep.change_range("LinearCount", str(freqstart) + unit, str(freqstop) + unit, num_of_freq_points)
-        sweep.props["GenerateSurfaceCurrent"] = save_fields
-        sweep.props["SaveRadFieldsOnly"] = save_rad_fields_only
-        sweep.props["FastSweep"] = interpolation
-        sweep.props["SAbsError"] = interpolation_tol
-        sweep.props["EnforcePassivity"] = interpolation
-        sweep.props["UseQ3DForDC"] = use_q3d_for_dc
-        sweep.props["MaxSolutions"] = interpolation_max_solutions
-        sweep.update()
 
-        return sweep
+        interpolation_tol = interpolation_tol_percent / 100.0
+
+        for s in self.setups:
+            if s.name == setupname:
+                setupdata = s
+                if sweepname in [sweep.name for sweep in setupdata.sweeps]:
+                    oldname = sweepname
+                    sweepname = generate_unique_name(oldname)
+                    self._messenger.add_warning_message(
+                        "Sweep {} is already present. Sweep has been renamed in {}.".format(oldname, sweepname)
+                    )
+                sweep = setupdata.add_sweep(sweepname=sweepname)
+                sweep.change_range("LinearStep", freqstart, freqstop, step_size, unit)
+                sweep.props["GenerateSurfaceCurrent"] = save_fields
+                sweep.props["SaveRadFieldsOnly"] = save_rad_fields_only
+                sweep.props["FastSweep"] = interpolation
+                sweep.props["SAbsError"] = interpolation_tol
+                sweep.props["EnforcePassivity"] = interpolation
+                sweep.props["UseQ3DForDC"] = use_q3d_for_dc
+                sweep.props["MaxSolutions"] = interpolation_max_solutions
+                sweep.update()
+                self.add_info_message("Linear step sweep {} has been correctly created".format(sweepname))
+                return sweep
+        return False
+
+
+    @aedt_exception_handler
+    def create_single_point_sweep(
+        self,
+        setupname,
+        unit,
+        freq,
+        sweepname=None,
+        save_fields=False,
+        save_rad_fields_only=False,
+    ):
+        """Create a Sweep with a single frequency point.
+
+        Parameters
+        ----------
+        setupname : str
+            Name of the setup.
+        unit : str
+            Unit of the frequency. For example, ``"MHz`` or ``"GHz"``.
+        freq : float, list
+            Frequency of the single point or list of frequencies to create distinct single points.
+        sweepname : str, optional
+            Name of the sweep. The default is ``None``.
+        save_fields : bool, optional
+            Whether to save the fields for all points and subranges defined in the sweep. The default is ``False``.
+        save_rad_fields_only : bool, optional
+            Whether to save only the radiating fields. The default is ``False``.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.SetupTemplates.SweepHFSS` or bool
+            Sweep object if successful, ``False`` otherwise.
+        """
+        if sweepname is None:
+            sweepname = generate_unique_name("SinglePoint")
+
+        add_subranges = False
+        if isinstance(freq, list):
+            if not freq:
+                raise AttributeError("Frequency list is empty! Specify at least one frequency point.")
+            freq0 = freq.pop(0)
+            if freq:
+                add_subranges = True
+        else:
+            freq0 = freq
+
+        if setupname not in self.setup_names:
+            return False
+        for s in self.setups:
+            if s.name == setupname:
+                setupdata = s
+                if sweepname in [sweep.name for sweep in setupdata.sweeps]:
+                    oldname = sweepname
+                    sweepname = generate_unique_name(oldname)
+                    self._messenger.add_warning_message(
+                        "Sweep {} is already present. Sweep has been renamed in {}.".format(oldname, sweepname)
+                    )
+                sweepdata = setupdata.add_sweep(sweepname, "Discrete")
+                sweepdata.change_range("SinglePoint", freq0, unit)
+                sweepdata.props["GenerateSurfaceCurrent"] = save_fields
+                sweepdata.props["SaveRadFieldsOnly"] = save_rad_fields_only
+                sweepdata.update()
+                if add_subranges:
+                    for f in freq:
+                        sweepdata.add_subrange(rangetype="SinglePoint", start=f, unit=unit)
+                self.add_info_message("Single point sweep {} has been correctly created".format(sweepname))
+                return sweepdata
+        return False
 
     @aedt_exception_handler
     def import_gds(self, gds_path, aedb_path=None, xml_path=None, set_as_active=True, close_active_project=False):

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -1398,11 +1398,12 @@ class GeometryModeler(Modeler, object):
             excitation for each mode.
 
         """
-        list_names = []
-        if "GetExcitations" in dir(self._parent.oboundary):
+        try:
             list_names = list(self._parent.oboundary.GetExcitations())
             del list_names[1::2]
-        return list_names
+            return list_names
+        except:
+            return []
 
     @aedt_exception_handler
     def get_boundaries_name(self):

--- a/pyaedt/modules/SolveSetup.py
+++ b/pyaedt/modules/SolveSetup.py
@@ -1019,8 +1019,8 @@ class Setup3DLayout(object):
         sweepname : str, optional
             Name of the sweep. The default is ``None``.
         sweeptype : str, optional
-            Type of the sweep. Options are ``"Fast"``, ``"Interpolating"``, and
-            ``"Discrete"``. The default is ``"Interpolating"``.
+            Type of the sweep. Options are ``"Interpolating"`` and ``"Discrete"``.
+            The default is ``"Interpolating"``.
 
         Returns
         -------


### PR DESCRIPTION
- refactored hfss.create_single_point_sweep()
- created hfss.create_linear_step_sweep()
- made hfss.create_frequency_sweep() deprecated
- fixed hfss.create_linear_count_sweep()
- Fixed modeler.get_excitations_name()
- Fixed hfss sweep template
- Fixed sweep.add_subrange()
- created hfss3dlayout.create_single_point_sweep()
- created hfss3dlayout.create_linear_step_sweep()
- made hfss3dlayout.create_frequency_sweep() deprecated
- created hfss3dlayout.create_linear_count_sweep()
- If sweep name exists, does not exit and create a unique name.
- added SweepHFSS3DLayout.change_type
- added SweepHFSS3DLayout.set_save_fields
- Fixed added and improved unit tests
- Fixed example
- introduced PYAEDT_ERROR_HANDLER env variable
