### PR TITLE
Handle vtk modules for the unit tests.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,6 +49,7 @@ jobs:
           pip install . --use-feature=in-tree-build
           pip install -r requirements_test.txt
           pip install pytest-azurepipelines
+          Copy-Item -Path "C:\actions-runner\opengl32.dll" -Destination "testenv\Lib\site-packages\vtkmodules" -Force
           mkdir tmp
           cd tmp
           python -c "import pyaedt; print('Imported pyaedt')"


### PR DESCRIPTION
Copy `opengl32.dll` into `vtkmodules` folder in the `testenv`.