### PR TITLE
Check the AEDT version specified by the user when launching the Desktop.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ To post issues, questions, and code, go to `PyAEDT Issues
 Dependencies
 ------------
 To run PyAEDT, you must have a local licenced copy of AEDT.
-PyAEDT supports AEDT versions 2021 R1 or later.
+PyAEDT supports AEDT versions 2021 R1 or newer.
 
 Student Version
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ To post issues, questions, and code, go to `PyAEDT Issues
 Dependencies
 ------------
 To run PyAEDT, you must have a local licenced copy of AEDT.
-PyAEDT supports AEDT versions prior to and including 2021 R2.
+PyAEDT supports AEDT versions 2021 R1 or later.
 
 Student Version
 ---------------

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -403,7 +403,7 @@ class Desktop:
     def _set_version(self, specified_version, student_version):
         version_student = False
         if specified_version:
-            if int(str(specified_version).split(".")[0])<2021:
+            if int(str(specified_version).split(".")[0]) < 2021:
                 raise ValueError("PyAEDT supports AEDT versions 2021 R1 and newers.")
             if student_version:
                 specified_version += "SV"

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -403,6 +403,8 @@ class Desktop:
     def _set_version(self, specified_version, student_version):
         version_student = False
         if specified_version:
+            if int(str(specified_version).split(".")[0])<2021:
+                raise ValueError("PyAEDT supports AEDT versions 2021 R1 and newers.")
             if student_version:
                 specified_version += "SV"
                 version_student = True

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -405,7 +405,10 @@ class Desktop:
         if specified_version:
             if float(specified_version) < 2021:
                 if float(specified_version) < 2019:
-                    warnings.warn("PyAEDT have limited capabilities when used with an AEDT version older than 2021 R1.")
+                    warnings.warn(
+                        """PyAEDT have limited capabilities when used with an AEDT version older than 2021 R1.
+                        PyAEDT officially supports AEDT versions 2021 R1 and newers."""
+                    )
                 else:
                     raise ValueError("PyAEDT supports AEDT versions 2021 R1 and newers.")
             if student_version:

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -403,8 +403,11 @@ class Desktop:
     def _set_version(self, specified_version, student_version):
         version_student = False
         if specified_version:
-            if int(str(specified_version).split(".")[0]) < 2021:
-                raise ValueError("PyAEDT supports AEDT versions 2021 R1 and newers.")
+            if float(specified_version) < 2021:
+                if float(specified_version) < 2019:
+                    warnings.warn("PyAEDT have limited capabilities when used with an AEDT version older than 2021 R1.")
+                else:
+                    raise ValueError("PyAEDT supports AEDT versions 2021 R1 and newers.")
             if student_version:
                 specified_version += "SV"
                 version_student = True

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -405,12 +405,12 @@ class Desktop:
         if specified_version:
             if float(specified_version) < 2021:
                 if float(specified_version) < 2019:
+                    raise ValueError("PyAEDT supports AEDT versions 2021 R1 and newers.")
+                else:
                     warnings.warn(
                         """PyAEDT have limited capabilities when used with an AEDT version older than 2021 R1.
                         PyAEDT officially supports AEDT versions 2021 R1 and newers."""
                     )
-                else:
-                    raise ValueError("PyAEDT supports AEDT versions 2021 R1 and newers.")
             if student_version:
                 specified_version += "SV"
                 version_student = True


### PR DESCRIPTION
Raise an exception if the version specified is older than 2021.

Fix #703 