### PR TITLE
add numpydoc parameter warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,16 +74,25 @@ numpydoc_show_class_members = False
 numpydoc_xref_param_type = True
 numpydoc_validate = True
 numpydoc_validation_checks = {
+
+    # general
     "GL06",  # Found unknown section
     "GL07",  # Sections are in the wrong order.
     "GL08",  # The object does not have a docstring
     "GL09",  # Deprecation warning should precede extended summary
     "GL10",  # reST directives {directives} must be followed by two colons
+
+    # Summary
     "SS01",  # No summary found
     "SS02",  # Summary does not start with a capital letter
     "SS03",  # Summary does not end with a period
     "SS04",  # Summary contains heading whitespaces
     "SS05",  # Summary must start with infinitive verb, not third person
+
+    # Parameters
+    "PR10",  # Parameter "{param_name}" requires a space before the colon '
+             #separating the parameter name and type",
+
 }
 
 numpydoc_validation_exclude = {  # set of regex

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -91,7 +91,7 @@ numpydoc_validation_checks = {
 
     # Parameters
     "PR10",  # Parameter "{param_name}" requires a space before the colon '
-             #separating the parameter name and type",
+             # separating the parameter name and type",
 
 }
 

--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -58,7 +58,7 @@ class Analysis(Design, object):
         Solution type to apply to the design.
     setup_name : str
         Name of the setup to use as the nominal.
-    specified_version: str
+    specified_version : str
         Version of AEDT  to use.
     NG : bool
         Whether to run AEDT in the non-graphical mode.

--- a/pyaedt/application/Analysis2D.py
+++ b/pyaedt/application/Analysis2D.py
@@ -32,7 +32,7 @@ class FieldAnalysis2D(Analysis):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT  to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional

--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -34,7 +34,7 @@ class FieldAnalysis3D(Analysis, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT  to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional

--- a/pyaedt/application/Analysis3DLayout.py
+++ b/pyaedt/application/Analysis3DLayout.py
@@ -32,7 +32,7 @@ class FieldAnalysis3DLayout(Analysis):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT  to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional

--- a/pyaedt/application/AnalysisIcepak.py
+++ b/pyaedt/application/AnalysisIcepak.py
@@ -35,7 +35,7 @@ class FieldAnalysisIcepak(Analysis, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT  to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -262,7 +262,7 @@ class DesignCache(object):
 
     Parameters
     ----------
-    parent: str
+    parent : str
         Name of the parent object.
 
     """
@@ -488,7 +488,7 @@ class Design(object):
     solution_type : str, optional
         Solution type to apply to the design. The default is
         ``None``, in which case the default type is applied.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
     NG : bool, optional
@@ -1265,7 +1265,9 @@ class Design(object):
     def set_license_type(self, license_type="Pool"):
         """Change the License Type between ``Pack`` and ``Pool``.
 
-        ..note: The command returns True even if the Key is wrong due to API limitation.
+        .. note::
+           The command returns ``True`` even if the Key is wrong due
+           to API limitation.
 
         Parameters
         ----------
@@ -1781,9 +1783,9 @@ class Design(object):
 
         Parameters
         ----------
-        close_projects: bool, optional
+        close_projects : bool, optional
             Whether to close all projects. The default is ``True``.
-        close_desktop: bool, optional
+        close_desktop : bool, optional
             Whether to close the desktop after releasing it. The default is ``True``.
 
         Returns

--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -315,17 +315,17 @@ class CSVDataset:
 
     Parameters
     ----------
-    csv_file: str, optional
+    csv_file : str, optional
         Input file consisting of delimited data with the first line as the header.
         The CSV value includes the header and data, which supports AEDT units information
         such as ``"1.23Wb"``. You can also augment the data with constant values.
-    separator: str, optional
+    separator : str, optional
         Value to use for the delimiter. The default is``None`` in which case a comma is
         assumed.
-    units_dict: dict, optional
+    units_dict : dict, optional
         Dictionary consisting of ``{Variable Name: unit}`` to rescale the data
         if it is not in the desired unit system.
-    append_dict: dict, optional
+    append_dict : dict, optional
         Dictionary consisting of ``{New Variable Name: value}`` to add variables
         with constant values to all data points. This dictionary is used to add
         multiple sweeps to one result file.

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -33,7 +33,7 @@ class Circuit(FieldAnalysisCircuit, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is  used.
         This parameter is ignored when Script is launched within AEDT.
@@ -823,22 +823,22 @@ class Circuit(FieldAnalysisCircuit, object):
             The default is ``None``.
         setupname : str, optional
             Name of the setup if it is a design. The default is ``None``.
-        is_solution_file: bool, optional
+        is_solution_file : bool, optional
             Whether it is an imported solution file. The default is ``False``.
-        filename: str, optional
+        filename : str, optional
             Full path and name for exporting the HSpice file. The default is ``None``.
-        passivity: bool, optional
+        passivity : bool, optional
             Whether to compute the passivity. The default is ``False``.
-        causality: bool, optional
+        causality : bool, optional
             Whether to compute the causality. The default is ``False``.
-        renormalize: bool, optional
+        renormalize : bool, optional
             Whether to renormalize the S-matrix to a specific port impedance.
             The default is ``False``.
-        impedance: float, optional
+        impedance : float, optional
             Impedance value if ``renormalize=True``. The default is ``50``.
-        error: float, optional
+        error : float, optional
             Fitting error. The default is ``0.5``.
-        poles: int, optional
+        poles : int, optional
             Number of fitting poles. The default is ``10000``.
 
         Returns

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -233,7 +233,7 @@ class Desktop:
     specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case the
         active setup or latest installed version is used.
-    non_graphical: bool, optional
+    non_graphical : bool, optional
         Whether to launch AEDT in the non-graphical mode. The default
         is ``False``, in which case AEDT is launched in the graphical mode.
     new_desktop_session : bool, optional

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -758,7 +758,7 @@ class Edb(object):
         WorkDir : str
             Directory in which to create the ``aedb`` folder. The AEDB file name will be
             the same as the BRD file name. The default value is ``None``.
-        anstranslator_full_path : str, Optional
+        anstranslator_full_path : str, optional
             Optional AnsTranslator full path.
         use_ppe : bool
             Whether to use or not PPE License. The default is ``False``.
@@ -786,7 +786,7 @@ class Edb(object):
         WorkDir : str
             Directory in which to create the ``aedb`` folder. The AEDB file name will be
             the same as the GDS file name. The default value is ``None``.
-        anstranslator_full_path : str, Optional
+        anstranslator_full_path : str, optional
             Optional AnsTranslator full path.
         use_ppe : bool
             Whether to use or not PPE License. The default is ``False``.

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -758,7 +758,7 @@ class Edb(object):
         WorkDir : str
             Directory in which to create the ``aedb`` folder. The AEDB file name will be
             the same as the BRD file name. The default value is ``None``.
-        anstranslator_full_path: str, Optional
+        anstranslator_full_path : str, Optional
             Optional AnsTranslator full path.
         use_ppe : bool
             Whether to use or not PPE License. The default is ``False``.
@@ -786,7 +786,7 @@ class Edb(object):
         WorkDir : str
             Directory in which to create the ``aedb`` folder. The AEDB file name will be
             the same as the GDS file name. The default value is ``None``.
-        anstranslator_full_path: str, Optional
+        anstranslator_full_path : str, Optional
             Optional AnsTranslator full path.
         use_ppe : bool
             Whether to use or not PPE License. The default is ``False``.

--- a/pyaedt/edb_core/EDB_Data.py
+++ b/pyaedt/edb_core/EDB_Data.py
@@ -880,7 +880,7 @@ class EDBPadProperties(object):
             Offset value for the X axis. The default is ``None``.
         offsety :  float, optional
             Offset value for the Y axis. The default is ``None``.
-        rotation: float, optional
+        rotation : float, optional
             Rotation value. The default is ``None``.
 
         Returns
@@ -1031,7 +1031,7 @@ class EDBPadstack(object):
             Offset value for the X axis. The default is ``None``.
         offsety :  float, optional
             Offset value for the Y axis. The default is ``None``.
-        rotation: float, optional
+        rotation : float, optional
             Rotation value in degrees. The default is ``None``.
 
         Returns

--- a/pyaedt/edb_core/hfss.py
+++ b/pyaedt/edb_core/hfss.py
@@ -73,13 +73,13 @@ class Edb3DLayout(object):
 
         Parameters
         ----------
-        pos_pin: Object
+        pos_pin : Object
             Edb Pin
-        neg_pin: Object
+        neg_pin : Object
             Edb Pin
-        impedance: float
+        impedance : float
             Port Impedance
-        port_name: str, Optional
+        port_name : str, Optional
             Port Name
 
         >>> from pyaedt import Edb
@@ -141,7 +141,7 @@ class Edb3DLayout(object):
             Negative Pin.
         current_value : float, optional
             Value for the current. The default is ``0.1``.
-        phase_value: optional
+        phase_value : optional
             Value for the phase. The default is ``0``.
         source_name : str, optional
             Name of the source. The default is ``""``.
@@ -220,7 +220,7 @@ class Edb3DLayout(object):
             Name of the negative net name. The default is ``"GND"``.
         impedance_value : float, optional
             Port impedance value. The default is ``50``.
-        port_name: str, optional
+        port_name : str, optional
             Name of the port. The default is ``""``.
 
         Returns
@@ -322,7 +322,7 @@ class Edb3DLayout(object):
             Name of the negative net. The default is ``"GND"``.
         current_value : float, optional
             Value for the current. The default is ``0.1``.
-        phase_value: optional
+        phase_value : optional
             Value for the phase. The default is ``0``.
         source_name : str, optional
             Name of the source. The default is ``""``.

--- a/pyaedt/edb_core/hfss.py
+++ b/pyaedt/edb_core/hfss.py
@@ -79,7 +79,7 @@ class Edb3DLayout(object):
             Edb Pin
         impedance : float
             Port Impedance
-        port_name : str, Optional
+        port_name : str, optional
             Port Name
 
         >>> from pyaedt import Edb

--- a/pyaedt/edb_core/layout.py
+++ b/pyaedt/edb_core/layout.py
@@ -196,7 +196,7 @@ class EdbLayout(object):
 
         Parameters
         ----------
-        layer_name: str
+        layer_name : str
             Name of the layer.
         net_list : list, optional
             List of net names.

--- a/pyaedt/edb_core/siwave.py
+++ b/pyaedt/edb_core/siwave.py
@@ -519,7 +519,7 @@ class EdbSiwave(object):
             Edb Pin
         impedance : float
             Port Impedance
-        port_name : str, Optional
+        port_name : str, optional
             Port Name
 
         >>> from pyaedt import Edb

--- a/pyaedt/edb_core/siwave.py
+++ b/pyaedt/edb_core/siwave.py
@@ -513,13 +513,13 @@ class EdbSiwave(object):
 
         Parameters
         ----------
-        pos_pin: Object
+        pos_pin : Object
             Edb Pin
-        neg_pin: Object
+        neg_pin : Object
             Edb Pin
-        impedance: float
+        impedance : float
             Port Impedance
-        port_name: str, Optional
+        port_name : str, Optional
             Port Name
 
         >>> from pyaedt import Edb
@@ -739,7 +739,7 @@ class EdbSiwave(object):
             Name of the negative net name. The default is ``None`` which will look for GND Nets.
         impedance_value : float, optional
             Port impedance value. The default is ``50``.
-        port_name: str, optional
+        port_name : str, optional
             Name of the port. The default is ``""``.
 
         Returns
@@ -871,7 +871,7 @@ class EdbSiwave(object):
             Name of the negative net name. The default is ``None`` which will look for GND Nets.
         current_value : float, optional
             Value for the current. The default is ``0.1``.
-        phase_value: optional
+        phase_value : optional
             Value for the phase. The default is ``0``.
         source_name : str, optional
             Name of the source. The default is ``""``.
@@ -1013,7 +1013,7 @@ class EdbSiwave(object):
             Stopping frequency. The default is ``1e9``.
         step_freq : float, optional
             Frequency size of the step. The default is ``1e6``.
-        discrete_sweep: bool, optonal
+        discrete_sweep : bool, optonal
             Whether the sweep is discrete. The default is ``False``.
 
         Returns
@@ -1063,7 +1063,7 @@ class EdbSiwave(object):
             Stopping frequency. The default is ``1e9``.
         step_freq : float, optional
             Frequency size of the step. The default is ``1e6``.
-        discrete_sweep: bool, optonal
+        discrete_sweep : bool, optonal
             Whether the sweep is discrete. The default is ``False``.
 
         Returns

--- a/pyaedt/edb_core/stackup.py
+++ b/pyaedt/edb_core/stackup.py
@@ -148,7 +148,7 @@ class EdbStackup(object):
 
         Parameters
         ----------
-        name: str
+        name : str
             Name of the conductor.
         conductivity : float, optional
             Conductivity of the conductor. The default is ``1e6``.
@@ -197,7 +197,7 @@ class EdbStackup(object):
             for ``higher_frequency``.
         lower_freqency : float
             Value for the lower frequency.
-        higher_frequency: float
+        higher_frequency : float
             Value for the higher frequency.
 
         Returns

--- a/pyaedt/generic/TouchstoneParser.py
+++ b/pyaedt/generic/TouchstoneParser.py
@@ -332,7 +332,8 @@ class TouchstoneData(object):
 def get_return_losses(excitation_names, excitation_name_prefix=""):
     """Get the list of all the Returnloss from a list of exctitations.
 
-    If no excitation is provided it will provide a full list of return Losses
+    If no excitation is provided it will provide a full list of return losses.
+
     Example: excitation_names ["1","2"] is_touchstone_expression=False output ["S(1,1)",, S(2,2)]
     Example: excitation_names ["S(1,1)","S(1,2)", S(2,2)] is_touchstone_expression=True output ["S(1,1)",, S(2,2)]
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -21,38 +21,38 @@ class Hfss(FieldAnalysis3D, object):
 
     Parameters
     ----------
-    projectname: str, optional
+    projectname : str, optional
         Name of the project to select or the full path to the project
         or AEDTZ archive to open. The default is ``None``, in which
         case an attempt is made to get an active project. If no
         projects are present, an empty project is created.
-    designname: str, optional
+    designname : str, optional
         Name of the design to select. The default is ``None``, in
         which case an attempt is made to get an active design. If no
         designs are present, an empty design is created.
-    solution_type: str, optional
+    solution_type : str, optional
         Solution type to apply to the design. The default is
         ``None``, in which case the default type is applied.
-    setup_name: str, optional
+    setup_name : str, optional
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
         This parameter is ignored when script is launched within AEDT.
-    NG: bool, optional
+    NG : bool, optional
         Whether to run AEDT in the non-graphical mode. The default
         is ``False``, in which case AEDT is launched in the graphical mode.
         This parameter is ignored when script is launched within AEDT.
-    new_desktop_session: bool, optional
+    new_desktop_session : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
         another instance of the ``specified_version`` is active on the
         machine. The default is ``True``. This parameter is ignored when
         script is launched within AEDT.
-    close_on_exit: bool, optional
+    close_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``False``.
-    student_version: bool, optional
+    student_version : bool, optional
         Whether to open the AEDT student version. The default is
         ``False``. This parameter is ignored when script is launched
         within AEDT.
@@ -1059,22 +1059,22 @@ class Hfss(FieldAnalysis3D, object):
 
         Parameters
         ----------
-        antenna_type: str, `SbrAntennas.ConicalHorn`
+        antenna_type : str, `SbrAntennas.ConicalHorn`
             Name of the antenna type. Enumerator SbrAntennas can also be used.
             The default is ``"Conical Horn"``.
-        target_cs: str, optional
+        target_cs : str, optional
             Target coordinate system. The default is ``None``, in which case
             the active coodiantes system is used.
-        model_units: str, optional
+        model_units : str, optional
             Model units to apply to the object. The default is
             ``None`` in which case the active modeler units are applied.
-        parameters_dict: dict, optional
+        parameters_dict : dict, optional
             The default is ``None``.
-        use_current_source_representation: bool, optional
+        use_current_source_representation : bool, optional
             The default is ``False``.
-        is_array: bool, optional
+        is_array : bool, optional
             The default is ``False``.
-        antenna_name: str, optional
+        antenna_name : str, optional
             Name of the 3D component. The default is ``None``, in which case the
             name is auto-generated based on the antenna type.
 
@@ -1168,22 +1168,22 @@ class Hfss(FieldAnalysis3D, object):
 
         Parameters
         ----------
-        ffd_full_path: str
+        ffd_full_path : str
             Full path to the FFD file.
-        antenna_size: str, optional
+        antenna_size : str, optional
             Antenna size with units. The default is ``"1mm"``.
-        antenna_impedance: str, optional
+        antenna_impedance : str, optional
             Antenna impedance with units. The default is ``"50ohm"``.
-        representation_type: str, optional
+        representation_type : str, optional
             Type of the antenna type. Options are ``"Far Field"`` or ``"Near Field"``.
             The default is ``"Far Field"``.
         target_cs : str, optional
             Target coordinate system. The default is ``None``, in which case the
             active coordinate system is used.
-        model_units: str, optional
+        model_units : str, optional
             Model units to apply to the object. The default is
             ``None``, in which case the active modeler units are applied.
-        antenna_name: str, optional
+        antenna_name : str, optional
             Name of the 3D component. The default is ``None``, in which case
             the name is auto-generated based on the antenna type.
 
@@ -1752,15 +1752,17 @@ class Hfss(FieldAnalysis3D, object):
         endobject :
             Second object (ending object for integration line)
         axisdir : int or :class:`pyaedt.application.Analysis.Analysis.AxisDir`, optional
-            Position of the port. It should be one of the values for ``Application.AxisDir``,
-            which are: ``XNeg``, ``YNeg``, ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.
-            The default is ``Application.AxisDir.XNeg``.
+            Position of the port. It should be one of the values for
+            ``Application.AxisDir``, which are: ``XNeg``, ``YNeg``,
+            ``ZNeg``, ``XPos``, ``YPos``, and ``ZPos``.  The default
+            is ``Application.AxisDir.XNeg``.
         sourcename : str, optional
             Perfect E name. The default is ``None``.
         is_infinite_gnd : bool, optional
             Whether the Perfect E is an infinite ground. The default is ``False``.
-        bound_on_plane: bool, optional
-            Whether to create the Perfect E on the plane orthogonal to ``AxisDir``. The default is ``True``.
+        bound_on_plane : bool, optional
+            Whether to create the Perfect E on the plane orthogonal to
+            ``AxisDir``. The default is ``True``.
 
         Returns
         -------
@@ -3615,32 +3617,32 @@ class Hfss(FieldAnalysis3D, object):
 
         Parameters
         ----------
-        time_var: str, optional
+        time_var : str, optional
             Name of the time variable. The default is ``None``, in which case
             the first time variable available is used.
-        sweep_time_duration: float, optional
+        sweep_time_duration : float, optional
             Sweep time duration. If greater than 0, a parametric sweep is
             created. The default is ``0``.
-        center_freq: float, optional
+        center_freq : float, optional
             Center frequency in GHz. The default is ``76.5``.
-        resolution: float, optional
+        resolution : float, optional
             Doppler resolution in meters. The default is ``1``.
-        period: float, optional
+        period : float, optional
             Period of analysis in meters. The default is ``200``.
-        velocity_resolution: float, optional
+        velocity_resolution : float, optional
             Doppler velocity resolution in meters per second.
             The default is ``0.4``.
-        min_velocity: str, optional
+        min_velocity : str, optional
             Minimum doppler velocity in meters per second. The default
             is ``-20``.
-        max_velocity: str, optional
+        max_velocity : str, optional
             Maximum doppler velocity in meters per second. The default
             is ``20``.
         ray_density_per_wavelenght : float, optional
             Doppler ray density per wavelength. The default is ``0.2``.
-        max_bounces: int, optional
+        max_bounces : int, optional
             Maximum number of bBounces. The default is ``5``.
-        setup_name: str, optional
+        setup_name : str, optional
             Name of the setup. The default is ``None``.
 
         Returns
@@ -3694,17 +3696,17 @@ class Hfss(FieldAnalysis3D, object):
 
         Parameters
         ----------
-        radar_file: str
+        radar_file : str
             Path to the directory with the radar file.
-        radar_name: str
+        radar_name : str
             Name of the radar file.
-        offset: list, optional
+        offset : list, optional
             Offset relative to the global coordinate system.
-        speed: float, optional
+        speed : float, optional
             Radar movement speed relative to the global coordinate system if greater than ``0``.
-        use_relative_cs: bool, optional
+        use_relative_cs : bool, optional
             Whether the relative coordinate system must be used. The default is ``False``.
-        relative_cs_name: str
+        relative_cs_name : str
             Name of the relative coordinate system to link the radar to.
             The default is ``None``, in which case the global coordinate system is used.
 

--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -941,7 +941,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         simulate_missing_solution : bool, optional
             Set this to ``True`` if the the solver has to simulate missing solution or
             ``False`` to interpolate the missing solution.
-        align_ports : bool, Optional
+        align_ports : bool, optional
             Set this to ``True`` if the the solver has to align microwave ports.
         renormalize_ports : bool, optional
             Set this to ``True`` if the the port impedance has to be renormalized.
@@ -954,7 +954,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         use_interpolating_sweep : bool, optional
             Set to ``True`` if the the solver has to use an interpolating sweep.
             Set to ``False`` to use a discrete sweep.
-        use_y_matrix : bool, Optional
+        use_y_matrix : bool, optional
             Set to ``True`` if the interpolation algorithm has to use YMatrix.
         interpolation_algorithm : str, optional
                 Defines which interpolation algorithm to use. Default is ``"auto"``.

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -37,7 +37,7 @@ class Icepak(FieldAnalysisIcepak):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is  used.
         This parameter is ignored when Script is launched within AEDT.
@@ -807,7 +807,7 @@ class Icepak(FieldAnalysisIcepak):
 
         Parameters
         ----------
-        component_prefix: str, optional
+        component_prefix : str, optional
             Component prefix to search for. The default is ``"COMP_"``.
 
         Returns
@@ -899,15 +899,15 @@ class Icepak(FieldAnalysisIcepak):
         ----------
         hs_height : int, optional
             Height of the heat sink. The default is ``100``.
-        hs_width: int, optional
+        hs_width : int, optional
             Width of the heat sink. The default is ``100``.
         hs_basethick : int, optional
             Thickness of the heat sink base. The default is ``10``.
-        pitch: optional
+        pitch : optional
             Pitch of the heat sink. The default is ``10``.
         thick : optional
             Thickness of the heat sink. The default is ``10``.
-        length: optional
+        length : optional
             The default is ``40``.
         height : optional
             The default is ``40``.
@@ -919,11 +919,11 @@ class Icepak(FieldAnalysisIcepak):
             The default is ``5``.
         symmetric : bool, optional
             Whether the heat sink is symmetric.  The default is ``True``.
-        symmetric_separation: optional
+        symmetric_separation : optional
             The default is ``20``.
         numcolumn_perside : int, optional
             Number of columns per side. The default is ``2``.
-        vertical_separation: optional
+        vertical_separation : optional
             The default is ``10``.
         matname : str, optional
             Name of the material. The default is ``Al-Extruded``.
@@ -1889,13 +1889,13 @@ class Icepak(FieldAnalysisIcepak):
             The default is ``"1"``.
         noOgrids : bool, optional
             The default is ``False``.
-        MLM_en: bool, optional
+        MLM_en : bool, optional
             The default is ``True``.
-        MLM_Type: str, optional
+        MLM_Type : str, optional
             The default is ``"3D"``.
         stairStep_en : bool, optional
             The default is ``False``.
-        edge_min_elements: str, optional
+        edge_min_elements : str, optional
             The default is ``"1"``.
         object : str, optional
             The default is ``"Region"``.

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -33,7 +33,7 @@ class Maxwell(object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used. This
         parameter is ignored when Script is launched within AEDT.
@@ -712,7 +712,7 @@ class Maxwell3d(Maxwell, FieldAnalysis3D, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used. This
         parameter is ignored when Script is launched within AEDT.
@@ -811,7 +811,7 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
         This parameter is ignored when Script is launched within AEDT.
@@ -977,9 +977,9 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
 
         Parameters
         ----------
-        edge_list: list
+        edge_list : list
             List of edges.
-        bound_name: str, optional
+        bound_name : str, optional
             Name of the boundary. The default is ``None``.
 
         Returns

--- a/pyaedt/mechanical.py
+++ b/pyaedt/mechanical.py
@@ -29,7 +29,7 @@ class Mechanical(FieldAnalysis3D, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
         This parameter is ignored when Script is launched within AEDT.

--- a/pyaedt/modeler/Model3DLayout.py
+++ b/pyaedt/modeler/Model3DLayout.py
@@ -170,11 +170,11 @@ class Modeler3DLayout(Modeler):
 
         Parameters
         ----------
-        object_to_expand: str
+        object_to_expand : str
             Name of the object to expand.
-        size: float, optional
+        size : float, optional
             Size of the expansion. The default is ``1``.
-        expand_type: str, optional
+        expand_type : str, optional
             Type of the expansion. Options are ``"ROUND"``, ``"MITER"``, and
             ``"CORNER"``. The default is ``"ROUND"``.
         replace_original : bool, optional

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -28,7 +28,7 @@ class CoordinateSystem(object):
         Inherited parent object.
     props : dict, optional
         Dictionary of properties. The default is ``None``.
-    name: optional
+    name : optional
         The default is ``None``.
 
     """
@@ -308,7 +308,7 @@ class CoordinateSystem(object):
             Name of the reference coordinate system. The default is ``"Global"``.
         name : str
             Name of the coordinate system. The default is ``None``.
-        mode: str, optional
+        mode : str, optional
             Definition mode. Options are ``"view"``, ``"axis"``, ``"zxz"``, ``"zyz"``,
             and ``"axisrotation"``. The default is ``"axis"``.
 
@@ -867,7 +867,7 @@ class GeometryModeler(Modeler, object):
             ``"Global"``.
         name : str
             Name of the coordinate system. The default is ``None``.
-        mode: str, optional
+        mode : str, optional
             Definition mode. Options are ``"view"``, ``"axis"``,
             ``"zxz"``, ``"zyz"``, and ``"axisrotation"``. The default
             is ``"axis"``.
@@ -1889,18 +1889,18 @@ class GeometryModeler(Modeler, object):
 
         Parameters
         ----------
-        objid: str, int
+        objid : str, int
             Name or ID of the object.
-        sweep_object: str, int
+        sweep_object : str, int
             Name or ID of the sweep.
         draft_angle : float, optional
             Draft angle in degrees. The default is ``0``.
         draft_type : str
             Type of the draft. Options are ``"Round"``, ``"Natural"``,
             and ``"Extended"``. The default is ``"Round"``.
-        is_check_face_intersection: bool, optional
+        is_check_face_intersection : bool, optional
             The default is ``False``.
-        twist_angle: float, optional
+        twist_angle : float, optional
            Twist angle in degrees. The default is ``0``.
 
         Returns
@@ -2044,12 +2044,11 @@ class GeometryModeler(Modeler, object):
         ----------
         objid : int
              ID of the object.
-        cs_axis:
+        cs_axis
             Coordinate system axis or the Application.CoordinateSystemAxis object.
         angle : float
             Angle of rotation. The units, defined by ``unit``, can be either
             degrees or radians. The default is ``90.0``.
-
         unit : text, optional
              Units for the angle. Options are ``"deg"`` or ``"rad"``.
              The default is ``"deg"``.
@@ -2832,9 +2831,9 @@ class GeometryModeler(Modeler, object):
 
         Parameters
         ----------
-        fl: list
+        fl : list
             List of object names.
-        name: str
+        name : str
             Name of the new object list.
 
         Returns
@@ -3785,7 +3784,7 @@ class GeometryModeler(Modeler, object):
 
         Parameters
         ----------
-        args: list or int
+        args : list or int
             Position of the item as either a list of the ``[x, y, z]`` coordinates
             or three separate values. If no or insufficient arguments
             are specified, ``0`` is applied.

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -1266,9 +1266,9 @@ class Object3d(object):
         draft_type : str
             Type of the draft. Options are ``"Extended"``, ``"Round"``,
             and ``"Natural"``. The default is ``"Round``.
-        is_check_face_intersection: bool, optional
+        is_check_face_intersection : bool, optional
            The default is ``False``.
-        twist_angle: float, optional
+        twist_angle : float, optional
             Angle at which to twist or rotate in degrees. The default is ``0``.
 
         Returns
@@ -1412,11 +1412,11 @@ class Padstack(object):
 
     Parameters
     ----------
-    name: str, optional
+    name : str, optional
         Name of the padstack. The default is ``"Padstack"``.
     padstackmanager : optional
         The default is ``None``.
-    units: str, optional
+    units : str, optional
         The default is ``mm``.
 
     """
@@ -1443,7 +1443,7 @@ class Padstack(object):
 
         Parameters
         ----------
-        holetype: str, optional
+        holetype : str, optional
             Type of the hole. The default is ``Circular``.
         sizes : str, optional
             Diameter of the hole with units. The default is ``"1mm"``.
@@ -1527,7 +1527,7 @@ class Padstack(object):
 
             Parameters
             ----------
-            holetype: str, optional
+            holetype : str, optional
                 Type of the hole. The default is ``Circular``.
             sizes : str, optional
                 Diameter of the hole with units. The default is ``"1mm"``.

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -36,7 +36,7 @@ class PolylineSegment:
     type : str
         Type of the object. Choices are ``"Line"``, ``"Arc"``, ``"Spline"``,
         and ``"AngularArc"``.
-    num_seg: int, optional
+    num_seg : int, optional
         Number of segments for the types ``"Arc"``, ``"Spline"``, and
         ``"AngularArc"``.  The default is ``0``. For the type
         ``Line``, this parameter is ignored.
@@ -698,7 +698,7 @@ class Polyline(Object3d):
             List of positions of the points that define the segment to insert.
             Either the starting point or ending point of the segment list must
             match one of the vertices of the existing polyline.
-        segment: str or :class:`pyaedt.modeler.Primitives.PolylineSegment`
+        segment : str or :class:`pyaedt.modeler.Primitives.PolylineSegment`
             Definition of the segment to insert. For the types ``"Line"`` and ``"Arc"``,
             use their string values ``"Line"`` and ``"Arc"``. For the types ``"AngularArc"``
             and ``"Spline"``, use the :class:`pyaedt.modeler.Primitives.PolylineSegment`
@@ -1125,7 +1125,7 @@ class Primitives(object):
 
         Parameters
         ----------
-        edge: int or :class:`pyaedt.modeler.Object3d.EdgePrimitive`
+        edge : int or :class:`pyaedt.modeler.Object3d.EdgePrimitive`
             Edge ID or :class:`pyaedt.modeler.Object3d.EdgePrimitive` object.
 
         Returns
@@ -1233,9 +1233,9 @@ class Primitives(object):
         close_surface : bool, optional
             The default is ``False``, which automatically joins the
             starting and ending points.
-        name: str, optional
+        name : str, optional
             Name of the polyline. The default is ``None``.
-        matname: str, optional
+        matname : str, optional
             Name of the material. The default is ``None``, in which case the
             default material is assigned.
         xsection_type : str, optional

--- a/pyaedt/modeler/Primitives3D.py
+++ b/pyaedt/modeler/Primitives3D.py
@@ -984,7 +984,7 @@ class Primitives3D(Primitives, object):
 
         Returns
         -------
-        pyaedt.modeler.actors.Vehicle
+        :class:`pyaedt.modeler.actors.Vehicle`
 
         """
         self._initialize_multipart()

--- a/pyaedt/modeler/Primitives3D.py
+++ b/pyaedt/modeler/Primitives3D.py
@@ -10,8 +10,9 @@ from ..generic.general_methods import retry_ntimes
 class Primitives3D(Primitives, object):
     """Manages primitives in 3D tools.
 
-    This class is inherited in the caller application and is accessible through the primitives variable part
-    of modeler object( eg. ``hfss.modeler.primitives`` or ``icepak.modeler.primitives``).
+    This class is inherited in the caller application and is
+    accessible through the primitives variable part of modeler object(
+    e.g. ``hfss.modeler.primitives`` or ``icepak.modeler.primitives``).
 
     Parameters
     ----------
@@ -35,7 +36,7 @@ class Primitives3D(Primitives, object):
         bool
             ``True`` when successful, ``False`` when failed.
 
-    """
+        """
 
     @aedt_exception_handler
     def create_box(self, position, dimensions_list, name=None, matname=None):
@@ -304,30 +305,34 @@ class Primitives3D(Primitives, object):
         return self._create_object(new_object_name)
 
     @aedt_exception_handler
-    def create_bondwire(self, start_position, end_position, h1=0.2, h2=0, alpha=80, beta=5, bond_type=0,
-                        diameter=0.025, facets=6, name=None, matname=None):
+    def create_bondwire(self, start_position, end_position, h1=0.2,
+                        h2=0, alpha=80, beta=5, bond_type=0,
+                        diameter=0.025, facets=6, name=None,
+                        matname=None):
         """Create a bondwire.
 
         Parameters
         ----------
         start_position : list
-            List of ``[x, y, z]`` coordinates for the starting position of the bond pad.
+            List of ``[x, y, z]`` coordinates for the starting
+            position of the bond pad.
         end_position :  list
-            List of ``[x, y, z]`` coordinates for the ending position of the bond pad.
-        h1: float, optional
+            List of ``[x, y, z]`` coordinates for the ending position
+            of the bond pad.
+        h1 : float, optional
             Height between the IC  die I/O pad and the top of the bondwire.
             The default is ``0.2``.
-        h2: float, optional
+        h2 : float, optional
             Height of the IC die I/O pad above the lead frame. The default
             is ``0``. A negative value indicates that the I/O pad is below
             the lead frame.
-        alpha: float, optional
+        alpha : float, optional
             Angle in degrees between the xy plane and the wire bond at the
             IC die I/O pad. The default is ``80``.
-        beta: float, optional
+        beta : float, optional
             Angle in degrees between the xy plane and the wire bond at the
             lead frame. The default is ``5``.
-        bond_type: int, optional
+        bond_type : int, optional
             Type of the boundwire, which indicates its shape. Options are:
 
             * ''0'' for JEDEC 5-point
@@ -335,9 +340,9 @@ class Primitives3D(Primitives, object):
             * ''2`` for Low
 
             The default is ''0``.
-        diameter: float, optional
+        diameter : float, optional
             Diameter of the wire. The default is ``0.025``.
-        facets: int, optional
+        facets : int, optional
             Number of wire facets. The default is ``6``.
         name : str, optional
             Name of the bondwire. The default is ``None``, in which case
@@ -831,7 +836,8 @@ class Primitives3D(Primitives, object):
                    relative_cs_name=None, actor_name=None):
         """Add a Walking Person Multipart from 3D Components.
 
-        It requires a json file in the folder containing person infos. An example json file is showed here.
+        It requires a json file in the folder containing person
+        infos. An example json file follows:
 
          .. code-block:: json
 
@@ -883,22 +889,24 @@ class Primitives3D(Primitives, object):
 
         Parameters
         ----------
-        actor_folder: str
-            Path to the actor folder. It must contain a json settings file and a 3dcomponent (.a3dcomp).
-        speed:  float, Optional
+        actor_folder : str
+            Path to the actor folder. It must contain a json settings
+            file and a 3dcomponent (.a3dcomp).
+        speed :  float, optional
             Object movement speed with time (m_per_sec).
-        global_offset: list, Optional
+        global_offset : list, optional
             Offset from Global Coordinate System [x,y,z] in meters.
-        yaw: float, Optional
+        yaw : float, optional
             Yaw Rotation from Global Coordinate System in deg.
-        pitch: float, Optional
+        pitch : float, optional
             Pitch Rotation from Global Coordinate System in deg.
-        roll: float, Optional
+        roll : float, optional
             Roll Rotation from Global Coordinate System in deg.
         relative_cs_name : str
             Relative CS Name of the actor. ``None`` for Global CS.
         actor_name : str
-            If provided, it overrides the actor name in the Json
+            If provided, it overrides the actor name in the JSON.
+
         Returns
         -------
         :class:`pyaedt.modeler.actors.Person`
@@ -922,8 +930,8 @@ class Primitives3D(Primitives, object):
                     actor_name=None):
         """Add a Moving Vehicle Multipart from 3D Components.
 
-        It requires a json file in the folder containing vehicle infos. An example json file is showed here.
-
+        It requires a json file in the folder containing vehicle
+        infos. An example json file follows:
 
          .. code-block:: json
 
@@ -961,22 +969,22 @@ class Primitives3D(Primitives, object):
         actor_folder : str
             Path to the actor directory. It must contain a json settings file
             and a 3dcomponent (``.a3dcomp`` file).
-        speed:  float, Optional
+        speed :  float, optional
             Object movement speed with time (m_per_sec).
-        global_offset: list, Optional
+        global_offset : list, optional
             Offset from Global Coordinate System [x,y,z] in meters.
-        yaw: float, Optional
+        yaw : float, optional
             Yaw Rotation from Global Coordinate System in deg.
-        pitch: float, Optional
+        pitch : float, optional
             Pitch Rotation from Global Coordinate System in deg.
-        roll: float, Optional
+        roll : float, optional
             Roll Rotation from Global Coordinate System in deg.
         relative_cs_name : str
             Relative CS Name of the actor. ``None`` for Global CS.
 
         Returns
         -------
-        :class:`pyaedt.modeler.actors.Vehicle`
+        pyaedt.modeler.actors.Vehicle
 
         """
         self._initialize_multipart()
@@ -1048,15 +1056,15 @@ class Primitives3D(Primitives, object):
         actor_folder : str
             Path to the actor directory. It must contain a json settings file and a
             3dcomponent (``.a3dcomp`` file)
-        speed:  float, Optional
+        speed :  float, optional
             Object movement speed with time (m_per_sec).
-        global_offset: list, Optional
+        global_offset : list, optional
             Offset from Global Coordinate System [x,y,z] in meters.
-        yaw: float, Optional
+        yaw : float, optional
             Yaw Rotation from Global Coordinate System in deg.
-        pitch: float, Optional
+        pitch : float, optional
             Pitch Rotation from Global Coordinate System in deg.
-        roll: float, Optional
+        roll : float, optional
             Roll Rotation from Global Coordinate System in deg.
         flapping_rate : float, optional
             Motion flapping rate in Hz.
@@ -1120,17 +1128,19 @@ class Primitives3D(Primitives, object):
         Parameters
         ----------
         env_folder : str
-            Path to the actor directory. It must contain a json settings file and a 3dcomponent (``.a3dcomp`` file).
-        global_offset: list, Optional
+            Path to the actor directory. It must contain a json
+            settings file and a 3dcomponent (``.a3dcomp`` file).
+        global_offset : list, optional
             Offset from Global Coordinate System [x,y,z] in meters.
-        yaw: float, Optional
+        yaw : float, optional
             Yaw Rotation from Global Coordinate System in deg.
-        pitch: float, Optional
+        pitch : float, optional
             Pitch Rotation from Global Coordinate System in deg.
-        roll: float, Optional
+        roll : float, optional
             Roll Rotation from Global Coordinate System in deg.
         relative_cs_name : str
             Relative CS Name of the actor. ``None`` for Global CS.
+
         Returns
         -------
         :class:`pyaedt.modeler.multiparts.Environment`

--- a/pyaedt/modeler/Primitives3DLayout.py
+++ b/pyaedt/modeler/Primitives3DLayout.py
@@ -36,7 +36,7 @@ class Primitives3DLayout(object):
 
         Parameters
         ----------
-        partname: int or str
+        partname : int or str
            Part ID or part name.
 
         Returns

--- a/pyaedt/modeler/PrimitivesNexxim.py
+++ b/pyaedt/modeler/PrimitivesNexxim.py
@@ -30,7 +30,7 @@ class NexximComponents(CircuitComponents):
         """Get the object ID if the part name is an integer or the object name if it is a string.
         Parameters
         ----------
-        partname: int or str
+        partname : int or str
             Part ID or object name.
 
         Returns
@@ -96,11 +96,11 @@ class NexximComponents(CircuitComponents):
         ----------
         design_name : str
             Name of the design.
-        solution_name: str
+        solution_name : str
             Name  of the solution.
         pin_names : list
             List of the pin names.
-        model_type: str, optional
+        model_type : str, optional
             Type of the model. The default is ``"hfss"``.
         posx : float, optional
             Position on the X axis. The default is ``0``.
@@ -351,7 +351,7 @@ class NexximComponents(CircuitComponents):
             Resistance in ohms. The default is ``50``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -386,7 +386,7 @@ class NexximComponents(CircuitComponents):
             Inductance value. The default is ``50``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the X axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -428,7 +428,7 @@ class NexximComponents(CircuitComponents):
             Capacitor value. The default is ``50``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -469,7 +469,7 @@ class NexximComponents(CircuitComponents):
             Voltage value. The default is ``50``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
         use_instance_id_netlist : bool, optional
@@ -511,7 +511,7 @@ class NexximComponents(CircuitComponents):
             List of values for the current pulse. The default is ``[]``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -568,7 +568,7 @@ class NexximComponents(CircuitComponents):
             List of values for the voltage pulse. The default is ``[]``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -623,7 +623,7 @@ class NexximComponents(CircuitComponents):
             Current value. The default is ``1``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -669,7 +669,7 @@ class NexximComponents(CircuitComponents):
             Value for the coupling inductor. The default is ``1``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -714,7 +714,7 @@ class NexximComponents(CircuitComponents):
             Name of the model. The default is ``"required"``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -755,7 +755,7 @@ class NexximComponents(CircuitComponents):
             Value for the NPN transistor. The default is ``None``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -796,7 +796,7 @@ class NexximComponents(CircuitComponents):
             Value for the PNP transistor. The default is ``None``.
         xpos : float, optional
             Position on the X axis. The default is ``0``.
-        ypos: float, optional
+        ypos : float, optional
             Position on the Y axis. The default is ``0``.
         angle : float, optional
             Angle rotation in degrees. The default is ``0``.
@@ -1064,15 +1064,15 @@ class NexximComponents(CircuitComponents):
         ----------
         comp_name : str
             Name of the subcircuit HFSS link.
-        pin_names: list
+        pin_names : list
             List of the pin names.
         source_project_path : str
             Path to the source project.
-        source_project_name: str
+        source_project_name : str
             Name  of the source project.
         source_design_name : str
             Name of the design.
-        solution_name: str, optional
+        solution_name : str, optional
             Name of the solution and sweep. The
             default is ``"Setup1 : Sweep"``.
 
@@ -1300,7 +1300,7 @@ class NexximComponents(CircuitComponents):
         ----------
         component : str
             Address of the component instance. For example, ``"Inst@Galileo_cutout3;87;1"``.
-        solution_name: str, optional
+        solution_name : str, optional
             Name of the solution and sweep. The default is ``"Setup1 : Sweep"``.
 
         Returns

--- a/pyaedt/modeler/actors.py
+++ b/pyaedt/modeler/actors.py
@@ -8,9 +8,9 @@ def read_actors(fn, actor_lib):
 
     Parameters
     ----------
-    fn: str
+    fn : str
         Name of the JSON file describing the actors.
-    actor_lib: str
+    actor_lib : str
         Full path to the library containing the actor definitions.
 
     Returns
@@ -36,12 +36,12 @@ class Generic(Actor, object):
 
     Parameters
     ----------
-    actor_folder: str
+    actor_folder : str
         Full path to the directory containing the definition of the person.
         This can be changed later in the :class:`Person` class definition.
-    speed: float or str
+    speed : float or str
         Speed of the person in the X-direction.
-    relative_cs_name: str
+    relative_cs_name : str
         Name of the relative coordinate system of the actor. The default is ``None``,
         in which case the global coordinate system is used.
 
@@ -65,16 +65,16 @@ class Person(Actor, object):
 
     Parameters
     ----------
-    actor_folder: str, required
+    actor_folder : str, required
         Full path to the folder containing the definition of the
         person.  This can be changed later in the :class:`Person`
         class definition.
-    speed: float or str
+    speed : float or str
         Speed of the person in the X-direction.
-    stride: float or str
+    stride : float or str
         Stride length of the person. The default is "0". An example of
         entering a string, which includes units, is ``"0.8meters"``.
-    relative_cs_name: str
+    relative_cs_name : str
         Name of the relative coordinate system of the actor. The
         default is ``None``, in which case the global coordinate
         system is used.
@@ -187,7 +187,7 @@ class Bird(Actor, object):
         Parameters
         ----------
         app: :class:`pyaedt.hfss.Hfss`
-        motion: bool
+        motion : bool
             The default is ``True``.
 
         Returns
@@ -208,12 +208,10 @@ class Vehicle(Actor, object):
 
     This class is derived from :class:`MultiPartComponent`.
 
-   This class is derived from :class:`MultiPartComponent`.
-
     .. note::
         Motion is always forward in the X-direction.
 
-    Properties
+    Parameters
     ----------
     car_folder : str, required
         Full path to the folder containing the definition of the
@@ -249,7 +247,7 @@ class Vehicle(Actor, object):
         Parameters
         ----------
         app: :class:`pyaedt.hfss.Hfss`
-        motion: bool, optional
+        motion : bool, optional
             The default is ``True``.
 
         Returns
@@ -271,11 +269,11 @@ class Radar(MultiPartComponent, object):
 
     Parameters
     ----------
-    radar_folder: str
+    radar_folder : str
         Full path to the folder containing the radar file.
-    name: str, optional
+    name : str, optional
         Name of the radar file. The default is ``None``.
-    motion: bool, optional
+    motion : bool, optional
         The default is ``False``.
 
     """
@@ -348,8 +346,8 @@ class Radar(MultiPartComponent, object):
 
         Parameters
         ----------
-        app: class: `pyaedt.hfss.Hfss`
-        motion: bool, optional
+        app : class: `pyaedt.hfss.Hfss`
+        motion : bool, optional
             The default is ``False``.
 
         Returns

--- a/pyaedt/modeler/multiparts.py
+++ b/pyaedt/modeler/multiparts.py
@@ -15,34 +15,34 @@ class MultiPartComponent(object):
 
     Parameters
     ----------
-    comp_folder: str
+    comp_folder : str
         Full path to the folder with the JSON file containing the component definition.
         This JSON file must have the same name as the folder.
-    name: str, optional
+    name : str, optional
         Name of the multipart component. If this value is set, the
         component is selected from the corresponding JSON file in
         ``comp_folder``. The default is ``None``, in which case the
         name of the first JSON file in the folder is used.
-    use_relative_cs: bool, optional
+    use_relative_cs : bool, optional
         Whether to use the relative coordinate system. The default is ``False``.
         Set to ``False`` if the multi-part component doesn't move. Set to ``True``
         if the multi-part component moves relative to the global coordinate system.
     relative_cs_name : str, optional
         Name of the coordinate system to connect the multipart relative system to
         when ``use_relative_cs=True``.
-    motion: bool, optional
+    motion : bool, optional
         Whether expressions should be used to define the position and orientation of
         the multi-part component. The default is ``False``.
-    offset: list, optional
+    offset : list, optional
         List of ``[x, y, z]`` coordinate values defining the component offset.
         The default is ``["0", "0", "0"]``.
     yaw : str or float, optional
         Yaw angle, indicating the rotation about the component Z-axis. The default
         is ``"0deg"``.
-    pitch: str or float, optional
+    pitch : str or float, optional
         Pitch angle, indicating the rotation about the component Y-axis The default
         is ``"0deg"``.
-    roll: str or float, optional
+    roll : str or float, optional
         Roll angle, indicating the rotation about the component X-axis. The default
         is ``"0deg"``.
     """
@@ -67,7 +67,7 @@ class MultiPartComponent(object):
 
         Parameters
         ----------
-        app: class:`pyaedt.Hfss`
+        app : class:`pyaedt.Hfss`
             HFSS application instance.
 
         Returns
@@ -479,7 +479,7 @@ class Environment(MultiPartComponent, object):
 
     Parameters
     ----------
-    env_folder: str
+    env_folder : str
         Full path to the folder with the JSON file containing the component definition.
     relative_cs_name : str, optional
         Name of the coordinate system to connect the multi-part relative system to.
@@ -570,12 +570,12 @@ class Actor(MultiPartComponent, object):
 
     Parameters
     ----------
-    actor_folder: str
+    actor_folder : str
         Full path to the folder containing the definition of the person.
         This can be changed later in the :class:`Person` class definition.
-    speed: float or str
+    speed : float or str
         Speed of the person in the X-direction. The default is ``0```.
-    relative_cs_name: str
+    relative_cs_name : str
         Name of the relative coordinate system of the actor. The default is ``None``,
         in which case the global coordinate system is used.
     """

--- a/pyaedt/modeler/parts.py
+++ b/pyaedt/modeler/parts.py
@@ -13,18 +13,24 @@ class Part(object):
         Path to the folder with the A3DCOMP files.
     part_dict : dict
         Defines relevant properties of the class with the following keywords:
-        * 'comp_name': str, Name of the A3DCOMP file.
-        * 'offset': list or str, Offset coordinate system definition relative to the parent.
-        * 'rotation_cs': list or str, Rotation coordinate system relative to the parent.
-        * 'rotation': str or numeric, Rotation angle.
-        * 'compensation_angle': str or numeric, Initial angle.
-        * 'rotation_axis': str, Rotation axis (``"X"``, ``"Y"``, or ``"Z"``).
-        * 'duplicate_number': str or int, Number of instances for linear duplication.
-        * 'duplicate_vector': list, Vector for duplication relative to the parent coordinate system.
-     parent :  str
-         The default is ``None``.
+
+        * ``'comp_name'`` : str, Name of the A3DCOMP file.
+        * ``'offset'`` : list or str, Offset coordinate system definition
+          relative to the parent.
+        * ``'rotation_cs'`` : list or str, Rotation coordinate system
+          relative to the parent.
+        * ``'rotation'`` : str or numeric, Rotation angle.
+        * ``'compensation_angle'`` : str or numeric, Initial angle.
+        * ``'rotation_axis'`` : str, Rotation axis (``"X"``, ``"Y"``, or ``"Z"``).
+        * ``'duplicate_number'`` : str or int, Number of instances for
+          linear duplication.
+        * ``'duplicate_vector'`` : list, Vector for duplication relative to
+          the parent coordinate system.
+
+     parent : str
+        The default is ``None``.
      name : str, optional
-            Name of the A3DCOMP file without the extension. The default is ``None``.
+        Name of the A3DCOMP file without the extension. The default is ``None``.
      """
 
     # List of known keys for a Part and default values:
@@ -359,7 +365,7 @@ class Part(object):
 
         Parameters
         ----------
-        app: pyaedt.Hfss
+        app : pyaedt.Hfss
             HFSS instance of AEDT.
         aedt_object : str
             Name of the design in AEDT.
@@ -391,7 +397,7 @@ class Part(object):
 
         Parameters
         ----------
-        app: class:`pyaedt.hfss.Hfss`
+        app : class:`pyaedt.hfss.Hfss`
             HFSS application instance.
 
         Returns
@@ -429,13 +435,13 @@ class Antenna(Part, object):
 
     Parameters
     ----------
-    root_folder:
-
-    ant_dict:
-
-    parent: str, optional
+    root_folder : str
+        Root directory
+    ant_dict : dict
+        Antenna dictionary
+    parent : str, optional
         The default is ``None``.
-    name: str, optional
+    name : str, optional
         The default is ``None``.
 
     """

--- a/pyaedt/modules/LayerStackup.py
+++ b/pyaedt/modules/LayerStackup.py
@@ -88,9 +88,9 @@ class Layer(object):
         The default is ``"signal"``.
     layerunits : str, optional
         The default is ``"mm"``.
-    roughunit: str, optional
+    roughunit : str, optional
         The default is ``"um"``.
-    negative: bool, optional
+    negative : bool, optional
         Whether the geometry on the layer is cut away
         from the layer. The default is ``False``.
     """

--- a/pyaedt/modules/Material.py
+++ b/pyaedt/modules/Material.py
@@ -720,10 +720,10 @@ class CommonMaterial(object):
     def _get_args(self, props=None):
         """Retrieve the arguments for a property.
 
-        Parameters:
-            prop: str, optoinal
-                Name of the property.
-                The default is ``None``.
+        Parameters
+        ----------
+        prop : str, optoinal
+            Name of the property.  The default is ``None``.
         """
         if not props:
             props = self._props
@@ -736,7 +736,7 @@ class CommonMaterial(object):
 
         Parameters
         ----------
-        propname: str
+        propname : str
             Name of the property.
         provpavlue :
             Value of the property.

--- a/pyaedt/modules/PostProcessor.py
+++ b/pyaedt/modules/PostProcessor.py
@@ -433,7 +433,7 @@ class FieldPlot:
         Name of the solution.
     quantityName : str
         Name of the plot or the name of the object.
-    intrinsicList: dict, optional
+    intrinsicList : dict, optional
         Name of the intrinsic dictionary. The default is ``{}``.
 
     """
@@ -1860,22 +1860,22 @@ class CircuitPostProcessor(PostProcessorCommon, object):
 
         Parameters
         ----------
-        setupname: str
+        setupname : str
             Name of the setup
-        ami_name: str
+        ami_name : str
             AMI Probe name to use
-        variation_list_w_value: list
+        variation_list_w_value : list
             list of variations with relative values
-        plot_type: str, Default ``"Rectangular Plot"``
+        plot_type : str, Default ``"Rectangular Plot"``
             String containing the report type. Default is ``"Rectangular Plot"``. It can be ``"Data Table"``,
             ``"Rectangular Stacked Plot"``or any of the other valid AEDT Report types.
-        plot_initial_response: bool, optional
+        plot_initial_response : bool, optional
             Set either to plot the initial input response.  Default is ``True``.
-        plot_intermediate_response: bool, optional
+        plot_intermediate_response : bool, optional
             Set whether to plot the intermediate input response.  Default is ``False``.
-        plot_final_response: bool, optional
+        plot_final_response : bool, optional
             Set whether to plot the final input response.  Default is ``False``.
-        plotname: str, optional
+        plotname : str, optional
             The plot name.  Default is a unique name.
 
         Returns
@@ -1970,7 +1970,7 @@ class CircuitPostProcessor(PostProcessorCommon, object):
         ami_plot_type : str, optional
             String containing the report AMI type. Default is ``"InitialEye"``. It can be ``"EyeAfterSource"``,
             ``"EyeAfterChannel"`` or ``"EyeAfterProbe"``.
-        plotname: str, optional
+        plotname : str, optional
             The name of the plot.  Defaults to a unique name starting with ``"Plot"``.
 
         Returns
@@ -2062,13 +2062,13 @@ class CircuitPostProcessor(PostProcessorCommon, object):
 
         Parameters
         ----------
-        setupname: str
+        setupname : str
             Name of the setup
-        probe_names: str or list
+        probe_names : str or list
             Name of the probe to plot in the EYE diagram.
         variation_list_w_value : list
             List of variations with relative values.
-        plotname: str, optional
+        plotname : str, optional
             The name of the plot.
 
         Returns

--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1466,7 +1466,7 @@ class SweepQ3D(object):
 
     setupname :str
         Name of the setup.
-    sweepname: str
+    sweepname : str
         Name of the sweep.
     sweeptype : str, optional
         Type of the sweep. Options are ``"Fast"``, ``"Interpolating"``,

--- a/pyaedt/modules/SolveSetup.py
+++ b/pyaedt/modules/SolveSetup.py
@@ -21,13 +21,13 @@ class Setup(object):
 
     Parameters
     ----------
-    parent: str
+    parent : str
         Inherited parent object.
-    solutiontype:
+    solutiontype : int, str
         Type of the setup.
-    setupname: str, optional
+    setupname : str, optional
         Name of the setup. The default is ``"MySetupAuto"``.
-    isnewsetup: bool, optional
+    isnewsetup : bool, optional
         Whether to create the setup from a template. The default is ``True``.
         If ``False``, access is to the existing setup.
 
@@ -435,13 +435,13 @@ class SetupCircuit(object):
 
     Parameters
     ----------
-    parent: str
+    parent : str
         Inherited parent object.
-    solutiontype:
+    solutiontype : str, int
         Type of the setup.
-    setupname: str, optional
+    setupname : str, optional
         Name of the setup. The default is ``"MySetupAuto"``.
-    isnewsetup: bool, optional
+    isnewsetup : bool, optional
       Whether to create the setup from a template. The default is ``True.``
       If ``False``, access is to the existing setup.
 
@@ -477,13 +477,13 @@ class SetupCircuit(object):
 
         Parameters
         ----------
-        parent: str
+        parent : str
             Inherited parent object.
-        solutiontype:
+        solutiontype : str, int
             Type of the setup.
-        setupname: str, optional
+        setupname : str, optional
             Name of the setup. The default is ``"MySetupAuto"``.
-        isnewsetup: bool, optional
+        isnewsetup : bool, optional
           Whether to create the setup from a template. The default is ``True.``
           If ``False``, access is to the existing setup.
 
@@ -842,13 +842,13 @@ class Setup3DLayout(object):
 
     Parameters
     ----------
-    parent: str
+    parent : str
         Inherited parent object.
-    solutiontype:
+    solutiontype : int or str
         Type of the setup.
-    setupname: str, optional
+    setupname : str, optional
         Name of the setup. The default is ``"MySetupAuto"``.
-    isnewsetup: bool, optional
+    isnewsetup : bool, optional
         Whether to create the setup from a template. The default is ``True.``
         If ``False``, access is to the existing setup.
 

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -116,7 +116,7 @@ class Q3d(QExtractor, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or nothing
         is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
         the active version or latest installed version is used.
         This parameter is ignored when Script is launched within AEDT.
@@ -484,10 +484,10 @@ class Q2d(QExtractor, object):
         Name of the setup to use as the nominal. The default is
         ``None``, in which case the active setup is used or
         nothing is used.
-    specified_version: str, optional
+    specified_version : str, optional
         Version of AEDT to use. The default is ``None``, in which case
-        the active version or latest installed version is used.
-        This parameter is ignored when Script is launched within AEDT.
+        the active version or latest installed version is used.  This
+        parameter is ignored when Script is launched within AEDT.
     NG : bool, optional
         Whether to launch AEDT in the non-graphical mode. The default
         is ``False``, in which case AEDT is launched in the graphical mode.
@@ -495,11 +495,13 @@ class Q2d(QExtractor, object):
     new_desktop_session : bool, optional
         Whether to launch an instance of AEDT in a new thread, even if
         another instance of the ``specified_version`` is active on the
-        machine. The default is ``True``. This parameter is ignored when Script is launched within AEDT.
+        machine. The default is ``True``. This parameter is ignored
+        when Script is launched within AEDT.
     close_on_exit : bool, optional
         Whether to release AEDT on exit. The default is ``False``.
     student_version : bool, optional
-        Whether to open the AEDT student version. This parameter is ignored when Script is launched within AEDT.
+        Whether to open the AEDT student version. This parameter is
+        ignored when Script is launched within AEDT.
 
     Examples
     --------


### PR DESCRIPTION
This PR adds the numpydoc Validation check `"PR10"`.

```py
Parameter "{param_name}" requires a space before the colon separating the parameter name and type.
```

The question was raised here:
https://github.com/pyansys/PyAEDT/pull/468#discussion_r711070093

For reference regarding numpydoc validation checks, see:
https://numpydoc.readthedocs.io/en/latest/validation.html
