### PR TITLE
All sweeptype default parameter value now starts with lower case.

### DIFF
--- a/pyaedt/hfss3dlayout.py
+++ b/pyaedt/hfss3dlayout.py
@@ -660,7 +660,7 @@ class Hfss3dLayout(FieldAnalysis3DLayout):
         freqstop,
         num_of_freq_points,
         sweepname=None,
-        sweeptype="interpolating",
+        sweeptype="Interpolating",
         interpolation_tol_percent=0.5,
         interpolation_max_solutions=250,
         save_fields=True,


### PR DESCRIPTION
Fix issue #77 .

It is a minor typo modification. It is without impact because it only concerns a default value string in a method's signature that has been deprecated.
All other issues (upper case uniformity across the entire package) have been resolved along the way.

@maxcapodi78 I checked that the `sweeptype` argument default values were upper case in different files.
