### PR TITLE
Correct the add_range() method for sweep "LogScale" subrange.

### DIFF
--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1248,7 +1248,7 @@ class SweepHFSS(object):
         ----------
         rangetype : str
             Type of the subrange. Options are ``"LinearCount"``,
-            ``"LinearStep"``, ``"LogScale"``, and ``"SinglePoints"``.
+            ``"LinearStep"``, ``"LogScale"`` and ``"SinglePoints"``.
         start : float
             Starting frequency.
         end : float, optional
@@ -1280,7 +1280,7 @@ class SweepHFSS(object):
             range["RangeEnd"] = str(end) + unit
             range["RangeStep"] = str(count) + unit
         elif rangetype == "LogScale":
-            range["RangeEnd"] = end
+            range["RangeEnd"] = str(end) + unit
             range["RangeCount"] = self.props["RangeCount"]
             range["RangeSamples"] = count
         elif rangetype == "SinglePoints":

--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1287,6 +1287,7 @@ class SweepHFSS(object):
             range["RangeEnd"] = str(start) + unit
             range["SaveSingleField"] = save_single_fields
         self.props["SweepRanges"]["Subrange"].append(range)
+        return True
 
     @aedt_exception_handler
     def create(self):


### PR DESCRIPTION
In the `range` dictionary, correct the `RangeEnd` value to be a string and not a float.

Return `True` at the end of the method `add_subrange`.

Fix #707 .