### PR TITLE
Restore broken examples because of a missing space.

### DIFF
--- a/pyaedt/modules/LayerStackup.py
+++ b/pyaedt/modules/LayerStackup.py
@@ -92,9 +92,9 @@ class Layer(object):
 
     Examples
     --------
-    >>>from pyaedt import Hfss3dLayout
-    >>>app = Hfss3dLayout()
-    >>>layers = app.modeler.primitives.layers["Top"]
+    >>> from pyaedt import Hfss3dLayout
+    >>> app = Hfss3dLayout()
+    >>> layers = app.modeler.primitives.layers["Top"]
     """
 
     def __init__(self, app, layertype="signal", negative=False):
@@ -573,9 +573,9 @@ class Layers(object):
 
     Examples
     --------
-    >>>from pyaedt import Hfss3dLayout
-    >>>app = Hfss3dLayout()
-    >>>layers = app.modeler.primitives.layers
+    >>> from pyaedt import Hfss3dLayout
+    >>> app = Hfss3dLayout()
+    >>> layers = app.modeler.primitives.layers
     """
 
     def __init__(self, modeler, roughnessunits="um"):

--- a/pyaedt/modules/Material.py
+++ b/pyaedt/modules/Material.py
@@ -216,9 +216,9 @@ class MatProperty(object):
 
     Examples
     --------
-    >>>from pyaedt import Hfss
-    >>>app = Hfss()
-    >>>matproperty = app.materials["copper"].conductivity
+    >>> from pyaedt import Hfss
+    >>> app = Hfss()
+    >>> matproperty = app.materials["copper"].conductivity
     """
 
     def __init__(self, material, name, val=None, thermalmodifier=None):
@@ -878,9 +878,9 @@ class Material(CommonMaterial, object):
 
     Examples
     --------
-    >>>from pyaedt import Hfss
-    >>>app = Hfss()
-    >>>material = app.materials["copper"]
+    >>> from pyaedt import Hfss
+    >>> app = Hfss()
+    >>> material = app.materials["copper"]
     """
 
     def __init__(self, materiallib, name, props=None):

--- a/pyaedt/modules/MaterialLib.py
+++ b/pyaedt/modules/MaterialLib.py
@@ -23,9 +23,9 @@ class Materials(object):
 
     Examples
     --------
-    >>>from pyaedt import Hfss
-    >>>app = Hfss()
-    >>>materials = app.materials
+    >>> from pyaedt import Hfss
+    >>> app = Hfss()
+    >>> materials = app.materials
     """
 
     def __init__(self, app):
@@ -484,7 +484,7 @@ class Materials(object):
         Returns
         -------
         list
-            List of dielctrics in the material database.
+            List of dielectrics in the material database.
 
         """
         data = []


### PR DESCRIPTION
Fix broken examples to improve their display in the online generated documentation.

Fix #700 