### PR TITLE
Fix/issue 609

### DIFF
--- a/_unittest/test_09_VariableManager.py
+++ b/_unittest/test_09_VariableManager.py
@@ -4,6 +4,7 @@ import gc
 import math
 
 from pyaedt.application.Variables import Variable
+from pyaedt.application.Variables import decompose_variable_value
 from pyaedt.generic.filesystem import Scratch
 from pyaedt.generic.general_methods import isclose
 from pyaedt.hfss import Hfss
@@ -333,3 +334,13 @@ class TestClass:
 
     def test_11_delete_variable(self):
         assert self.aedtapp.variable_manager.delete_variable("Var1")
+
+    def test_12_decompose_variable_value(self):
+        assert decompose_variable_value("3.123456m") == (3.123456, "m")
+        assert decompose_variable_value("3m") == (3, "m")
+        assert decompose_variable_value("3") == (3, "")
+        assert decompose_variable_value("3.") == (3., "")
+        assert decompose_variable_value("3.123456m2") == (3.123456, "m2")
+        assert decompose_variable_value("3.123456Nm-2") == (3.123456, "Nm-2")
+        assert decompose_variable_value("3.123456kg2m2") == (3.123456, "kg2m2")
+        assert decompose_variable_value("3.123456kgm2") == (3.123456, "kgm2")

--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -269,22 +269,17 @@ def decompose_variable_value(variable_value, full_variables={}):
             float_value = float(variable_value)
         except ValueError:
             # search for a valid units string at the end of the variable_value
-            if full_variables=={}:
-                value = re.findall(r"[0-9.]+", variable_value)[0]
-                float_value = float(value)
-                units = variable_value.replace(value,"")
-            else:
-                units = _find_units_in_dependent_variables(variable_value, full_variables)
+            loc = re.search("[a-z_A-Z]+", variable_value)
+            units = _find_units_in_dependent_variables(variable_value, full_variables)
 
-            # if loc:
-            #     loc_units = loc.span()[0]
-            #     extract_units = variable_value[loc_units:]
-            #     if unit_system(extract_units):
-            #         try:
-            #             float_value = float(variable_value[0:loc_units])
-            #             units = extract_units
-            #         except ValueError:
-            #             float_value = variable_value
+            if loc:
+                loc_units = loc.span()[0]
+                extract_units = variable_value[loc_units:]
+                try:
+                    float_value = float(variable_value[0:loc_units])
+                    units = extract_units
+                except ValueError:
+                    float_value = variable_value
 
     return float_value, units
 

--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -268,7 +268,8 @@ def decompose_variable_value(variable_value, full_variables={}):
         except ValueError:
             # search for a valid units string at the end of the variable_value
             loc = re.search("[a-z_A-Z]+$", variable_value)
-            units = _find_units_in_dependent_variables(variable_value, full_variables)
+            units = variable_value.replace(re.findall(r"[0-9.]+", variable_value)[0],"")
+            #units = _find_units_in_dependent_variables(variable_value, full_variables)
 
             if loc:
                 loc_units = loc.span()[0]

--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -251,6 +251,7 @@ def decompose_variable_value(variable_value, full_variables={}):
     ----------
     variable_value : float
     full_variables : dict
+
     Returns
     -------
 
@@ -267,19 +268,20 @@ def decompose_variable_value(variable_value, full_variables={}):
             float_value = float(variable_value)
         except ValueError:
             # search for a valid units string at the end of the variable_value
-            loc = re.search("[a-z_A-Z]+$", variable_value)
-            units = variable_value.replace(re.findall(r"[0-9.]+", variable_value)[0],"")
-            #units = _find_units_in_dependent_variables(variable_value, full_variables)
+            if full_variables=={}:
+                float_value = re.findall(r"[0-9.]+", variable_value)[0]
+                units = variable_value.replace(float_value,"")
+            units = _find_units_in_dependent_variables(variable_value, full_variables)
 
-            if loc:
-                loc_units = loc.span()[0]
-                extract_units = variable_value[loc_units:]
-                if unit_system(extract_units):
-                    try:
-                        float_value = float(variable_value[0:loc_units])
-                        units = extract_units
-                    except ValueError:
-                        float_value = variable_value
+            # if loc:
+            #     loc_units = loc.span()[0]
+            #     extract_units = variable_value[loc_units:]
+            #     if unit_system(extract_units):
+            #         try:
+            #             float_value = float(variable_value[0:loc_units])
+            #             units = extract_units
+            #         except ValueError:
+            #             float_value = variable_value
 
     return float_value, units
 

--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -254,7 +254,8 @@ def decompose_variable_value(variable_value, full_variables={}):
 
     Returns
     -------
-
+    tuples
+        tuples made of the float value of the variable and the units exposed as a string.
     """
     # set default return values - then check for valid units
     float_value = variable_value
@@ -269,9 +270,11 @@ def decompose_variable_value(variable_value, full_variables={}):
         except ValueError:
             # search for a valid units string at the end of the variable_value
             if full_variables=={}:
-                float_value = re.findall(r"[0-9.]+", variable_value)[0]
-                units = variable_value.replace(float_value,"")
-            units = _find_units_in_dependent_variables(variable_value, full_variables)
+                value = re.findall(r"[0-9.]+", variable_value)[0]
+                float_value = float(value)
+                units = variable_value.replace(value,"")
+            else:
+                units = _find_units_in_dependent_variables(variable_value, full_variables)
 
             # if loc:
             #     loc_units = loc.span()[0]


### PR DESCRIPTION
Fix the issue #609 .
The variable decomposition was not working for units including both letters and digits such as 'm2'.

With the new modification we get the index of the first letter in the `variable `string and then we split it to get the unit and the value.