### PR TITLE
Expose odesktop property from Design class.

### DIFF
--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
+from pyaedt.generic.general_methods import is_ironpython
+
 test_project_name = "Coax_HFSS"
 example_project = os.path.join(local_path, "example_models", test_project_name + ".aedt")
 
@@ -236,5 +238,7 @@ class TestClass:
         assert self.aedtapp.omaterial_manager
 
     def test_27_odesktop(self):
-        print(type(self.aedtapp.odesktop))
-        assert str(type(self.aedtapp.odesktop)) == "<class 'win32com.client.CDispatch'>"
+        if is_ironpython:
+            assert str(type(self.aedtapp.odesktop)) == "<type 'ADesktopWrapper'>"
+        else:
+            assert str(type(self.aedtapp.odesktop)) == "<class 'win32com.client.CDispatch'>"

--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -236,4 +236,5 @@ class TestClass:
         assert self.aedtapp.omaterial_manager
 
     def test_27_odesktop(self):
+        print(type(self.aedtapp.odesktop))
         assert str(type(self.aedtapp.odesktop)) == "<class 'win32com.client.CDispatch'>"

--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -230,3 +230,6 @@ class TestClass:
 
     def test_25_change_registry_from_file(self):
         assert self.aedtapp.set_registry_from_file(os.path.join(local_path, "example_models", "Test.acf"))
+
+    def test_27_odesktop(self):
+        assert self.aedtapp.odesktop

--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -236,4 +236,4 @@ class TestClass:
         assert self.aedtapp.omaterial_manager
 
     def test_27_odesktop(self):
-        assert self.aedtapp.odesktop
+        assert str(type(self.aedtapp.odesktop)) == "<class 'win32com.client.CDispatch'>"

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -573,7 +573,7 @@ class Design(object):
         self._desktop = main_module.oDesktop
         self._desktop_install_dir = main_module.sDesktopinstallDirectory
         self._messenger = self._logger._messenger
-        self._aedt_version = self.odesktop.GetVersion()[0:6]
+        self._aedt_version = self._desktop.GetVersion()[0:6]
 
         if solution_type:
             assert (
@@ -1214,7 +1214,7 @@ class Design(object):
             AEDT installation directory.
 
         """
-        return self.odesktop_install_dir
+        return self._desktop_install_dir
 
     @aedt_exception_handler
     def export_profile(self, setup_name, variation_string="", file_path=None):

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -593,7 +593,18 @@ class Design(object):
 
     @property
     def odesktop(self):
-        """Desktop instance containing all projects and designs."""
+        """Desktop instance containing all projects and designs.
+        
+        
+        Examples
+        --------
+        Get the COM object representing the desktop.
+
+        >>> from pyaedt import Hfss
+        >>> hfss = Hfss()
+        >>> hfss.odesktop
+        <class 'win32com.client.CDispatch'>
+        """
         return self._desktop
 
     @property

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -594,8 +594,7 @@ class Design(object):
     @property
     def odesktop(self):
         """Desktop instance containing all projects and designs.
-        
-        
+
         Examples
         --------
         Get the COM object representing the desktop.

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -595,6 +595,7 @@ class Design(object):
 
     @property
     def odesktop(self):
+        """Desktop instance containing all projects and designs."""
         return self._desktop
 
     @property


### PR DESCRIPTION
Expose `odesktop` through a read-only property from the `Design`.
Use the `odesktop` accessor instead of the private member. `_desktop`.
Fix #694 