### PR TITLE
Rename 'setUpClass' as 'setup_class' and 'tearDownClass' as 'teardown_class'.

### DIFF
--- a/_unittest_ironpython/generate_tests.py
+++ b/_unittest_ironpython/generate_tests.py
@@ -1,5 +1,5 @@
-""" Generate automatically launch files for all pytest test modules with filenames startign with "_test"
-This overwrites any existign files that may have been modified
+""" Generate automatically launch files for all pytest test modules with filenames starting with "_test".
+This overwrites any existing file that may have been modified.
 """
 import os
 

--- a/_unittest_ironpython/generate_tests.py
+++ b/_unittest_ironpython/generate_tests.py
@@ -15,11 +15,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 test_names = [name for name in dir(test_obj) if name.startswith(test_filter)]

--- a/_unittest_ironpython/test_00_EDB.py
+++ b/_unittest_ironpython/test_00_EDB.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_01_Design.py
+++ b/_unittest_ironpython/test_01_Design.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_02_2D_modeler.py
+++ b/_unittest_ironpython/test_02_2D_modeler.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
     def tearDown(self):

--- a/_unittest_ironpython/test_02_3D_modeler.py
+++ b/_unittest_ironpython/test_02_3D_modeler.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_03_Materials.py
+++ b/_unittest_ironpython/test_03_Materials.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_04_GeometryOperators.py
+++ b/_unittest_ironpython/test_04_GeometryOperators.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_05_Mesh.py
+++ b/_unittest_ironpython/test_05_Mesh.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_06_MessageManager.py
+++ b/_unittest_ironpython/test_06_MessageManager.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_07_Object3D.py
+++ b/_unittest_ironpython/test_07_Object3D.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_08_Primitives3D.py
+++ b/_unittest_ironpython/test_08_Primitives3D.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_09_Primitives2D.py
+++ b/_unittest_ironpython/test_09_Primitives2D.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_09_VariableManager.py
+++ b/_unittest_ironpython/test_09_VariableManager.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_10_downloads.py
+++ b/_unittest_ironpython/test_10_downloads.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_11_Setup.py
+++ b/_unittest_ironpython/test_11_Setup.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_12_PostProcessing.py
+++ b/_unittest_ironpython/test_12_PostProcessing.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_13_LoadAEDTFile.py
+++ b/_unittest_ironpython/test_13_LoadAEDTFile.py
@@ -11,11 +11,11 @@ mymodule = __import__("_unittest." + test_name, fromlist=fromlist)
 def make_test_sequence_functions_generate_class(test_obj):
     class TestSequenceFunctionsGenerate(PytestMockup):
         @classmethod
-        def setUpClass(cls):
+        def setup_class(cls):
             test_obj.setup_class()
 
         @classmethod
-        def tearDownClass(cls):
+        def teardown_class(cls):
             test_obj.teardown_class()
 
     return TestSequenceFunctionsGenerate

--- a/_unittest_ironpython/test_14_AedtLogger.py
+++ b/_unittest_ironpython/test_14_AedtLogger.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_20_HFSS.py
+++ b/_unittest_ironpython/test_20_HFSS.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_21_Circuit.py
+++ b/_unittest_ironpython/test_21_Circuit.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_22_Circuit_DynamicLink.py
+++ b/_unittest_ironpython/test_22_Circuit_DynamicLink.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_26_emit.py
+++ b/_unittest_ironpython/test_26_emit.py
@@ -10,11 +10,11 @@ if os.name != "posix":
 
     class TestSequenceFunctionsGenerate(PytestMockup):
         @classmethod
-        def setUpClass(cls):
+        def setup_class(cls):
             test_obj.setup_class()
 
         @classmethod
-        def tearDownClass(cls):
+        def teardown_class(cls):
             test_obj.teardown_class()
 
     test_names = [name for name in dir(test_obj) if name.startswith(test_filter)]

--- a/_unittest_ironpython/test_27_Maxwell2D.py
+++ b/_unittest_ironpython/test_27_Maxwell2D.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_28_Maxwell3D.py
+++ b/_unittest_ironpython/test_28_Maxwell3D.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_29_Mechanical.py
+++ b/_unittest_ironpython/test_29_Mechanical.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_30_Q2D.py
+++ b/_unittest_ironpython/test_30_Q2D.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_31_Q3D.py
+++ b/_unittest_ironpython/test_31_Q3D.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_32_RMxprt.py
+++ b/_unittest_ironpython/test_32_RMxprt.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_34_Simplorer.py
+++ b/_unittest_ironpython/test_34_Simplorer.py
@@ -10,11 +10,11 @@ if os.name != "posix":
 
     class TestSequenceFunctionsGenerate(PytestMockup):
         @classmethod
-        def setUpClass(cls):
+        def setup_class(cls):
             test_obj.setup_class()
 
         @classmethod
-        def tearDownClass(cls):
+        def teardown_class(cls):
             test_obj.teardown_class()
 
     test_names = [name for name in dir(test_obj) if name.startswith(test_filter)]

--- a/_unittest_ironpython/test_40_3dlayout_edb.py
+++ b/_unittest_ironpython/test_40_3dlayout_edb.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_41_3dlayout_modeler.py
+++ b/_unittest_ironpython/test_41_3dlayout_modeler.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_97_SBR.py
+++ b/_unittest_ironpython/test_97_SBR.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 

--- a/_unittest_ironpython/test_98_Icepak.py
+++ b/_unittest_ironpython/test_98_Icepak.py
@@ -10,11 +10,11 @@ test_obj = mymodule.TestClass()
 
 class TestSequenceFunctionsGenerate(PytestMockup):
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         test_obj.setup_class()
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         test_obj.teardown_class()
 
 


### PR DESCRIPTION
In the _unittest_ironpython folder I renamed 'setUpClass' as 'setup_class' and 'tearDownClass' as 'teardown_class'.
All methods, class methods or instance methods must follow the snake_case convention.
Fix issue #689 .