### PR TITLE
hole_diam cannot be a string to be passed to arg_with_dim.

### DIFF
--- a/pyaedt/modeler/Primitives3DLayout.py
+++ b/pyaedt/modeler/Primitives3DLayout.py
@@ -420,7 +420,7 @@ class Primitives3DLayout(object):
         arg.append("vrotation:="), arg.append([str(rotation) + "deg"])
         if hole_diam:
             arg.append("overrides hole:="), arg.append(True)
-            arg.append("hole diameter:="), arg.append([self.arg_with_dim("hole_diam")])
+            arg.append("hole diameter:="), arg.append([self.arg_with_dim(hole_diam)])
 
         else:
             arg.append("overrides hole:="), arg.append(False)


### PR DESCRIPTION
Fix the issue #552 .
The `hole_diam` variable must be passed to the `arg_with_dim()` and not a string "hole_diam".