### PR TITLE
Fix the behavior for none and empty string.

### DIFF
--- a/pyaedt/application/MessageManager.py
+++ b/pyaedt/application/MessageManager.py
@@ -341,9 +341,9 @@ class AEDTMessageManager(object):
 
         """
         if self._log_on_desktop:
-            if not proj_name:
+            if proj_name is None:
                 proj_name = self._project_name
-            if not des_name:
+            if des_name is None:
                 des_name = self._design_name
             self._desktop.ClearMessages(proj_name, des_name, level)
 


### PR DESCRIPTION
Currently, for the `clear_messages` method in the `MessageManager`, if the arguments `proj_name` and `des_name` are empty string, we will delete the current project and current design messages which is the opposite behavior of the description exposed in the docstring.

We must check that these two arguments are None to assign them the current project and design, not if the string is empty.