### PR TITLE
Fix #428 .

### DIFF
--- a/pyaedt/edb_core/siwave.py
+++ b/pyaedt/edb_core/siwave.py
@@ -652,7 +652,7 @@ class EdbSiwave(object):
         current_source.positive_node.component_node = pos_pin.GetComponent()
         current_source.positive_node.node_pins = pos_pin
         current_source.negative_node.component_node = neg_pin.GetComponent()
-        current_source.negative_node.node_pins = pos_pin
+        current_source.negative_node.node_pins = neg_pin
         return self._create_terminal_on_pins(current_source)
 
     @aedt_exception_handler


### PR DESCRIPTION
Duplicate GND pin groups were created when there were two positive pin groups on the same device.
It was because the positive pins were assigned to the negative node.
Fix #428 .