### PR TITLE
Fixed minor grammar mistakes

### DIFF
--- a/doc/source/Resources/Code_Guidelines.rst
+++ b/doc/source/Resources/Code_Guidelines.rst
@@ -574,7 +574,7 @@ Duplicated Code
 Follow the DRY principle, which states that "Every piece of knowledge
 must have a single, unambiguous, authoritative representation within a
 system."  Attempt to follow this unless it overly complicates the code.
-For instance, the following example converts Fahrenheit to Celsius
+For instance, the following example converts Fahrenheit to Kelvin
 twice, which now requires the developer to maintain two separate lines
 that do the same thing.
 
@@ -586,7 +586,7 @@ that do the same thing.
    temp2 = 46
    new_temp_k = ((temp2 - 32) * (5 / 9)) + 273.15
 
-Instead, write a simple method that converts Fahrenheit to Celsius:
+Instead, write a simple method that converts Fahrenheit to Kelvin:
 
 .. code:: python
 

--- a/doc/source/Resources/Contributing.rst
+++ b/doc/source/Resources/Contributing.rst
@@ -203,7 +203,7 @@ This project has a branching model that enables rapid development of features wi
 Minor Release Steps
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Minor releases are feature and bug releases that improve the functionality and stability of PyAEDT. Before crfeating a minor release, do the following:
+Minor releases are feature and bug releases that improve the functionality and stability of PyAEDT. Before creating a minor release, do the following:
 
 1. Create a new branch from the ``main`` branch with name ``release/``MAJOR.MINOR (for example ``release/0.2``).
 


### PR DESCRIPTION
- Spelling mistake in "Contributing" section
- "Code Guidelines" section references a Fahrenheit to Kelvin function as Fahrenheit to Celsius 