### PR TITLE
Add an example of how to add multiple sweep range.

### DIFF
--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1266,6 +1266,16 @@ class SweepHFSS(object):
         bool
             ``True`` when successful, ``False`` when failed.
 
+        Example
+        -------
+
+        setup = self.aedtapp.create_setup(setupname="MySetup")
+        sweep = setup.add_sweep()
+        sweep.change_type("Interpolating")
+        sweep.change_range("LinearStep", 1.1, 2.1, 0.4, "GHz")
+        sweep.add_subrange("LinearCount", 1, 1.5, 3, "MHz")
+        sweep.add_subrange("LogScale", 1.1, 1.1, "GHz")
+
         """
         if rangetype == "LinearCount" or rangetype == "LinearStep" or rangetype == "LogScale":
             if not end or not count:

--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1266,8 +1266,8 @@ class SweepHFSS(object):
         bool
             ``True`` when successful, ``False`` when failed.
 
-        Example
-        -------
+        Examples
+        --------
         Create a setup in an HFSS design and add multiple sweep ranges.
 
         >>> setup = hfss.create_setup(setupname="MySetup")

--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1268,13 +1268,14 @@ class SweepHFSS(object):
 
         Example
         -------
+        Create a setup in an HFSS design and add multiple sweep ranges.
 
-        setup = self.aedtapp.create_setup(setupname="MySetup")
-        sweep = setup.add_sweep()
-        sweep.change_type("Interpolating")
-        sweep.change_range("LinearStep", 1.1, 2.1, 0.4, "GHz")
-        sweep.add_subrange("LinearCount", 1, 1.5, 3, "MHz")
-        sweep.add_subrange("LogScale", 1.1, 1.1, "GHz")
+        >>> setup = hfss.create_setup(setupname="MySetup")
+        >>> sweep = setup.add_sweep()
+        >>> sweep.change_type("Interpolating")
+        >>> sweep.change_range("LinearStep", 1.1, 2.1, 0.4, "GHz")
+        >>> sweep.add_subrange("LinearCount", 1, 1.5, 5, "MHz")
+        >>> sweep.add_subrange("LogScale", 1, 3, 10, "GHz")
 
         """
         if rangetype == "LinearCount" or rangetype == "LinearStep" or rangetype == "LogScale":


### PR DESCRIPTION
Add an example in the `add_subrange()` method to demonstrate how to add multiple sweep range.

Fix #677 .