### PR TITLE
Fix, port renorm option is respected also in Driven Terminal

### DIFF
--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -90,7 +90,7 @@ class TestClass:
         )
         assert port.name == "sheet1_Port"
         assert port.name in [i.name for i in self.aedtapp.boundaries]
-        assert port.props['RenormalizeAllTerminals'] is False
+        assert port.props["RenormalizeAllTerminals"] is False
 
         self.aedtapp.solution_type = "Modal"
         udp = self.aedtapp.modeler.Position(200, 0, 0)
@@ -98,7 +98,7 @@ class TestClass:
         port = self.aedtapp.create_wave_port_from_sheet(o6, 5, self.aedtapp.AxisDir.XPos, 40, 2, "sheet2_Port", True)
         assert port.name == "sheet2_Port"
         assert port.name in [i.name for i in self.aedtapp.boundaries]
-        assert port.props['RenormalizeAllTerminals'] is True
+        assert port.props["RenormalizeAllTerminals"] is True
 
         id6 = self.aedtapp.modeler.primitives.create_box([20, 20, 20], [10, 10, 2], matname="Copper", name="My_Box")
         id7 = self.aedtapp.modeler.primitives.create_box([20, 25, 30], [10, 2, 2], matname="Copper")

--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -86,16 +86,19 @@ class TestClass:
         o5 = self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1")
         self.aedtapp.solution_type = "Terminal"
         port = self.aedtapp.create_wave_port_from_sheet(
-            o5, 5, self.aedtapp.AxisDir.XNeg, 40, 2, "sheet1_Port", True, terminal_references=["outer"]
+            o5, 5, self.aedtapp.AxisDir.XNeg, 40, 2, "sheet1_Port", renorm=False, terminal_references=["outer"]
         )
         assert port.name == "sheet1_Port"
         assert port.name in [i.name for i in self.aedtapp.boundaries]
+        assert port.props['RenormalizeAllTerminals'] is False
+
         self.aedtapp.solution_type = "Modal"
         udp = self.aedtapp.modeler.Position(200, 0, 0)
         o6 = self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet2")
         port = self.aedtapp.create_wave_port_from_sheet(o6, 5, self.aedtapp.AxisDir.XPos, 40, 2, "sheet2_Port", True)
         assert port.name == "sheet2_Port"
         assert port.name in [i.name for i in self.aedtapp.boundaries]
+        assert port.props['RenormalizeAllTerminals'] is True
 
         id6 = self.aedtapp.modeler.primitives.create_box([20, 20, 20], [10, 10, 2], matname="Copper", name="My_Box")
         id7 = self.aedtapp.modeler.primitives.create_box([20, 25, 30], [10, 2, 2], matname="Copper")

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -299,7 +299,7 @@ class Hfss(FieldAnalysis3D, object):
         return self._create_boundary(portname, props, "LumpedPort")
 
     @aedt_exception_handler
-    def _create_port_terminal(self, objectname, int_line_stop, portname, iswaveport=False):
+    def _create_port_terminal(self, objectname, int_line_stop, portname, renorm=True, iswaveport=False):
         ref_conductors = self.modeler.convert_to_selections(int_line_stop, True)
         props = OrderedDict({})
         props["Faces"] = int(objectname)
@@ -338,7 +338,7 @@ class Hfss(FieldAnalysis3D, object):
             props["DoDeembed"] = True
             if iswaveport:
                 props["DeembedDist"] = "0mm"
-            props["RenormalizeAllTerminals"] = True
+            props["RenormalizeAllTerminals"] = renorm
             props["ShowReporterFilter"] = False
             props["UseAnalyticAlignment"] = False
             boundary.props = props
@@ -1596,7 +1596,7 @@ class Hfss(FieldAnalysis3D, object):
                 return self._create_lumped_driven(sheet_name, point0, point1, impedance, portname, renorm, deemb)
             else:
                 faces = self.modeler.primitives.get_object_faces(sheet_name)
-                return self._create_port_terminal(faces[0], endobject, portname, iswaveport=False)
+                return self._create_port_terminal(faces[0], endobject, portname, renorm=renorm, iswaveport=False)
         return False
 
     @aedt_exception_handler
@@ -2051,7 +2051,7 @@ class Hfss(FieldAnalysis3D, object):
                 )
             else:
                 faces = self.modeler.primitives.get_object_faces(sheet_name)
-                return self._create_port_terminal(faces[0], endobject, portname, iswaveport=True)
+                return self._create_port_terminal(faces[0], endobject, portname, renorm=renorm, iswaveport=True)
         return False
 
     @aedt_exception_handler
@@ -2480,7 +2480,7 @@ class Hfss(FieldAnalysis3D, object):
                 )
             else:
                 faces = self.modeler.primitives.get_object_faces(sheet_name)
-                return self._create_port_terminal(faces[0], endobject, portname, iswaveport=True)
+                return self._create_port_terminal(faces[0], endobject, portname, renorm=renorm, iswaveport=True)
         return False
 
     @aedt_exception_handler
@@ -3069,7 +3069,7 @@ class Hfss(FieldAnalysis3D, object):
             elif portname in self.modeler.get_excitations_name():
                 portname = generate_unique_name(portname)
             if terminal_references:
-                return self._create_port_terminal(faces, terminal_references, portname, iswaveport=True)
+                return self._create_port_terminal(faces, terminal_references, portname, renorm=renorm, iswaveport=True)
             else:
                 self.logger.error("Reference Conductors are missed.")
                 return False
@@ -3148,7 +3148,9 @@ class Hfss(FieldAnalysis3D, object):
                 if not faces:
                     self.logger.error("Wrong Input object. it has to be a face id or a sheet.")
                     return False
-                port = self._create_port_terminal(faces, reference_object_list, portname, iswaveport=False)
+                port = self._create_port_terminal(
+                    faces, reference_object_list, portname, renorm=renorm, iswaveport=False
+                )
 
             return port
         return False
@@ -3166,7 +3168,7 @@ class Hfss(FieldAnalysis3D, object):
             "`assig_voltage_source_to_sheet` is deprecated. Use `assign_voltage_source_to_sheet` instead.",
             DeprecationWarning,
         )
-        self.assign_voltage_source_to_sheet(sheet_name, axisdir=0, sourcename=None)
+        self.assign_voltage_source_to_sheet(sheet_name, axisdir, sourcename)
 
     @aedt_exception_handler
     def assign_voltage_source_to_sheet(self, sheet_name, axisdir=0, sourcename=None):

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -3459,8 +3459,8 @@ class GeometryModeler(Modeler, object):
         Returns
         -------
         list
-            List of six float values representing the bounding box
-            in the form ``[min_x, min_y, min_z, max_x, max_y, max_z]``.
+            List of three float values representing the bounding box dimensions
+            in the form ``[dim_x, dim_y, dim_z]``.
 
         References
         ----------


### PR DESCRIPTION
_create_port_terminal had no "renorm" parameter. Consequently the renorm option was ignored if the solution type was Driven Terminal.