### PR TITLE
Improve the comment to be accurate regarding the code behavior.

### DIFF
--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -1153,7 +1153,8 @@ class Design(object):
 
     @aedt_exception_handler
     def add_info_message(self, message_text, message_type=None):
-        """Add a type 0 "Info" message to the active design level of the Message Manager tree.
+        """Add a type 0 "Info" message to either global, active project or active design
+        level of the Message Manager tree.
 
         Also add an info message to the logger if the handler is present.
 
@@ -1186,7 +1187,8 @@ class Design(object):
 
     @aedt_exception_handler
     def add_warning_message(self, message_text, message_type=None):
-        """Add a type 0 "Warning" message to the active design level of the Message Manager tree.
+        """Add a type 0 "Warning" message to either global, active project or active design
+        level of the Message Manager tree.
 
         Also add an info message to the logger if the handler is present.
 
@@ -1219,7 +1221,8 @@ class Design(object):
 
     @aedt_exception_handler
     def add_error_message(self, message_text, message_type=None):
-        """Add a type 0 "Error" message to the active design level of the Message Manager tree.
+        """Add a type 0 "Error" message to either global, active project or active design
+        level of the Message Manager tree.
 
         Also add an error message to the logger if the handler is present.
 


### PR DESCRIPTION
The comments of the 3 logging methods suggest that the messages can only be logged at the design level, whereas it can also be done at either the 'global' or 'project' level.
'Design' is the default level and not the only valid level.