### PR TITLE
Improve the test of create_component_from_pins()

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -453,8 +453,9 @@ class TestClass:
 
     def test_54_create_component_from_pins(self):
         pins = self.edbapp.core_components.get_pin_from_component("R13")
-        assert self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[0]
-        assert self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[1].GetName() == "newcomp"
+        component = self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[0]
+        assert component[0]
+        assert component[1].GetName() == "newcomp"
 
     def test_55b_create_cutout(self):
         output = os.path.join(self.local_scratch.path, "cutout.aedb")

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -453,7 +453,8 @@ class TestClass:
 
     def test_54_create_component_from_pins(self):
         pins = self.edbapp.core_components.get_pin_from_component("R13")
-        assert self.edbapp.core_components.create_component_from_pins(pins, "newcomp")
+        assert self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[0]
+        assert self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[1].Name == "Foo"
 
     def test_55b_create_cutout(self):
         output = os.path.join(self.local_scratch.path, "cutout.aedb")

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -453,7 +453,7 @@ class TestClass:
 
     def test_54_create_component_from_pins(self):
         pins = self.edbapp.core_components.get_pin_from_component("R13")
-        component = self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[0]
+        component = self.edbapp.core_components.create_component_from_pins(pins, "newcomp")
         assert component[0]
         assert component[1].GetName() == "newcomp"
 

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -454,7 +454,7 @@ class TestClass:
     def test_54_create_component_from_pins(self):
         pins = self.edbapp.core_components.get_pin_from_component("R13")
         assert self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[0]
-        assert self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[1].Name == "Foo"
+        assert self.edbapp.core_components.create_component_from_pins(pins, "newcomp")[1].GetName() == "newcomp"
 
     def test_55b_create_cutout(self):
         output = os.path.join(self.local_scratch.path, "cutout.aedb")


### PR DESCRIPTION
Improve the test and its assertions for the component creation.
Make sure that the tuple returned by `create_component_from_pins` is correct.
Fix #783 