### PR TITLE
Added new method for bounding box calculation

### DIFF
--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -481,7 +481,7 @@ class FieldAnalysis3D(Analysis, object):
         else:
             allObjects = object_list[:]
 
-        self.logger.info("Exporting {} objects".format(len(allObjects)))
+        self.logger.debug("Exporting {} objects".format(len(allObjects)))
         major = -1
         minor = -1
         # actual version supported by AEDT is 29.0

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -356,6 +356,7 @@ class Design(object):
             self._logger = main_module.aedt_logger
             self.release_on_exit = False
 
+        self.student_version = main_module.student_version
         self._mttime = None
         self._design_type = design_type
         self._desktop = main_module.oDesktop

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -285,6 +285,7 @@ class Desktop:
         self.close_on_exit = close_on_exit
         self._main.pyaedt_version = pyaedtversion
         self._main.interpreter_ver = _pythonver
+        self._main.student_version = student_version
         if is_ironpython:
             self._main.isoutsideDesktop = False
         else:
@@ -299,13 +300,13 @@ class Desktop:
         else:
             if "oDesktop" in dir(self._main):
                 del self._main.oDesktop
-            version_student, version_key, version = self._set_version(specified_version, student_version)
+            self._main.student_version, version_key, version = self._set_version(specified_version, student_version)
             if _com == "ironpython":
                 print("Launching PyAEDT outside Electronics Desktop with IronPython")
                 self._init_ironpython(non_graphical, new_desktop_session, version)
             elif _com == "pythonnet_v3":
                 print("Launching PyAEDT outside Electronics Desktop with CPython and Pythonnet")
-                self._init_cpython(non_graphical, new_desktop_session, version, student_version, version_key)
+                self._init_cpython(non_graphical, new_desktop_session, version, self._main.student_version, version_key)
             else:
                 oAnsoftApp = win32com.client.Dispatch(version)
                 self._main.oDesktop = oAnsoftApp.GetAppDesktop()
@@ -395,7 +396,7 @@ class Desktop:
         self._main.pyaedt_initialized = True
 
     def _set_version(self, specified_version, student_version):
-        version_student = False
+        student_version_flag = False
         if specified_version:
             if float(specified_version) < 2021:
                 if float(specified_version) < 2019:
@@ -407,22 +408,22 @@ class Desktop:
                     )
             if student_version:
                 specified_version += "SV"
-                version_student = True
+                student_version_flag = True
             assert specified_version in self.version_keys, "Specified version {} not known.".format(specified_version)
             version_key = specified_version
         else:
             if student_version and self.current_version_student:
                 version_key = self.current_version_student
-                version_student = True
+                student_version_flag = True
             else:
                 version_key = self.current_version
-                version_student = False
-        if student_version and version_student:
+                student_version_flag = False
+        if student_version and student_version_flag:
             version = "Ansoft.ElectronicsDesktop." + version_key[:-2]
         else:
             version = "Ansoft.ElectronicsDesktop." + version_key
         self._main.sDesktopinstallDirectory = os.getenv(self._version_ids[version_key])
-        return version_student, version_key, version
+        return student_version_flag, version_key, version
 
     def _init_ironpython(self, non_graphical, new_aedt_session, version):
         base_path = self._main.sDesktopinstallDirectory

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -780,7 +780,7 @@ class Object3d(object):
         >>> oEditor.GetModelBoundingBox
 
         """
-        tmp_path = os.path.expandvars('%temp%')
+        tmp_path = os.path.expandvars("%temp%")
         filename = os.path.join(tmp_path, self.name + ".sat")
 
         self._primitives._app.export_3d_model(self.name, tmp_path, ".sat", [self.name])
@@ -811,7 +811,7 @@ class Object3d(object):
         try:
             os.remove(filename)
         except:
-            print("ERROR: Cannot remove temp file.")
+            self.logger.warning("ERROR: Cannot remove temp file.")
         return bb
 
     @property

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -16,6 +16,7 @@ import random
 import string
 import math
 import os
+import re
 
 from pyaedt import aedt_exception_handler, _retry_ntimes
 from pyaedt.modeler.GeometryOperators import GeometryOperators
@@ -727,12 +728,11 @@ class Object3d(object):
         self._part_coordinate_system = None
         self._model = None
 
-    @property
-    def bounding_box(self):
-        """Bounding box of a part.
+    def _bounding_box_unmodel(self):
+        """Bounding box of a part, unmodel/undo method.
 
-        This is done by creating a new empty design, copying the object there, and getting the model bounding box. A
-        list of six 3D position vectors is returned.
+        This is done by setting all other objects as unmodel and getting the model bounding box.
+        Then an undo operation restore the design.
 
         Returns
         -------
@@ -740,35 +740,7 @@ class Object3d(object):
             List of six ``[x, y, z]`` positions of the bounding box containing
             Xmin, Ymin, Zmin, Xmax, Ymax, and Zmax values.
 
-        References
-        ----------
-
-        >>> oEditor.GetModelBoundingBox
-
         """
-        if self._primitives._app._aedt_version >= "2021.2":
-            model_obj = self._primitives._app.post.export_model_obj(
-                obj_list=[self.name], export_path=None, export_as_single_objects=True, air_objects=True
-            )
-            if model_obj:
-                x = []
-                y = []
-                z = []
-                with open(model_obj[0][0], "r") as f:
-                    lines = f.read().splitlines()
-                    for line in lines:
-                        l = line.split(" ")
-                        if l[0] and l[0] == "v" and len(l) > 3:
-                            x.append(float(l[1]))
-                            y.append(float(l[2]))
-                            z.append(float(l[3]))
-                bounds = [min(x), min(y), min(z), max(x), max(y), max(z)]
-                if os.path.exists(model_obj[0][0]):
-                    try:
-                        os.remove(model_obj[0][0])
-                    except:
-                        pass
-                return bounds
         objs_to_unmodel = [
             val.name for i, val in self._primitives.objects.items() if val.model and val.name != self.name
         ]
@@ -789,6 +761,84 @@ class Object3d(object):
             self._primitives._app.project_name, self._primitives._app.design_name, 1
         )
         return bounding
+
+    def _bounding_box_sat(self):
+        """Bounding box of a part.
+
+        This is done by exporting a part as a SAT file and reading the bounding box information from the SAT file.
+        A list of six 3D position vectors is returned.
+
+        Returns
+        -------
+        list of [list of float]
+            List of six ``[x, y, z]`` positions of the bounding box containing
+            Xmin, Ymin, Zmin, Xmax, Ymax, and Zmax values.
+
+        References
+        ----------
+
+        >>> oEditor.GetModelBoundingBox
+
+        """
+        tmp_path = os.path.expandvars('%temp%')
+        filename = os.path.join(tmp_path, self.name + ".sat")
+
+        self._primitives._app.export_3d_model(self.name, tmp_path, ".sat", [self.name])
+
+        if not os.path.isfile(filename):
+            raise Exception("Cannot export the ACIS SAT file for object {}".format(self.name))
+
+        with open(filename, "r") as fh:
+            temp = fh.read().splitlines()
+        all_lines = [s for s in temp if s.startswith("body ")]
+
+        bb = []
+        if len(all_lines) == 1:
+            line = all_lines[0]
+            pattern = r".+ (.+) (.+) (.+) (.+) (.+) (.+) #$"
+            m = re.search(pattern, line)
+            if m:
+                try:
+                    for i in range(1, 7):
+                        bb.append(float(m.group(i)))
+                except:
+                    raise Exception("WARNING: Error parsing the SAT file. Object " + str(self.name))
+            else:
+                raise Exception("WARNING: Error parsing the SAT file. Object " + str(self.name))
+        else:
+            raise Exception("WARNING: Error parsing the SAT file. Object " + str(self.name))
+
+        try:
+            os.remove(filename)
+        except:
+            print("ERROR: Cannot remove temp file.")
+        return bb
+
+    @property
+    def bounding_box(self):
+        """Bounding box of a part.
+
+        A list of six 3D position vectors is returned.
+
+        Returns
+        -------
+        list of [list of float]
+            List of six ``[x, y, z]`` positions of the bounding box containing
+            Xmin, Ymin, Zmin, Xmax, Ymax, and Zmax values.
+
+        References
+        ----------
+
+        >>> oEditor.GetModelBoundingBox
+
+        """
+        if not self._primitives._app.student_version:
+            try:
+                return self._bounding_box_sat()
+            except:
+                return self._bounding_box_unmodel()
+        else:
+            return self._bounding_box_unmodel()
 
     @property
     def bounding_dimension(self):


### PR DESCRIPTION
A new method to evaluate the object bounding box has been implemented. 
It exports the object as .sat file and reads the bounding box values from the .sat file. 
It is faster by a factor of 9 and safer because it does not change the object properties. 
The new implementation rolls back to the old method for the student version (no export available) and in case of errors.