### PR TITLE
Add the clear option when creating a new HFSS sweep subrange.

### DIFF
--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -233,9 +233,8 @@ class TestClass:
         assert setuptd.name not in self.aedtapp.existing_analysis_setups
 
     def test_06f_sweep_add_subrange(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 20], [10, 10, 5], "box_sweep", "Copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 30], [10, 10, 5], "box_sweep2", "copper")
-        box2.material_name = "Copper"
+        box_sweep = self.aedtapp.modeler.primitives.create_box([0, 0, 20], [10, 10, 5], "box_sweep", "Copper")
+        box_sweep2 = self.aedtapp.modeler.primitives.create_box([0, 0, 30], [10, 10, 5], "box_sweep2", "Copper")
         port = self.aedtapp.create_wave_port_between_objects(
             "box_sweep", "box_sweep2", self.aedtapp.AxisDir.XNeg, 50, 1, "WaveForSweep", False
         )
@@ -248,9 +247,8 @@ class TestClass:
         assert sweep.add_subrange("LogScale", 1, 3, 10, "GHz")
 
     def test_06g_sweep_clear_subrange(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 50], [10, 10, 5], "box_sweep3", "Copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 60], [10, 10, 5], "box_sweep4", "copper")
-        box2.material_name = "Copper"
+        box_sweep3 = self.aedtapp.modeler.primitives.create_box([0, 0, 50], [10, 10, 5], "box_sweep3", "Copper")
+        box_sweep4 = self.aedtapp.modeler.primitives.create_box([0, 0, 60], [10, 10, 5], "box_sweep4", "Copper")
         port = self.aedtapp.create_wave_port_between_objects(
             "box_sweep3", "box_sweep4", self.aedtapp.AxisDir.XNeg, 50, 1, "WaveForSweepWithClear", False
         )
@@ -269,6 +267,23 @@ class TestClass:
         assert sweep.props["RangeStart"] == "3GHz"
         assert sweep.props["RangeEnd"] == "8GHz"
         assert sweep.props["RangeCount"] == 10
+        assert sweep.add_subrange("LinearStep", 1.1, 2.1, 0.4, "GHz", clear=True)
+        assert sweep.props["RangeType"] == "LinearStep"
+        assert sweep.props["RangeStart"] == "1.1GHz"
+        assert sweep.props["RangeEnd"] == "2.1GHz"
+        assert sweep.props["RangeStep"] == "0.4GHz"
+        assert sweep.add_subrange("LogScale", 1, 3, 10, clear=True)
+        assert sweep.props["RangeType"] == "LogScale"
+        assert sweep.props["RangeStart"] == "1GHz"
+        assert sweep.props["RangeEnd"] == "3GHz"
+        assert sweep.props["RangeSamples"] == 10
+        sweep.props["Type"] = "Discrete"
+        sweep.update()
+        assert sweep.add_subrange("SinglePoints", 23, clear=True)
+        assert sweep.props["RangeType"] == "SinglePoints"
+        assert sweep.props["RangeStart"] == "23GHz"
+        assert sweep.props["RangeEnd"] == "23GHz"
+        assert sweep.props["SaveSingleField"] == False
 
     def test_06z_validate_setup(self):
         list, ok = self.aedtapp.validate_full_design(ports=7)

--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -232,8 +232,46 @@ class TestClass:
         assert self.aedtapp.delete_setup(setup_name)
         assert setuptd.name not in self.aedtapp.existing_analysis_setups
 
+    def test_06f_sweep_add_subrange(self):
+        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 20], [10, 10, 5], "box_sweep", "Copper")
+        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 30], [10, 10, 5], "box_sweep2", "copper")
+        box2.material_name = "Copper"
+        port = self.aedtapp.create_wave_port_between_objects(
+            "box_sweep", "box_sweep2", self.aedtapp.AxisDir.XNeg, 50, 1, "WaveForSweep", False
+        )
+        setup = self.aedtapp.create_setup(setupname="MySetupForSweep")
+        sweep = setup.add_sweep()
+        assert sweep.add_subrange("LinearCount", 1, 3, 10, "GHz")
+        assert sweep.add_subrange("LinearCount", 2, 4, 10, "GHz")
+        assert sweep.add_subrange("LinearStep", 1.1, 2.1, 0.4, "GHz")
+        assert sweep.add_subrange("LinearCount", 1, 1.5, 5, "MHz")
+        assert sweep.add_subrange("LogScale", 1, 3, 10, "GHz")
+
+    def test_06g_sweep_clear_subrange(self):
+        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 50], [10, 10, 5], "box_sweep3", "Copper")
+        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 60], [10, 10, 5], "box_sweep4", "copper")
+        box2.material_name = "Copper"
+        port = self.aedtapp.create_wave_port_between_objects(
+            "box_sweep3", "box_sweep4", self.aedtapp.AxisDir.XNeg, 50, 1, "WaveForSweepWithClear", False
+        )
+        setup = self.aedtapp.create_setup(setupname="MySetupClearSweep")
+        sweep = setup.add_sweep()
+        assert sweep.add_subrange("LinearCount", 1.1, 3.6, 10, "GHz", clear=True)
+        assert sweep.props["RangeType"] == "LinearCount"
+        assert sweep.props["RangeStart"] == "1.1GHz"
+        assert sweep.props["RangeEnd"] == "3.6GHz"
+        assert sweep.props["RangeCount"] == 10
+        assert sweep.add_subrange("LinearCount", 2, 5, 10, "GHz")
+        setup.update()
+        sweep.update()
+        assert sweep.add_subrange("LinearCount", 3, 8, 10, "GHz", clear=True)
+        assert sweep.props["RangeType"] == "LinearCount"
+        assert sweep.props["RangeStart"] == "3GHz"
+        assert sweep.props["RangeEnd"] == "8GHz"
+        assert sweep.props["RangeCount"] == 10
+
     def test_06z_validate_setup(self):
-        list, ok = self.aedtapp.validate_full_design(ports=5)
+        list, ok = self.aedtapp.validate_full_design(ports=7)
         assert ok
 
     def test_07_set_power(self):

--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1261,7 +1261,7 @@ class SweepHFSS(object):
             Whether to save the fields of the single point. The default is ``False``.
             Used only for ``rangetype="SinglePoints"``.
         clear : boolean, optional
-            If set to true, all other subranges will be suppressed except the current one under creation.
+            If set to ``True``, all other subranges will be suppressed except the current one under creation.
             Default value is ``False``.
 
         Returns

--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1241,7 +1241,7 @@ class SweepHFSS(object):
             self.props["SweepRanges"] = {"Subrange": []}
 
     @aedt_exception_handler
-    def add_subrange(self, rangetype, start, end=None, count=None, unit="GHz", save_single_fields=False):
+    def add_subrange(self, rangetype, start, end=None, count=None, unit="GHz", save_single_fields=False, clear=False):
         """Add a subrange to the sweep.
 
         Parameters
@@ -1260,6 +1260,9 @@ class SweepHFSS(object):
         save_single_fields : bool, optional
             Whether to save the fields of the single point. The default is ``False``.
             Used only for ``rangetype="SinglePoints"``.
+        clear : boolean, optional
+            If set to true, all other subranges will be suppressed except the current one under creation.
+            Default value is ``False``.
 
         Returns
         -------
@@ -1281,6 +1284,26 @@ class SweepHFSS(object):
         if rangetype == "LinearCount" or rangetype == "LinearStep" or rangetype == "LogScale":
             if not end or not count:
                 raise AttributeError("Parameters 'end' and 'count' must be present.")
+
+        if clear:
+            self.props["RangeType"] = rangetype
+            self.props["RangeStart"] = str(start) + unit
+            if rangetype == "LinearCount":
+                self.props["RangeEnd"] = str(end) + unit
+                self.props["RangeCount"] = count
+            elif rangetype == "LinearStep":
+                self.props["RangeEnd"] = str(end) + unit
+                self.props["RangeStep"] = str(count) + unit
+            elif rangetype == "LogScale":
+                self.props["RangeEnd"] = str(end) + unit
+                self.props["RangeSamples"] = count
+            elif rangetype == "SinglePoints":
+                self.props["RangeEnd"] = str(start) + unit
+                self.props["SaveSingleField"] = save_single_fields
+            self.props["SweepRanges"] = {"Subrange": []}
+            self.update()
+            return True
+
         range = {}
         range["RangeType"] = rangetype
         range["RangeStart"] = str(start) + unit

--- a/pyaedt/modules/SetupTemplates.py
+++ b/pyaedt/modules/SetupTemplates.py
@@ -1301,8 +1301,7 @@ class SweepHFSS(object):
                 self.props["RangeEnd"] = str(start) + unit
                 self.props["SaveSingleField"] = save_single_fields
             self.props["SweepRanges"] = {"Subrange": []}
-            self.update()
-            return True
+            return self.update()
 
         range = {}
         range["RangeType"] = rangetype
@@ -1321,7 +1320,8 @@ class SweepHFSS(object):
             range["RangeEnd"] = str(start) + unit
             range["SaveSingleField"] = save_single_fields
         self.props["SweepRanges"]["Subrange"].append(range)
-        return True
+
+        return self.update()
 
     @aedt_exception_handler
     def create(self):


### PR DESCRIPTION
From now on, `add_subrange()` has a new `clear` argument.
It is possible to reset/delete all the existing and default sweeps of the setup.
Some new unit tests were added for the `add_subrange()`.
Fix #743 .