### PR TITLE
Remove the PDSHole class duplicate and use the outter one.

### DIFF
--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -1586,7 +1586,7 @@ class Padstack(object):
             if value:
                 self._pad = value
             else:
-                self._pad = self.PDSHole(holetype="None", sizes=[])
+                self._pad = Padstack.PDSHole(holetype="None", sizes=[])
 
         @property
         def antipad(self):
@@ -1598,7 +1598,7 @@ class Padstack(object):
             if value:
                 self._antipad = value
             else:
-                self._antipad = self.PDSHole(holetype="None", sizes=[])
+                self._antipad = Padstack.PDSHole(holetype="None", sizes=[])
 
         @property
         def thermal(self):
@@ -1610,32 +1610,8 @@ class Padstack(object):
             if value:
                 self._thermal = value
             else:
-                self._thermal = self.PDSHole(holetype="None", sizes=[])
+                self._thermal = Padstack.PDSHole(holetype="None", sizes=[])
 
-        class PDSHole:
-            """Properties of a padstack hole.
-
-            Parameters
-            ----------
-            holetype : str, optional
-                Type of the hole. The default is ``Circular``.
-            sizes : str, optional
-                Diameter of the hole with units. The default is ``"1mm"``.
-            xpos : str, optional
-                The default is ``"0mm"``.
-            ypos : str, optional
-                The default is ``"0mm"``.
-            rot : str, otpional
-                Rotation in degrees. The default is ``"0deg"``.
-
-            """
-
-            def __init__(self, holetype="Cir", sizes=["1mm"], xpos="0mm", ypos="0mm", rot="0deg"):
-                self.shape = holetype
-                self.sizes = sizes
-                self.x = xpos
-                self.y = ypos
-                self.rot = rot
 
     @property
     def pads_args(self):

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -1612,7 +1612,6 @@ class Padstack(object):
             else:
                 self._thermal = Padstack.PDSHole(holetype="None", sizes=[])
 
-
     @property
     def pads_args(self):
         """Pad properties."""


### PR DESCRIPTION
The inner class `PDSHole` in the outer class `PDSLayer `is not necessary anymore. We can use the `PDSHole `class in `Padstack `directly.

Fix #574.