### PR TITLE
Set the encoding to 'utf-8'.

### DIFF
--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -440,7 +440,7 @@ class Desktop:
 
         p = subprocess.Popen('tasklist /FI "IMAGENAME eq {}" /v'.format(process), stdout=subprocess.PIPE)
         result = p.communicate()
-        output = result[0].decode(encoding=sys.stdout.encoding, errors='ignore').split(os.linesep)
+        output = result[0].decode(encoding="utf-8", errors='ignore').split(os.linesep)
 
         pattern = r"(?i)^(?:{})\s+?(\d+)\s+.+[\s|\\](?:{})\s+".format(process, username)
         for l in output:


### PR DESCRIPTION
Encoding must be set to utf-8 because the full documentation will fail on the build agent otherwise.

Fix issue #623 .