### PR TITLE
Add Icepak exception in HPC settings

### DIFF
--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -1327,6 +1327,8 @@ class Analysis(Design, object):
                 update_hpc_option(target_name, "NumEngines", num_tasks, False)
             update_hpc_option(target_name, "ConfigName", config_name, True)
             update_hpc_option(target_name, "DesignType", self.design_type, True)
+            if self.design_type == "Icepak":
+                update_hpc_option(target_name, "UseAutoSettings", self.design_type, False)
             try:
                 self._desktop.SetRegistryFromFile(target_name)
                 self.set_registry_key(r"Desktop/ActiveDSOConfigurations/" + self.design_type, config_name)


### PR DESCRIPTION
If Icepak Design then Auto Setup must be Disabled. 