### PR TITLE
Add a title '5G linear array antenna'.

### DIFF
--- a/examples/00-basic-examples/03_5G_antenna_example.py
+++ b/examples/00-basic-examples/03_5G_antenna_example.py
@@ -1,4 +1,5 @@
 """
+5G linear array antenna
 --------------------------------------
 This example shows how to use HFSS 3D Layout to create and solve a 5G linear array antenna.
 """


### PR DESCRIPTION
Fix issue #535.
When the doc is generated, a warning appears for the example 03_5G_antenna_example.
It is because the example does not have a title in its docstring.