### PR TITLE
Removed modeler.primitives from unit tests and examples as it is deprecated.

### DIFF
--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -177,7 +177,7 @@ def pyaedt_unittest_check_desktop_error(func):
         except Exception as e:
             pytest.exit("Desktop Crashed - Aborting the test!")
         args[0].cache.update()
-        # model_report = args[0].aedtapp.modeler.primitives.model_consistency_report
+        # model_report = args[0].aedtapp.modeler.model_consistency_report
         # assert not model_report["Missing Objects"]
         # assert not model_report["Non-Existent Objects"]
         assert args[0].cache.no_new_errors

--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -114,7 +114,7 @@ class TestClass:
 
     def test_09_set_objects_temperature(self):
         ambient_temp = 22
-        objects = [o for o in self.aedtapp.modeler.primitives.solid_names if self.aedtapp.modeler.primitives[o].model]
+        objects = [o for o in self.aedtapp.modeler.solid_names if self.aedtapp.modeler[o].model]
         assert self.aedtapp.modeler.set_objects_temperature(objects, ambient_temp=ambient_temp, create_project_var=True)
 
     def test_10_change_material_override(self):

--- a/_unittest/test_02_2D_modeler.py
+++ b/_unittest/test_02_2D_modeler.py
@@ -45,8 +45,8 @@ class TestClass(BasisTest):
         assert self.aedtapp.modeler._omaterial_manager
 
     def test_create_rectangle(self):
-        rect1 = self.aedtapp.modeler.primitives.create_rectangle([0, -2, -2], [3, 8])
-        rect2 = self.aedtapp.modeler.primitives.create_rectangle(
+        rect1 = self.aedtapp.modeler.create_rectangle([0, -2, -2], [3, 8])
+        rect2 = self.aedtapp.modeler.create_rectangle(
             position=[10, -2, -2], dimension_list=[3, 10], name="MyRectangle", matname="Copper"
         )
         assert rect1.solve_inside
@@ -67,8 +67,8 @@ class TestClass(BasisTest):
 
     def test_create_rectangle_rz(self):
         self.aedtapp.solution_type = "MagnetostaticZ"
-        rect1 = self.aedtapp.modeler.primitives.create_rectangle([1, 0, -2], [8, 3])
-        rect2 = self.aedtapp.modeler.primitives.create_rectangle(
+        rect1 = self.aedtapp.modeler.create_rectangle([1, 0, -2], [8, 3])
+        rect2 = self.aedtapp.modeler.create_rectangle(
             position=[10, 0, -2], dimension_list=[10, 3], name="MyRectangle", matname="Copper"
         )
         list_of_pos = [ver.position for ver in rect1.vertices]
@@ -78,8 +78,8 @@ class TestClass(BasisTest):
         assert sorted(list_of_pos) == [[10.0, 0.0, -2.0], [10.0, 0.0, 8.0], [13.0, 0.0, -2.0], [13.0, 0.0, 8.0]]
 
     def test_create_circle(self):
-        circle1 = self.aedtapp.modeler.primitives.create_circle([0, -2, 0], 3)
-        circle2 = self.aedtapp.modeler.primitives.create_circle(
+        circle1 = self.aedtapp.modeler.create_circle([0, -2, 0], 3)
+        circle2 = self.aedtapp.modeler.create_circle(
             position=[0, -2, -2], radius=3, num_sides=6, name="MyCircle", matname="Copper"
         )
         assert circle1.solve_inside
@@ -93,8 +93,8 @@ class TestClass(BasisTest):
         assert isclose(circle1.faces[0].area, math.pi * 3.0 * 3.0)
 
     def test_create_ellipse(self):
-        ellipse1 = self.aedtapp.modeler.primitives.create_ellipse([0, -2, 0], 4.0, 0.2)
-        ellipse2 = self.aedtapp.modeler.primitives.create_ellipse(
+        ellipse1 = self.aedtapp.modeler.create_ellipse([0, -2, 0], 4.0, 0.2)
+        ellipse2 = self.aedtapp.modeler.create_ellipse(
             position=[0, -2, 0], major_radius=4.0, ratio=0.2, name="MyEllipse", matname="Copper"
         )
         assert ellipse1.solve_inside
@@ -108,8 +108,8 @@ class TestClass(BasisTest):
         assert isclose(ellipse2.faces[0].area, math.pi * 4.0 * 4.0 * 0.2)
 
     def test_create_regular_polygon(self):
-        pg1 = self.aedtapp.modeler.primitives.create_regular_polygon([0, 0, 0], [0, 2, 0])
-        pg2 = self.aedtapp.modeler.primitives.create_regular_polygon(
+        pg1 = self.aedtapp.modeler.create_regular_polygon([0, 0, 0], [0, 2, 0])
+        pg2 = self.aedtapp.modeler.create_regular_polygon(
             position=[0, 0, 0], start_point=[0, 2, 0], num_sides=3, name="MyPolygon", matname="Copper"
         )
         assert pg1.solve_inside
@@ -124,14 +124,14 @@ class TestClass(BasisTest):
 
     @pytest.mark.skipif(config["build_machine"] or is_ironpython, reason="Not running in ironpython")
     def test_plot(self):
-        self.aedtapp.modeler.primitives.create_regular_polygon([0, 0, 0], [0, 2, 0])
-        self.aedtapp.modeler.primitives.create_regular_polygon(
+        self.aedtapp.modeler.create_regular_polygon([0, 0, 0], [0, 2, 0])
+        self.aedtapp.modeler.create_regular_polygon(
             position=[0, 0, 0], start_point=[0, 2, 0], num_sides=3, name="MyPolygon", matname="Copper"
         )
         obj = self.aedtapp.plot(show=False, export_path=os.path.join(self.local_scratch.path, "image.jpg"))
         assert os.path.exists(obj.image_file)
 
     def test_edit_menu_commands(self):
-        rect1 = self.aedtapp.modeler.primitives.create_rectangle([1, 0, -2], [8, 3])
+        rect1 = self.aedtapp.modeler.create_rectangle([1, 0, -2], [8, 3])
         assert self.aedtapp.modeler.mirror(rect1, [1, 0, 0], [1, 0, 0])
         assert self.aedtapp.modeler.move(rect1, [1, 1, 0])

--- a/_unittest/test_02_3D_modeler.py
+++ b/_unittest/test_02_3D_modeler.py
@@ -13,27 +13,27 @@ class TestClass(BasisTest):
 
     def restore_model(self):
         for name in self.aedtapp.modeler.get_matched_object_name("outer*"):
-            self.aedtapp.modeler.primitives.delete(name)
-        outer = self.aedtapp.modeler.primitives.create_cylinder(
+            self.aedtapp.modeler.delete(name)
+        outer = self.aedtapp.modeler.create_cylinder(
             cs_axis="X", position=[0, 0, 0], radius=1, height=20, name="outer", matname="Aluminum"
         )
         for name in self.aedtapp.modeler.get_matched_object_name("Core*"):
-            self.aedtapp.modeler.primitives.delete(name)
-        core = self.aedtapp.modeler.primitives.create_cylinder(
+            self.aedtapp.modeler.delete(name)
+        core = self.aedtapp.modeler.create_cylinder(
             cs_axis="X", position=[0, 0, 0], radius=0.8, height=20, name="Core", matname="teflon_based"
         )
         for name in self.aedtapp.modeler.get_matched_object_name("inner*"):
-            self.aedtapp.modeler.primitives.delete(name)
-        inner = self.aedtapp.modeler.primitives.create_cylinder(
+            self.aedtapp.modeler.delete(name)
+        inner = self.aedtapp.modeler.create_cylinder(
             cs_axis="X", position=[0, 0, 0], radius=0.3, height=20, name="inner", matname="Aluminum"
         )
 
         for name in self.aedtapp.modeler.get_matched_object_name("Poly1*"):
-            self.aedtapp.modeler.primitives.delete(name)
+            self.aedtapp.modeler.delete(name)
         udp1 = [0, 0, 0]
         udp2 = [5, 0, 0]
         udp3 = [5, 5, 0]
-        self.aedtapp.modeler.primitives.create_polyline([udp1, udp2, udp3], name="Poly1", xsection_type="Rectangle")
+        self.aedtapp.modeler.create_polyline([udp1, udp2, udp3], name="Poly1", xsection_type="Rectangle")
 
         self.aedtapp.modeler.subtract(outer, core)
         self.aedtapp.modeler.subtract(core, inner)
@@ -62,7 +62,7 @@ class TestClass(BasisTest):
 
     @pyaedt_unittest_check_desktop_error
     def test_05_split(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([-10, -10, -10], [20, 20, 20], "box_to_split")
+        box1 = self.aedtapp.modeler.create_box([-10, -10, -10], [20, 20, 20], "box_to_split")
         assert self.aedtapp.modeler.split("box_to_split", 2)
 
     @pyaedt_unittest_check_desktop_error
@@ -102,9 +102,9 @@ class TestClass(BasisTest):
     @pyaedt_unittest_check_desktop_error
     def test_09_thicken_sheet(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        id5 = self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.XY, udp, 10, name="sheet1")
+        id5 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.XY, udp, 10, name="sheet1")
         udp = self.aedtapp.modeler.Position(100, 100, 100)
-        id6 = self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.XY, udp, 10, name="sheet2")
+        id6 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.XY, udp, 10, name="sheet2")
         status = self.aedtapp.modeler.thicken_sheet(id5, 3)
         assert status
         status = self.aedtapp.modeler.automatic_thicken_sheets(id6, 3, False)
@@ -125,21 +125,21 @@ class TestClass(BasisTest):
         assert self.aedtapp.modeler.rotate("Poly1", self.aedtapp.AXIS.X, 30)
 
     def test_14_subtract(self):
-        o1 = self.aedtapp.modeler.primitives["outer"].clone()
-        o2 = self.aedtapp.modeler.primitives["inner"].clone()
+        o1 = self.aedtapp.modeler["outer"].clone()
+        o2 = self.aedtapp.modeler["inner"].clone()
         assert self.aedtapp.modeler.subtract(o1, o2)
 
     def test_15_purge_history(self):
-        o1 = self.aedtapp.modeler.primitives["outer"].clone()
-        o2 = self.aedtapp.modeler.primitives["inner"].clone()
+        o1 = self.aedtapp.modeler["outer"].clone()
+        o2 = self.aedtapp.modeler["inner"].clone()
         assert self.aedtapp.modeler.purge_history([o1, o2])
 
     def test_16_get_model_bounding_box(self):
         assert len(self.aedtapp.modeler.get_model_bounding_box()) == 6
 
     def test_17_unite(self):
-        o1 = self.aedtapp.modeler.primitives["outer"].clone()
-        o2 = self.aedtapp.modeler.primitives["inner"].clone()
+        o1 = self.aedtapp.modeler["outer"].clone()
+        o2 = self.aedtapp.modeler["inner"].clone()
         assert self.aedtapp.modeler.unite([o1, o2])
 
     def test_18_chamfer(self):
@@ -153,21 +153,21 @@ class TestClass(BasisTest):
 
     def test_20_intersect(self):
         udp = [0, 0, 0]
-        o1 = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10], name="Rect1")
-        o2 = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.PLANE.XY, udp, [3, 12], name="Rect2")
+        o1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10], name="Rect1")
+        o2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [3, 12], name="Rect2")
         assert self.aedtapp.modeler.intersect([o1, o2])
 
     def test_21_connect(self):
         udp = [0, 0, 0]
-        id1 = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10])
+        id1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10])
         udp = self.aedtapp.modeler.Position(0, 0, 10)
-        id2 = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.PLANE.XY, udp, [-3, 10])
+        id2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [-3, 10])
         assert self.aedtapp.modeler.connect([id1, id2])
 
     def test_22_translate(self):
         udp = [0, 0, 0]
-        id1 = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10])
-        id2 = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.PLANE.XY, udp, [3, 12])
+        id1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [5, 10])
+        id2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, udp, [3, 12])
         udp2 = self.aedtapp.modeler.Position(0, 20, 5)
         assert self.aedtapp.modeler.translate([id1, id2], udp2)
 
@@ -178,7 +178,7 @@ class TestClass(BasisTest):
     def test_24_check_plane(self):
 
         udp = [0, 0, 0]
-        o1 = self.aedtapp.modeler.primitives.create_box(udp, [4, 5, 5])
+        o1 = self.aedtapp.modeler.create_box(udp, [4, 5, 5])
         plane = self.aedtapp.modeler.check_plane(o1.id, udp)
         planes = ["XY", "XZ", "YZ"]
         assert plane in planes
@@ -198,7 +198,7 @@ class TestClass(BasisTest):
         assert self.aedtapp.modeler.edit_region_dimensions([40, 30, 30, 50, 50, 100])
 
     def test_28_create_face_list(self):
-        fl = self.aedtapp.modeler.primitives.get_object_faces("Second_airbox")
+        fl = self.aedtapp.modeler.get_object_faces("Second_airbox")
         assert self.aedtapp.modeler.create_face_list(fl, "my_face_list")
 
     def test_28B_create_object_list(self):
@@ -233,7 +233,7 @@ class TestClass(BasisTest):
         assert self.aedtapp.modeler.set_object_model_state("Second_airbox", False)
 
     def test_33_duplicate_around_axis(self):
-        id1 = self.aedtapp.modeler.primitives.create_box([10, 10, 10], [4, 5, 5])
+        id1 = self.aedtapp.modeler.create_box([10, 10, 10], [4, 5, 5])
         axis = self.aedtapp.AXIS.X
         _, obj_list = self.aedtapp.modeler.duplicate_around_axis(
             id1, cs_axis=axis, angle="180deg", nclones=2, create_new_objects=False
@@ -329,30 +329,24 @@ class TestClass(BasisTest):
         self.aedtapp.modeler.set_working_coordinate_system("new1")
 
     def test_44_sweep_around_axis(self):
-        rect1 = self.aedtapp.modeler.primitives.create_rectangle(
-            self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_split"
-        )
+        rect1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_split")
         assert rect1.sweep_around_axis("Z", sweep_angle=360, draft_angle=0)
 
     def test_45_sweep_along_path(self):
         udp1 = [0, 0, 0]
         udp2 = [5, 0, 0]
-        path = self.aedtapp.modeler.primitives.create_polyline([udp1, udp2], name="Poly1")
-        rect1 = self.aedtapp.modeler.primitives.create_rectangle(
-            self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_sweep"
-        )
+        path = self.aedtapp.modeler.create_polyline([udp1, udp2], name="Poly1")
+        rect1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_sweep")
         assert rect1.sweep_along_path(path)
 
     def test_46_section_object(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([-10, -10, -10], [20, 20, 20], "box_to_split")
+        box1 = self.aedtapp.modeler.create_box([-10, -10, -10], [20, 20, 20], "box_to_split")
         assert self.aedtapp.modeler.section(box1, 0, create_new=True, section_cross_object=False)
         pass
 
     def test_47_sweep_along_vector(self):
         sweep_vector = [5, 0, 0]
-        rect1 = self.aedtapp.modeler.primitives.create_rectangle(
-            self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_vector"
-        )
+        rect1 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, 0, 0], [20, 20], "rectangle_to_vector")
         assert rect1.sweep_along_vector(sweep_vector)
 
     def test_48_coordinate_systems_parametric(self):

--- a/_unittest/test_05_Mesh.py
+++ b/_unittest/test_05_Mesh.py
@@ -30,7 +30,7 @@ class TestClass:
     def test_assign_model_resolution(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 200
-        o = self.aedtapp.modeler.primitives.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "inner")
+        o = self.aedtapp.modeler.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "inner")
         self.aedtapp.mesh.assign_model_resolution(o, 1e-4, "ModelRes1")
         assert "ModelRes1" in [i.name for i in self.aedtapp.mesh.meshoperations]
         mr2 = self.aedtapp.mesh.assign_model_resolution(o.faces[0], 1e-4, "ModelRes2")
@@ -39,7 +39,7 @@ class TestClass:
     def test_assign_surface_mesh(self):
         udp = self.aedtapp.modeler.Position(10, 10, 0)
         coax_dimension = 200
-        o = self.aedtapp.modeler.primitives.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "surface")
+        o = self.aedtapp.modeler.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "surface")
         surface = self.aedtapp.mesh.assign_surface_mesh(o.id, 3, "Surface")
         assert "Surface" in [i.name for i in self.aedtapp.mesh.meshoperations]
         assert surface.props["SliderMeshSettings"] == 3
@@ -47,9 +47,7 @@ class TestClass:
     def test_assign_surface_mesh_manual(self):
         udp = self.aedtapp.modeler.Position(20, 20, 0)
         coax_dimension = 200
-        o = self.aedtapp.modeler.primitives.create_cylinder(
-            self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "surface_manual"
-        )
+        o = self.aedtapp.modeler.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "surface_manual")
         surface = self.aedtapp.mesh.assign_surface_mesh_manual(o.id, 1e-6, aspect_ratio=3, meshop_name="Surface_Manual")
         assert "Surface_Manual" in [i.name for i in self.aedtapp.mesh.meshoperations]
         assert surface.props["SurfDev"] == 1e-6
@@ -69,7 +67,7 @@ class TestClass:
 
     def test_maxwell_mesh(self):
         m3d = Maxwell3d()
-        o = m3d.modeler.primitives.create_box([0, 0, 0], [10, 10, 10], name="Box_Mesh")
+        o = m3d.modeler.create_box([0, 0, 0], [10, 10, 10], name="Box_Mesh")
         assert m3d.mesh.assign_rotational_layer(o.name, meshop_name="Rotational")
         assert m3d.mesh.assign_edge_cut(o.name, meshop_name="Edge")
         assert m3d.mesh.assign_density_control(o.name, maxelementlength=10000, meshop_name="Density")

--- a/_unittest/test_07_Object3D.py
+++ b/_unittest/test_07_Object3D.py
@@ -48,35 +48,35 @@ class TestClass:
             [(RI + N) * math.cos(tetarad), (RI + N) * math.sin(tetarad), HT / 2],
         ]
 
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
-        return self.aedtapp.modeler.primitives.create_polyline(position_list=pointsList1, name=name)
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
+        return self.aedtapp.modeler.create_polyline(position_list=pointsList1, name=name)
 
     def create_copper_box(self, name=None):
         if not name:
             name = "MyBox"
-        o = self.aedtapp.modeler.primitives[name]
+        o = self.aedtapp.modeler[name]
         if not o:
-            o = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], name, "Copper")
+            o = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], name, "Copper")
         return o
 
     def create_copper_box_test_performance(self):
         for o in range(10):
-            o = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], "MyboxLoop", "Copper")
+            o = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "MyboxLoop", "Copper")
 
     def create_copper_sphere(self, name=None):
         if not name:
             name = "Mysphere"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
-        return self.aedtapp.modeler.primitives.create_sphere([0, 0, 0], radius=4, name=name, matname="Copper")
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
+        return self.aedtapp.modeler.create_sphere([0, 0, 0], radius=4, name=name, matname="Copper")
 
     def create_copper_cylinder(self, name=None):
         if not name:
             name = "MyCyl"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
-        return self.aedtapp.modeler.primitives.create_cylinder(
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
+        return self.aedtapp.modeler.create_cylinder(
             cs_axis="Y", position=[0, 0, 0], radius=1, height=20, numSides=8, name=name, matname="Copper"
         )
 
@@ -102,7 +102,7 @@ class TestClass:
         o = self.create_copper_box("DeleteBox")
         name = o.name
         o.delete()
-        assert not self.aedtapp.modeler.primitives[name]
+        assert not self.aedtapp.modeler[name]
         assert not o.__dict__
 
     def test_01_subtract_object(self):
@@ -250,7 +250,7 @@ class TestClass:
         test = initial_object.edges[4].chamfer(chamfer_type=4)
         assert not test
 
-        self.aedtapp.modeler.primitives.delete(initial_object)
+        self.aedtapp.modeler.delete(initial_object)
 
     def test_11_fillet(self):
         initial_object = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "FilletTest", "Copper")
@@ -260,7 +260,7 @@ class TestClass:
         assert test
         test = initial_object.edges[1].fillet(radius=0.2, setback=0.1)
         assert not test
-        self.aedtapp.modeler.primitives.delete(initial_object)
+        self.aedtapp.modeler.delete(initial_object)
 
     def test_object_length(self):
         initial_object = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "FilletTest", "Copper")
@@ -273,7 +273,7 @@ class TestClass:
         for i in range(0, 3):
             sum_sq += (end_point.position[i] - start_point.position[i]) ** 2
         assert isclose(math.sqrt(sum_sq), test_edge.length)
-        self.aedtapp.modeler.primitives.delete(initial_object)
+        self.aedtapp.modeler.delete(initial_object)
 
     def test_12_set_color(self):
         initial_object = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "ColorTest")
@@ -300,7 +300,7 @@ class TestClass:
         initial_object.color = (255, "Invalid", 0)
         assert initial_object.color == (255, 0, 0)
 
-        self.aedtapp.modeler.primitives.delete("ColorTest")
+        self.aedtapp.modeler.delete("ColorTest")
 
     def test_print_object(self):
         o = self.create_copper_box()
@@ -318,9 +318,9 @@ class TestClass:
     def test_13_delete_self(self):
         o = self.create_copper_box()
         my_name = o.name
-        assert my_name in self.aedtapp.modeler.primitives.object_names
+        assert my_name in self.aedtapp.modeler.object_names
         o.delete()
-        assert my_name not in self.aedtapp.modeler.primitives.object_names
+        assert my_name not in self.aedtapp.modeler.object_names
 
     def test_14_translate_delete_self(self):
         o = self.create_copper_box()
@@ -336,17 +336,17 @@ class TestClass:
         added_objects = turn.duplicate_around_axis(cs_axis="Z", angle=8, nclones=19)
         turn.unite(added_objects)
         assert len(added_objects) == 18
-        assert "single_turn" in self.aedtapp.modeler.primitives.line_names
+        assert "single_turn" in self.aedtapp.modeler.line_names
 
     def test_16_duplicate_around_axis_and_unite(self):
         turn = self.create_example_coil("single_turn")
         added_objects = turn.duplicate_along_line([0, 0, 15], nclones=3, attachObject=False)
         assert len(added_objects) == 2
-        assert "single_turn" in self.aedtapp.modeler.primitives.line_names
+        assert "single_turn" in self.aedtapp.modeler.line_names
 
     # TODO: Finish asserts anc check the boolean inputs - they are not present in the GUI ??
     def test_17_section_object(self):
-        o = self.aedtapp.modeler.primitives.create_box([-10, 0, 0], [10, 10, 5], "SectionBox", "Copper")
+        o = self.aedtapp.modeler.create_box([-10, 0, 0], [10, 10, 5], "SectionBox", "Copper")
         o.section(plane="YZ", create_new=True, section_cross_object=False)
 
     def test_18_create_spiral(self):

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -42,43 +42,43 @@ class TestClass(BasisTest):
     def create_copper_box(self, name=None):
         if not name:
             name = "MyBox"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
         else:
             pass
-        new_object = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], name, "Copper")
+        new_object = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], name, "Copper")
         return new_object
 
     def create_copper_sphere(self, name=None):
         if not name:
             name = "Mysphere"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
-        return self.aedtapp.modeler.primitives.create_sphere([0, 0, 0], radius="1mm", name=name, matname="Copper")
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
+        return self.aedtapp.modeler.create_sphere([0, 0, 0], radius="1mm", name=name, matname="Copper")
 
     def create_copper_cylinder(self, name=None):
         if not name:
             name = "MyCyl"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
-        return self.aedtapp.modeler.primitives.create_cylinder(
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
+        return self.aedtapp.modeler.create_cylinder(
             cs_axis="Y", position=[20, 20, 0], radius=5, height=20, numSides=8, name=name, matname="Copper"
         )
 
     def create_rectangle(self, name=None):
         if not name:
             name = "MyRectangle"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
         plane = self.aedtapp.PLANE.XY
-        return self.aedtapp.modeler.primitives.create_rectangle(plane, [5, 3, 8], [4, 5], name=name)
+        return self.aedtapp.modeler.create_rectangle(plane, [5, 3, 8], [4, 5], name=name)
 
     def create_copper_torus(self, name=None):
         if not name:
             name = "MyTorus"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
-        return self.aedtapp.modeler.primitives.create_torus(
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
+        return self.aedtapp.modeler.create_torus(
             [30, 30, 0], major_radius=1.2, minor_radius=0.5, axis="Z", name=name, material_name="Copper"
         )
 
@@ -88,24 +88,24 @@ class TestClass(BasisTest):
 
         test_points = [[0, 100, 0], [-100, 0, 0], [-50, -50, 0], [0, 0, 0]]
 
-        if self.aedtapp.modeler.primitives[name + "segmented"]:
-            self.aedtapp.modeler.primitives.delete(name + "segmented")
+        if self.aedtapp.modeler[name + "segmented"]:
+            self.aedtapp.modeler.delete(name + "segmented")
 
-        if self.aedtapp.modeler.primitives[name + "compound"]:
-            self.aedtapp.modeler.primitives.delete(name + "compound")
+        if self.aedtapp.modeler[name + "compound"]:
+            self.aedtapp.modeler.delete(name + "compound")
 
-        p1 = self.aedtapp.modeler.primitives.create_polyline(position_list=test_points, name=name + "segmented")
-        p2 = self.aedtapp.modeler.primitives.create_polyline(
+        p1 = self.aedtapp.modeler.create_polyline(position_list=test_points, name=name + "segmented")
+        p2 = self.aedtapp.modeler.create_polyline(
             position_list=test_points, segment_type=["Line", "Arc"], name=name + "compound"
         )
         return p1, p2, test_points
 
     @pyaedt_unittest_check_desktop_error
     def test_01_resolve_object(self):
-        o = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], "MyCreatedBox", "Copper")
-        o1 = self.aedtapp.modeler.primitives._resolve_object(o)
-        o2 = self.aedtapp.modeler.primitives._resolve_object(o.id)
-        o3 = self.aedtapp.modeler.primitives._resolve_object(o.name)
+        o = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "MyCreatedBox", "Copper")
+        o1 = self.aedtapp.modeler._resolve_object(o)
+        o2 = self.aedtapp.modeler._resolve_object(o.id)
+        o3 = self.aedtapp.modeler._resolve_object(o.name)
 
         assert isinstance(o1, Object3d)
         assert isinstance(o2, Object3d)
@@ -114,27 +114,27 @@ class TestClass(BasisTest):
         assert o2.id == o.id
         assert o3.id == o.id
         self.cache.ignore_error_message_local("Error. Object")
-        oinvalid1 = self.aedtapp.modeler.primitives._resolve_object(-1)
-        oinvalid2 = self.aedtapp.modeler.primitives._resolve_object("FrankInvalid")
+        oinvalid1 = self.aedtapp.modeler._resolve_object(-1)
+        oinvalid2 = self.aedtapp.modeler._resolve_object("FrankInvalid")
         assert not oinvalid1
         assert not oinvalid2
 
     @pyaedt_unittest_check_desktop_error
     def test_02_create_box(self):
-        o = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], "MyCreatedBox_11", "Copper")
+        o = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "MyCreatedBox_11", "Copper")
         assert o.id > 0
         assert o.name.startswith("MyCreatedBox_11")
         assert o.object_type == "Solid"
         assert o.is3d == True
         assert o.material_name == "copper"
-        assert "MyCreatedBox_11" in self.aedtapp.modeler.primitives.solid_names
-        assert len(self.aedtapp.modeler.primitives.object_names) == len(self.aedtapp.modeler.primitives.objects)
+        assert "MyCreatedBox_11" in self.aedtapp.modeler.solid_names
+        assert len(self.aedtapp.modeler.object_names) == len(self.aedtapp.modeler.objects)
 
     @pyaedt_unittest_check_desktop_error
     def test_03_create_box_assertions(self):
         try:
             invalid_entry = "Frank"
-            self.aedtapp.modeler.primitives.create_box([0, 0, 0], invalid_entry, "MyCreatedBox", "Copper")
+            self.aedtapp.modeler.create_box([0, 0, 0], invalid_entry, "MyCreatedBox", "Copper")
             assert False
         except AssertionError:
             pass
@@ -142,7 +142,7 @@ class TestClass(BasisTest):
     @pyaedt_unittest_check_desktop_error
     def test_04_create_polyhedron(self):
 
-        o1 = self.aedtapp.modeler.primitives.create_polyhedron()
+        o1 = self.aedtapp.modeler.create_polyhedron()
         assert o1.id > 0
         assert o1.name.startswith("New")
         assert o1.object_type == "Solid"
@@ -150,7 +150,7 @@ class TestClass(BasisTest):
         assert o1.material_name == "vacuum"
         assert o1.solve_inside
 
-        o2 = self.aedtapp.modeler.primitives.create_polyhedron(
+        o2 = self.aedtapp.modeler.create_polyhedron(
             cs_axis=AXIS.Z,
             center_position=[0, 0, 0],
             start_position=[0, 1, 0],
@@ -165,9 +165,9 @@ class TestClass(BasisTest):
         assert o2.material_name == "aluminum"
         assert o2.solve_inside == False
 
-        assert o1.name in self.aedtapp.modeler.primitives.solid_names
-        assert o2.name in self.aedtapp.modeler.primitives.solid_names
-        assert len(self.aedtapp.modeler.primitives.object_names) == len(self.aedtapp.modeler.primitives.objects)
+        assert o1.name in self.aedtapp.modeler.solid_names
+        assert o2.name in self.aedtapp.modeler.solid_names
+        assert len(self.aedtapp.modeler.object_names) == len(self.aedtapp.modeler.objects)
         pass
 
     @pyaedt_unittest_check_desktop_error
@@ -184,7 +184,7 @@ class TestClass(BasisTest):
 
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         dimensions = [10, 10, 5]
-        o = self.aedtapp.modeler.primitives.create_box(udp, dimensions)
+        o = self.aedtapp.modeler.create_box(udp, dimensions)
         assert len(o.name) == 16
         assert o.material_name == "vacuum"
 
@@ -229,7 +229,7 @@ class TestClass(BasisTest):
     def test_13_create_circle(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
         plane = self.aedtapp.PLANE.XY
-        o = self.aedtapp.modeler.primitives.create_circle(plane, udp, 2, name="MyCircle", matname="Copper")
+        o = self.aedtapp.modeler.create_circle(plane, udp, 2, name="MyCircle", matname="Copper")
         assert o.id > 0
         assert o.name.startswith("MyCircle")
         assert o.object_type == "Sheet"
@@ -240,7 +240,7 @@ class TestClass(BasisTest):
     def test_14_create_sphere(self):
         udp = self.aedtapp.modeler.Position(20, 20, 0)
         radius = 5
-        o = self.aedtapp.modeler.primitives.create_sphere(udp, radius, "MySphere", "Copper")
+        o = self.aedtapp.modeler.create_sphere(udp, radius, "MySphere", "Copper")
         assert o.id > 0
         assert o.name.startswith("MySphere")
         assert o.object_type == "Solid"
@@ -252,7 +252,7 @@ class TestClass(BasisTest):
         axis = self.aedtapp.AXIS.Y
         radius = 5
         height = 50
-        o = self.aedtapp.modeler.primitives.create_cylinder(axis, udp, radius, height, 8, "MyCyl", "Copper")
+        o = self.aedtapp.modeler.create_cylinder(axis, udp, radius, height, 8, "MyCyl", "Copper")
         assert o.id > 0
         assert o.name.startswith("MyCyl")
         assert o.object_type == "Solid"
@@ -263,25 +263,21 @@ class TestClass(BasisTest):
     def test_16_create_ellipse(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
         plane = self.aedtapp.PLANE.XY
-        o1 = self.aedtapp.modeler.primitives.create_ellipse(
-            plane, udp, 5, 1.5, True, name="MyEllpise01", matname="Copper"
-        )
+        o1 = self.aedtapp.modeler.create_ellipse(plane, udp, 5, 1.5, True, name="MyEllpise01", matname="Copper")
         assert o1.id > 0
         assert o1.name.startswith("MyEllpise01")
         assert o1.object_type == "Sheet"
         assert o1.is3d is False
         assert not o1.solve_inside
 
-        o2 = self.aedtapp.modeler.primitives.create_ellipse(
-            plane, udp, 5, 1.5, True, name="MyEllpise01", matname="Vacuum"
-        )
+        o2 = self.aedtapp.modeler.create_ellipse(plane, udp, 5, 1.5, True, name="MyEllpise01", matname="Vacuum")
         assert o2.id > 0
         assert o2.name.startswith("MyEllpise01")
         assert o2.object_type == "Sheet"
         assert o2.is3d is False
         assert not o2.solve_inside
 
-        o3 = self.aedtapp.modeler.primitives.create_ellipse(plane, udp, 5, 1.5, False, name="MyEllpise02")
+        o3 = self.aedtapp.modeler.create_ellipse(plane, udp, 5, 1.5, False, name="MyEllpise02")
         assert o3.id > 0
         assert o3.name.startswith("MyEllpise02")
         assert o3.object_type == "Line"
@@ -292,7 +288,7 @@ class TestClass(BasisTest):
     def test_17_create_object_from_edge(self):
         o = self.create_copper_cylinder()
         edges = o.edges
-        o = self.aedtapp.modeler.primitives.create_object_from_edge(edges[0])
+        o = self.aedtapp.modeler.create_object_from_edge(edges[0])
         assert o.id > 0
         assert o.object_type == "Line"
         assert o.is3d is False
@@ -302,7 +298,7 @@ class TestClass(BasisTest):
     def test_18_create_object_from_face(self):
         o = self.create_copper_cylinder()
         faces = o.faces
-        o = self.aedtapp.modeler.primitives.create_object_from_face(faces[0])
+        o = self.aedtapp.modeler.create_object_from_face(faces[0])
         assert o.id > 0
         assert o.object_type == "Sheet"
         assert o.is3d is False
@@ -315,15 +311,13 @@ class TestClass(BasisTest):
         udp3 = [5, 5, 0]
         udp4 = [2, 5, 3]
         arrofpos = [udp1, udp4, udp2, udp3, udp1]
-        P = self.aedtapp.modeler.primitives.create_polyline(
-            arrofpos, cover_surface=True, name="Poly1", matname="Copper"
-        )
+        P = self.aedtapp.modeler.create_polyline(arrofpos, cover_surface=True, name="Poly1", matname="Copper")
         assert isinstance(P, Polyline)
         assert isinstance(P, Object3d)
         assert P.object_type == "Sheet"
         assert P.is3d == False
         assert isinstance(P.color, tuple)
-        get_P = self.aedtapp.modeler.primitives["Poly1"]
+        get_P = self.aedtapp.modeler["Poly1"]
         assert isinstance(get_P, Polyline)
 
     @pyaedt_unittest_check_desktop_error
@@ -333,10 +327,10 @@ class TestClass(BasisTest):
         udp3 = [5, 5, 0]
         udp4 = [2, 5, 3]
         arrofpos = [udp1, udp2, udp3]
-        P = self.aedtapp.modeler.primitives.create_polyline(arrofpos, name="Poly_xsection", xsection_type="Rectangle")
+        P = self.aedtapp.modeler.create_polyline(arrofpos, name="Poly_xsection", xsection_type="Rectangle")
         assert isinstance(P, Polyline)
-        assert self.aedtapp.modeler.primitives[P.id].object_type == "Solid"
-        assert self.aedtapp.modeler.primitives[P.id].is3d == True
+        assert self.aedtapp.modeler[P.id].object_type == "Solid"
+        assert self.aedtapp.modeler[P.id].is3d == True
 
     @pyaedt_unittest_check_desktop_error
     def test_21_sweep_along_path(self):
@@ -344,32 +338,28 @@ class TestClass(BasisTest):
         udp2 = [5, 0, 0]
         udp3 = [5, 5, 0]
         arrofpos = [udp1, udp2, udp3]
-        path = self.aedtapp.modeler.primitives.create_polyline(arrofpos, name="poly_vector")
+        path = self.aedtapp.modeler.create_polyline(arrofpos, name="poly_vector")
         my_name = path.name
-        assert my_name in self.aedtapp.modeler.primitives.line_names
-        assert my_name in self.aedtapp.modeler.primitives.model_objects
-        assert my_name in self.aedtapp.modeler.primitives.object_names
+        assert my_name in self.aedtapp.modeler.line_names
+        assert my_name in self.aedtapp.modeler.model_objects
+        assert my_name in self.aedtapp.modeler.object_names
         assert isinstance(self.aedtapp.modeler.get_vertices_of_line(my_name), list)
-        rect = self.aedtapp.modeler.primitives.create_rectangle(
-            self.aedtapp.PLANE.YZ, [0, -2, -2], [4, 3], name="rect_1"
-        )
+        rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, -2, -2], [4, 3], name="rect_1")
         swept = self.aedtapp.modeler.sweep_along_path(rect, path)
         assert swept
-        assert rect.name in self.aedtapp.modeler.primitives.solid_names
+        assert rect.name in self.aedtapp.modeler.solid_names
 
     @pyaedt_unittest_check_desktop_error
     def test_22_sweep_along_vector(self):
-        rect2 = self.aedtapp.modeler.primitives.create_rectangle(
-            self.aedtapp.PLANE.YZ, [0, -2, -2], [4, 3], name="rect_2"
-        )
+        rect2 = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [0, -2, -2], [4, 3], name="rect_2")
         assert self.aedtapp.modeler.sweep_along_vector(rect2, [10, 20, 20])
-        assert rect2.name in self.aedtapp.modeler.primitives.solid_names
+        assert rect2.name in self.aedtapp.modeler.solid_names
 
     @pyaedt_unittest_check_desktop_error
     def test_23_create_rectangle(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
         plane = self.aedtapp.PLANE.XY
-        o = self.aedtapp.modeler.primitives.create_rectangle(plane, udp, [4, 5], name="MyRectangle", matname="Copper")
+        o = self.aedtapp.modeler.create_rectangle(plane, udp, [4, 5], name="MyRectangle", matname="Copper")
         assert o.id > 0
         assert o.name.startswith("MyRectangle")
         assert o.object_type == "Sheet"
@@ -379,7 +369,7 @@ class TestClass(BasisTest):
     def test_24_create_cone(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
         axis = self.aedtapp.AXIS.Z
-        o = self.aedtapp.modeler.primitives.create_cone(axis, udp, 20, 10, 5, name="MyCone", matname="Copper")
+        o = self.aedtapp.modeler.create_cone(axis, udp, 20, 10, 5, name="MyCone", matname="Copper")
         assert o.id > 0
         assert o.name.startswith("MyCone")
         assert o.object_type == "Solid"
@@ -389,8 +379,8 @@ class TestClass(BasisTest):
     def test_25_get_object_id(self):
         udp = self.aedtapp.modeler.Position(5, 3, 8)
         plane = self.aedtapp.PLANE.XY
-        o = self.aedtapp.modeler.primitives.create_rectangle(plane, udp, [4, 5], name="MyRectangle5")
-        assert self.aedtapp.modeler.primitives.get_obj_id(o.name) == o.id
+        o = self.aedtapp.modeler.create_rectangle(plane, udp, [4, 5], name="MyRectangle5")
+        assert self.aedtapp.modeler.get_obj_id(o.name) == o.id
 
     @pyaedt_unittest_check_desktop_error
     def test_26_get_object_names(self):
@@ -398,10 +388,10 @@ class TestClass(BasisTest):
         p1, p2, points = self.create_polylines()
         c1 = self.create_copper_box()
         r1 = self.create_rectangle()
-        solid_list = self.aedtapp.modeler.primitives.solid_names
-        sheet_list = self.aedtapp.modeler.primitives.sheet_names
-        line_list = self.aedtapp.modeler.primitives.line_names
-        all_objects_list = self.aedtapp.modeler.primitives.object_names
+        solid_list = self.aedtapp.modeler.solid_names
+        sheet_list = self.aedtapp.modeler.sheet_names
+        line_list = self.aedtapp.modeler.line_names
+        all_objects_list = self.aedtapp.modeler.object_names
 
         assert c1.name in solid_list
         assert r1.name in sheet_list
@@ -414,7 +404,7 @@ class TestClass(BasisTest):
 
         print("Solids")
         for solid in solid_list:
-            solid_object = self.aedtapp.modeler.primitives[solid]
+            solid_object = self.aedtapp.modeler[solid]
 
             print(solid)
             print(solid_object.name)
@@ -424,19 +414,19 @@ class TestClass(BasisTest):
 
         print("Sheets")
         for sheet in sheet_list:
-            sheet_object = self.aedtapp.modeler.primitives[sheet]
+            sheet_object = self.aedtapp.modeler[sheet]
             print(sheet)
             print(sheet_object.name)
-            assert self.aedtapp.modeler.primitives[sheet].is3d is False
-            assert self.aedtapp.modeler.primitives[sheet].object_type == "Sheet"
+            assert self.aedtapp.modeler[sheet].is3d is False
+            assert self.aedtapp.modeler[sheet].object_type == "Sheet"
 
         print("Lines")
         for line in line_list:
-            line_object = self.aedtapp.modeler.primitives[line]
+            line_object = self.aedtapp.modeler[line]
             print(line)
             print(line_object.name)
-            assert self.aedtapp.modeler.primitives[line].is3d is False
-            assert self.aedtapp.modeler.primitives[line].object_type == "Line"
+            assert self.aedtapp.modeler[line].is3d is False
+            assert self.aedtapp.modeler[line].object_type == "Line"
 
         assert len(all_objects_list) == len(solid_list) + len(line_list) + len(sheet_list)
 
@@ -445,15 +435,15 @@ class TestClass(BasisTest):
         self.create_polylines()
         self.create_copper_box()
         self.create_rectangle()
-        listsobj = self.aedtapp.modeler.primitives.get_objects_by_material("vacuum")
+        listsobj = self.aedtapp.modeler.get_objects_by_material("vacuum")
         assert len(listsobj) > 0
-        listsobj = self.aedtapp.modeler.primitives.get_objects_by_material("FR4")
+        listsobj = self.aedtapp.modeler.get_objects_by_material("FR4")
         assert len(listsobj) == 0
 
     @pyaedt_unittest_check_desktop_error
     def test_28_get_object_faces(self):
         self.create_rectangle()
-        o = self.aedtapp.modeler.primitives["MyRectangle"]
+        o = self.aedtapp.modeler["MyRectangle"]
         assert len(o.faces) == 1
         assert len(o.edges) == 4
         assert len(o.vertices) == 4
@@ -462,83 +452,83 @@ class TestClass(BasisTest):
         self.cache.ignore_error_message_local("Script macro error: Can't find face by name and position.")
         o = self.create_rectangle(name="MyRectangle_for_primitives")
         udp = self.aedtapp.modeler.Position(5, 3, 8)
-        edge_id = self.aedtapp.modeler.primitives.get_edgeid_from_position(udp, o.name)
+        edge_id = self.aedtapp.modeler.get_edgeid_from_position(udp, o.name)
         assert edge_id > 0
-        edge_id = self.aedtapp.modeler.primitives.get_edgeid_from_position(udp)
+        edge_id = self.aedtapp.modeler.get_edgeid_from_position(udp)
         assert edge_id > 0
 
     @pyaedt_unittest_check_desktop_error
     def test_30_get_faces_from_position(self):
         self.cache.ignore_error_message_local("Script macro error: Can't find face by name and position.")
         o = self.create_rectangle("New_Rectangle1")
-        edge_id = self.aedtapp.modeler.primitives.get_faceid_from_position([5, 3, 8], "New_Rectangle1")
+        edge_id = self.aedtapp.modeler.get_faceid_from_position([5, 3, 8], "New_Rectangle1")
         assert edge_id > 0
         udp = self.aedtapp.modeler.Position(100, 100, 100)
-        edge_id = self.aedtapp.modeler.primitives.get_faceid_from_position(udp)
+        edge_id = self.aedtapp.modeler.get_faceid_from_position(udp)
         assert not edge_id
 
     @pyaedt_unittest_check_desktop_error
     def test_31_delete_object(self):
         self.create_rectangle(name="MyRectangle")
-        assert "MyRectangle" in self.aedtapp.modeler.primitives.object_names
-        deleted = self.aedtapp.modeler.primitives.delete("MyRectangle")
+        assert "MyRectangle" in self.aedtapp.modeler.object_names
+        deleted = self.aedtapp.modeler.delete("MyRectangle")
         assert deleted
-        assert "MyRectangle" not in self.aedtapp.modeler.primitives.object_names
+        assert "MyRectangle" not in self.aedtapp.modeler.object_names
 
     @pyaedt_unittest_check_desktop_error
     def test_32_get_face_vertices(self):
         plane = self.aedtapp.PLANE.XY
-        rectid = self.aedtapp.modeler.primitives.create_rectangle(plane, [1, 2, 3], [7, 13], name="rect_for_get")
-        listfaces = self.aedtapp.modeler.primitives.get_object_faces("rect_for_get")
-        vertices = self.aedtapp.modeler.primitives.get_face_vertices(listfaces[0])
+        rectid = self.aedtapp.modeler.create_rectangle(plane, [1, 2, 3], [7, 13], name="rect_for_get")
+        listfaces = self.aedtapp.modeler.get_object_faces("rect_for_get")
+        vertices = self.aedtapp.modeler.get_face_vertices(listfaces[0])
         assert len(vertices) == 4
 
     @pyaedt_unittest_check_desktop_error
     def test_33_get_edge_vertices(self):
-        listedges = self.aedtapp.modeler.primitives.get_object_edges("rect_for_get")
-        vertices = self.aedtapp.modeler.primitives.get_edge_vertices(listedges[0])
+        listedges = self.aedtapp.modeler.get_object_edges("rect_for_get")
+        vertices = self.aedtapp.modeler.get_edge_vertices(listedges[0])
         assert len(vertices) == 2
 
     @pyaedt_unittest_check_desktop_error
     def test_34_get_vertex_position(self):
-        listedges = self.aedtapp.modeler.primitives.get_object_edges("rect_for_get")
-        vertices = self.aedtapp.modeler.primitives.get_edge_vertices(listedges[0])
-        pos1 = self.aedtapp.modeler.primitives.get_vertex_position(vertices[0])
+        listedges = self.aedtapp.modeler.get_object_edges("rect_for_get")
+        vertices = self.aedtapp.modeler.get_edge_vertices(listedges[0])
+        pos1 = self.aedtapp.modeler.get_vertex_position(vertices[0])
         assert len(pos1) == 3
-        pos2 = self.aedtapp.modeler.primitives.get_vertex_position(vertices[1])
+        pos2 = self.aedtapp.modeler.get_vertex_position(vertices[1])
         assert len(pos2) == 3
         edge_length = ((pos1[0] - pos2[0]) ** 2 + (pos1[1] - pos2[1]) ** 2 + (pos1[2] - pos2[2]) ** 2) ** 0.5
         assert edge_length == 7
 
     @pyaedt_unittest_check_desktop_error
     def test_35_get_face_area(self):
-        listfaces = self.aedtapp.modeler.primitives.get_object_faces("rect_for_get")
-        area = self.aedtapp.modeler.primitives.get_face_area(listfaces[0])
+        listfaces = self.aedtapp.modeler.get_object_faces("rect_for_get")
+        area = self.aedtapp.modeler.get_face_area(listfaces[0])
         assert area == 7 * 13
 
     @pyaedt_unittest_check_desktop_error
     def test_36_get_face_center(self):
-        listfaces = self.aedtapp.modeler.primitives.get_object_faces("rect_for_get")
-        center = self.aedtapp.modeler.primitives.get_face_center(listfaces[0])
+        listfaces = self.aedtapp.modeler.get_object_faces("rect_for_get")
+        center = self.aedtapp.modeler.get_face_center(listfaces[0])
         assert center == [4.5, 8.5, 3.0]
 
     @pyaedt_unittest_check_desktop_error
     def test_37_get_edge_midpoint(self):
-        listedges = self.aedtapp.modeler.primitives.get_object_edges("rect_for_get")
-        point = self.aedtapp.modeler.primitives.get_edge_midpoint(listedges[0])
+        listedges = self.aedtapp.modeler.get_object_edges("rect_for_get")
+        point = self.aedtapp.modeler.get_edge_midpoint(listedges[0])
         assert point == [4.5, 2.0, 3.0]
 
     @pyaedt_unittest_check_desktop_error
     def test_38_get_bodynames_from_position(self):
         center = [20, 20, 0]
         radius = 1
-        id = self.aedtapp.modeler.primitives.create_sphere(center, radius, "fred")
-        spherename = self.aedtapp.modeler.primitives.get_bodynames_from_position(center)
+        id = self.aedtapp.modeler.create_sphere(center, radius, "fred")
+        spherename = self.aedtapp.modeler.get_bodynames_from_position(center)
         assert "fred" in spherename
 
         plane = self.aedtapp.PLANE.XY
-        rectid = self.aedtapp.modeler.primitives.create_rectangle(plane, [-50, -50, -50], [2, 2], name="bob")
-        rectname = self.aedtapp.modeler.primitives.get_bodynames_from_position([-49.0, -49.0, -50.0])
+        rectid = self.aedtapp.modeler.create_rectangle(plane, [-50, -50, -50], [2, 2], name="bob")
+        rectname = self.aedtapp.modeler.get_bodynames_from_position([-49.0, -49.0, -50.0])
         assert "bob" in rectname
 
         udp1 = self.aedtapp.modeler.Position(-23, -23, 13)
@@ -546,23 +536,23 @@ class TestClass(BasisTest):
         udp3 = self.aedtapp.modeler.Position(-31, -31, 7)
         udp4 = self.aedtapp.modeler.Position(2, 5, 3)
         arrofpos = [udp1, udp2, udp3, udp4]
-        P = self.aedtapp.modeler.primitives.create_polyline(arrofpos, cover_surface=False, name="bill")
-        polyname = self.aedtapp.modeler.primitives.get_bodynames_from_position([-27, -27, 11])
+        P = self.aedtapp.modeler.create_polyline(arrofpos, cover_surface=False, name="bill")
+        polyname = self.aedtapp.modeler.get_bodynames_from_position([-27, -27, 11])
         assert "bill" in polyname
 
     @pyaedt_unittest_check_desktop_error
     def test_39_getobjects_with_strings(self):
-        list1 = self.aedtapp.modeler.primitives.get_objects_w_string("MyCone")
-        list2 = self.aedtapp.modeler.primitives.get_objects_w_string("my", False)
+        list1 = self.aedtapp.modeler.get_objects_w_string("MyCone")
+        list2 = self.aedtapp.modeler.get_objects_w_string("my", False)
 
         assert len(list1) > 0
         assert len(list2) > 0
 
     @pyaedt_unittest_check_desktop_error
     def test_40_getmodel_objects(self):
-        list1 = self.aedtapp.modeler.primitives.model_objects
-        list2 = self.aedtapp.modeler.primitives.non_model_objects
-        list3 = self.aedtapp.modeler.primitives.object_names
+        list1 = self.aedtapp.modeler.model_objects
+        list2 = self.aedtapp.modeler.non_model_objects
+        list3 = self.aedtapp.modeler.object_names
         for el in list1:
             if el not in list3:
                 print("Missing {}".format(el))
@@ -570,7 +560,7 @@ class TestClass(BasisTest):
 
     @pyaedt_unittest_check_desktop_error
     def test_41a_create_rect_sheet_to_region(self):
-        self.aedtapp.modeler.primitives.create_region()
+        self.aedtapp.modeler.create_region()
         self.create_copper_box(name="MyBox_to_gnd")
         groundplane = self.aedtapp.modeler.create_sheet_to_ground("MyBox_to_gnd")
         assert groundplane.id > 0
@@ -586,12 +576,12 @@ class TestClass(BasisTest):
     def test_41b_get_edges_for_circuit_port(self):
         udp = self.aedtapp.modeler.Position(0, 0, 8)
         plane = self.aedtapp.PLANE.XY
-        o = self.aedtapp.modeler.primitives.create_rectangle(plane, udp, [3, 10], name="MyGND", matname="Copper")
+        o = self.aedtapp.modeler.create_rectangle(plane, udp, [3, 10], name="MyGND", matname="Copper")
         face_id = o.faces[0].id
-        edges1 = self.aedtapp.modeler.primitives.get_edges_for_circuit_port(
+        edges1 = self.aedtapp.modeler.get_edges_for_circuit_port(
             face_id, XY_plane=True, YZ_plane=False, XZ_plane=False, allow_perpendicular=True, tol=1e-6
         )
-        edges2 = self.aedtapp.modeler.primitives.get_edges_for_circuit_port_from_sheet(
+        edges2 = self.aedtapp.modeler.get_edges_for_circuit_port_from_sheet(
             "MyGND", XY_plane=True, YZ_plane=False, XZ_plane=False, allow_perpendicular=True, tol=1e-6
         )
 
@@ -618,7 +608,7 @@ class TestClass(BasisTest):
 
     @pyaedt_unittest_check_desktop_error
     def test_44_create_polyline_basic_segments(self):
-        prim3D = self.aedtapp.modeler.primitives
+        prim3D = self.aedtapp.modeler
         self.aedtapp["p1"] = "100mm"
         self.aedtapp["p2"] = "71mm"
         test_points = [["0mm", "p1", "0mm"], ["-p1", "0mm", "0mm"], ["-p1/2", "-p1/2", "0mm"], ["0mm", "0mm", "0mm"]]
@@ -649,7 +639,7 @@ class TestClass(BasisTest):
 
     @pyaedt_unittest_check_desktop_error
     def test_45_create_circle_from_2_arc_segments(self):
-        prim3D = self.aedtapp.modeler.primitives
+        prim3D = self.aedtapp.modeler
         assert prim3D.create_polyline(
             position_list=[[34.1004, 14.1248, 0], [27.646, 16.7984, 0], [24.9725, 10.3439, 0], [31.4269, 7.6704, 0]],
             segment_type=["Arc", "Arc"],
@@ -661,7 +651,7 @@ class TestClass(BasisTest):
 
     @pyaedt_unittest_check_desktop_error
     def test_46_compound_polylines_segments(self):
-        prim3D = self.aedtapp.modeler.primitives
+        prim3D = self.aedtapp.modeler
         self.aedtapp["p1"] = "100mm"
         self.aedtapp["p2"] = "71mm"
         test_points = [["0mm", "p1", "0mm"], ["-p1", "0mm", "0mm"], ["-p1/2", "-p1/2", "0mm"], ["0mm", "0mm", "0mm"]]
@@ -682,7 +672,7 @@ class TestClass(BasisTest):
         self.aedtapp["p1"] = "100mm"
         self.aedtapp["p2"] = "71mm"
         test_points = [["0mm", "p1", "0mm"], ["-p1", "0mm", "0mm"], ["-p1/2", "-p1/2", "0mm"], ["0mm", "0mm", "0mm"]]
-        P = self.aedtapp.modeler.primitives.create_polyline(
+        P = self.aedtapp.modeler.create_polyline(
             position_list=test_points, close_surface=True, name="PL08_segmented_compound_insert_segment"
         )
         assert P
@@ -694,7 +684,7 @@ class TestClass(BasisTest):
 
     @pyaedt_unittest_check_desktop_error
     def test_48_insert_polylines_segments_test2(self):
-        prim3D = self.aedtapp.modeler.primitives
+        prim3D = self.aedtapp.modeler
         self.aedtapp["p1"] = "100mm"
         self.aedtapp["p2"] = "71mm"
         test_points = [["0mm", "p1", "0mm"], ["-p1", "0mm", "0mm"], ["-p1/2", "-p1/2", "0mm"], ["0mm", "0mm", "0mm"]]
@@ -711,7 +701,7 @@ class TestClass(BasisTest):
     @pyaedt_unittest_check_desktop_error
     def test_49_modify_crossection(self):
 
-        P = self.aedtapp.modeler.primitives.create_polyline(
+        P = self.aedtapp.modeler.create_polyline(
             position_list=[[34.1004, 14.1248, 0], [27.646, 16.7984, 0], [24.9725, 10.3439, 0]],
             name="Rotor_Subtract_25_0",
             matname="copper",
@@ -739,72 +729,72 @@ class TestClass(BasisTest):
 
         p1, p2, test_points = self.create_polylines("Poly_remove_")
 
-        P = self.aedtapp.modeler.primitives["Poly_remove_segmented"]
+        P = self.aedtapp.modeler["Poly_remove_segmented"]
         P.remove_vertex(test_points[2])
         time.sleep(0.1)
-        P1 = self.aedtapp.modeler.primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
+        P1 = self.aedtapp.modeler.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
         P1.remove_vertex([0, 1, 2])
         time.sleep(0.1)
 
-        P2 = self.aedtapp.modeler.primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
+        P2 = self.aedtapp.modeler.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
         P2.remove_vertex(["0mm", "1mm", "2mm"])
         time.sleep(0.1)
 
-        P3 = self.aedtapp.modeler.primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
+        P3 = self.aedtapp.modeler.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
         P3.remove_vertex(["0mm", "1mm", "2mm"], abstol=1e-6)
 
     @pyaedt_unittest_check_desktop_error
     def test_51_remove_edges_from_polyline(self):
 
-        primitives = self.aedtapp.modeler.primitives
+        primitives = self.aedtapp.modeler
         P = primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
         P.remove_edges(edge_id=0)
-        assert P.name in self.aedtapp.modeler.primitives.line_names
+        assert P.name in self.aedtapp.modeler.line_names
         P = primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4], [3, 1, 6]])
         P.remove_edges(edge_id=[0, 1])
-        assert P.name in self.aedtapp.modeler.primitives.line_names
+        assert P.name in self.aedtapp.modeler.line_names
         P = primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4], [3, 1, 6]])
         P.remove_edges(edge_id=[1, 2])
-        assert P.name in self.aedtapp.modeler.primitives.line_names
+        assert P.name in self.aedtapp.modeler.line_names
         P = primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4], [3, 1, 6]])
         P.remove_edges(edge_id=2)
-        assert P.name in self.aedtapp.modeler.primitives.line_names
+        assert P.name in self.aedtapp.modeler.line_names
 
     @pyaedt_unittest_check_desktop_error
     def test_52_remove_edges_from_polyline_invalid(self):
         self.cache.ignore_error_message_local("Body could not be created for part ")
-        P = self.aedtapp.modeler.primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
+        P = self.aedtapp.modeler.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
         P.remove_edges(edge_id=[0, 1])
-        assert not P.name in self.aedtapp.modeler.primitives.line_names
+        assert not P.name in self.aedtapp.modeler.line_names
 
     @pyaedt_unittest_check_desktop_error
     def test_53_duplicate_polyline_and_manipulate(self):
         # TODO Figure this one out !
         self.cache.ignore_error_message_local("Body could not be created for part NewObject_")
-        P1 = self.aedtapp.modeler.primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
+        P1 = self.aedtapp.modeler.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
         P2 = P1.clone()
         assert P2.id != P1.id
 
     @pyaedt_unittest_check_desktop_error
     def test_54_create_bond_wires(self):
         self.cache.ignore_error_message_local("Wrong Profile Type")
-        b0 = self.aedtapp.modeler.primitives.create_bondwire(
+        b0 = self.aedtapp.modeler.create_bondwire(
             [0, 0, 0], [10, 10, 2], h1=0.15, h2=0, diameter=0.034, facets=8, matname="copper", name="jedec51"
         )
         assert b0
-        b1 = self.aedtapp.modeler.primitives.create_bondwire(
+        b1 = self.aedtapp.modeler.create_bondwire(
             [0, 0, 0], [10, 10, 2], h1=0.15, h2=0, diameter=0.034, bond_type=1, matname="copper", name="jedec41"
         )
         assert b1
-        b2 = self.aedtapp.modeler.primitives.create_bondwire(
+        b2 = self.aedtapp.modeler.create_bondwire(
             [0, 0, 0], [10, 10, 2], h1=0.15, h2=0, diameter=0.034, bond_type=2, matname="copper", name="low"
         )
         assert b2
-        b3 = self.aedtapp.modeler.primitives.create_bondwire(
+        b3 = self.aedtapp.modeler.create_bondwire(
             [0, 0, 0], [10, 10, 2], h1=0.15, h2=0, diameter=0.034, bond_type=3, matname="copper", name="jedec41"
         )
         assert not b3
-        b4 = self.aedtapp.modeler.primitives.create_bondwire(
+        b4 = self.aedtapp.modeler.create_bondwire(
             (2, 2, 0), (0, 0, 0), h1=0.15, h2=0, diameter=0.034, bond_type=1, matname="copper", name="jedec41"
         )
         assert b4
@@ -832,43 +822,37 @@ class TestClass(BasisTest):
     def test_60_get_edges_on_bounding_box(self):
         self.aedtapp.close_project(name=self.aedtapp.project_name, saveproject=False)
         self.aedtapp.load_project(self.test_99_project)
-        edges = self.aedtapp.modeler.primitives.get_edges_on_bounding_box(
-            ["Port1", "Port2"], return_colinear=True, tol=1e-6
-        )
+        edges = self.aedtapp.modeler.get_edges_on_bounding_box(["Port1", "Port2"], return_colinear=True, tol=1e-6)
         assert len(edges) == 2
-        edges = self.aedtapp.modeler.primitives.get_edges_on_bounding_box(
-            ["Port1", "Port2"], return_colinear=False, tol=1e-6
-        )
+        edges = self.aedtapp.modeler.get_edges_on_bounding_box(["Port1", "Port2"], return_colinear=False, tol=1e-6)
         assert len(edges) == 4
 
     @pyaedt_unittest_check_desktop_error
     def test_61_get_closest_edge_to_position(self):
         my_box = self.create_copper_box("test_closest_edge")
-        assert isinstance(self.aedtapp.modeler.primitives.get_closest_edgeid_to_position([0.2, 0, 0]), int)
+        assert isinstance(self.aedtapp.modeler.get_closest_edgeid_to_position([0.2, 0, 0]), int)
         pass
 
     @pytest.mark.skipif(config["build_machine"] or is_ironpython, reason="Not running in non-graphical mode")
     def test_62_import_space_claim(self):
         self.aedtapp.insert_design("SCImport")
         assert self.aedtapp.modeler.import_spaceclaim_document(os.path.join(self.local_scratch.path, scdoc))
-        assert len(self.aedtapp.modeler.primitives.objects) == 1
+        assert len(self.aedtapp.modeler.objects) == 1
 
     def test_63_import_step(self):
         self.aedtapp.insert_design("StepImport")
         assert self.aedtapp.modeler.import_3d_cad(self.step_file)
-        assert len(self.aedtapp.modeler.primitives.object_names) == 1
+        assert len(self.aedtapp.modeler.object_names) == 1
 
     def test_64_create_equationbased_curve(self):
         self.aedtapp.insert_design("Equations")
-        eq_line = self.aedtapp.modeler.primitives.create_equationbased_curve(x_t="_t", y_t="_t*2", num_points=0)
+        eq_line = self.aedtapp.modeler.create_equationbased_curve(x_t="_t", y_t="_t*2", num_points=0)
         assert len(eq_line.edges) == 1
-        eq_segmented = self.aedtapp.modeler.primitives.create_equationbased_curve(x_t="_t", y_t="_t*2", num_points=5)
+        eq_segmented = self.aedtapp.modeler.create_equationbased_curve(x_t="_t", y_t="_t*2", num_points=5)
         assert len(eq_segmented.edges) == 4
 
-        eq_xsection = self.aedtapp.modeler.primitives.create_equationbased_curve(
-            x_t="_t", y_t="_t*2", xsection_type="Circle"
-        )
-        assert eq_xsection.name in self.aedtapp.modeler.primitives.solid_names
+        eq_xsection = self.aedtapp.modeler.create_equationbased_curve(x_t="_t", y_t="_t*2", xsection_type="Circle")
+        assert eq_xsection.name in self.aedtapp.modeler.solid_names
 
     def test_65_create_3dcomponent(self):
         self.aedtapp.solution_type = "Modal"
@@ -877,7 +861,7 @@ class TestClass(BasisTest):
         compfile = self.aedtapp.components3d["Dipole_Antenna_DM"]
         geometryparams = self.aedtapp.get_components3d_vars("Dipole_Antenna_DM")
         geometryparams["dipole_length"] = "l_dipole"
-        name = self.aedtapp.modeler.primitives.insert_3d_component(compfile, geometryparams)
+        name = self.aedtapp.modeler.insert_3d_component(compfile, geometryparams)
         assert isinstance(name, str)
 
     def test_65b_group_components(self):
@@ -886,32 +870,32 @@ class TestClass(BasisTest):
         compfile = self.aedtapp.components3d["Dipole_Antenna_DM"]
         geometryparams = self.aedtapp.get_components3d_vars("Dipole_Antenna_DM")
         geometryparams["dipole_length"] = "l_dipole"
-        name = self.aedtapp.modeler.primitives.insert_3d_component(compfile, geometryparams)
-        name2 = self.aedtapp.modeler.primitives.insert_3d_component(compfile, geometryparams)
+        name = self.aedtapp.modeler.insert_3d_component(compfile, geometryparams)
+        name2 = self.aedtapp.modeler.insert_3d_component(compfile, geometryparams)
         assert self.aedtapp.modeler.create_group(components=[name, name2], group_name="test_group") == "test_group"
 
     def test_66_assign_material(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([60, 60, 60], [4, 5, 5])
-        box2 = self.aedtapp.modeler.primitives.create_box([50, 50, 50], [2, 3, 4])
-        cyl1 = self.aedtapp.modeler.primitives.create_cylinder(cs_axis="X", position=[50, 0, 0], radius=1, height=20)
-        cyl2 = self.aedtapp.modeler.primitives.create_cylinder(cs_axis="Z", position=[0, 0, 50], radius=1, height=10)
+        box1 = self.aedtapp.modeler.create_box([60, 60, 60], [4, 5, 5])
+        box2 = self.aedtapp.modeler.create_box([50, 50, 50], [2, 3, 4])
+        cyl1 = self.aedtapp.modeler.create_cylinder(cs_axis="X", position=[50, 0, 0], radius=1, height=20)
+        cyl2 = self.aedtapp.modeler.create_cylinder(cs_axis="Z", position=[0, 0, 50], radius=1, height=10)
 
         objects_list = [box1, box2, cyl1, cyl2]
         self.aedtapp.assign_material(objects_list, "copper")
-        assert self.aedtapp.modeler.primitives[box1].material_name == "copper"
-        assert self.aedtapp.modeler.primitives[box2].material_name == "copper"
-        assert self.aedtapp.modeler.primitives[cyl1].material_name == "copper"
-        assert self.aedtapp.modeler.primitives[cyl2].material_name == "copper"
+        assert self.aedtapp.modeler[box1].material_name == "copper"
+        assert self.aedtapp.modeler[box2].material_name == "copper"
+        assert self.aedtapp.modeler[cyl1].material_name == "copper"
+        assert self.aedtapp.modeler[cyl2].material_name == "copper"
 
         obj_names_list = [box1.name, box2.name, cyl1.name, cyl2.name]
         self.aedtapp.assign_material(obj_names_list, "aluminum")
-        assert self.aedtapp.modeler.primitives[box1].material_name == "aluminum"
-        assert self.aedtapp.modeler.primitives[box2].material_name == "aluminum"
-        assert self.aedtapp.modeler.primitives[cyl1].material_name == "aluminum"
-        assert self.aedtapp.modeler.primitives[cyl2].material_name == "aluminum"
+        assert self.aedtapp.modeler[box1].material_name == "aluminum"
+        assert self.aedtapp.modeler[box2].material_name == "aluminum"
+        assert self.aedtapp.modeler[cyl1].material_name == "aluminum"
+        assert self.aedtapp.modeler[cyl2].material_name == "aluminum"
 
     def test_67_cover_lines(self):
-        P1 = self.aedtapp.modeler.primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]], close_surface=True)
+        P1 = self.aedtapp.modeler.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]], close_surface=True)
         assert self.aedtapp.modeler.cover_lines(P1)
 
     @pyaedt_unittest_check_desktop_error
@@ -927,25 +911,25 @@ class TestClass(BasisTest):
     def test_69_create_torus_exceptions(self):
 
         with pytest.raises(ValueError) as excinfo:
-            self.aedtapp.modeler.primitives.create_torus(
+            self.aedtapp.modeler.create_torus(
                 [30, 30], major_radius=-0.3, minor_radius=0.5, axis="Z", name="torus", material_name="Copper"
             )
             assert "Center argument must be a valid 3 element sequence." in str(excinfo.value)
 
         # with pytest.raises(ValueError) as excinfo:
-        #     self.aedtapp.modeler.primitives.create_torus(
+        #     self.aedtapp.modeler.create_torus(
         #         [30, 30, 0], major_radius=-0.3, minor_radius=0.5, axis="Z", name="torus", material_name="Copper"
         #     )
         #     assert "Both major and minor radius must be greater than 0" in str(excinfo.value)
 
         # with pytest.raises(ValueError) as excinfo:
-        #     self.aedtapp.modeler.primitives.create_torus(
+        #     self.aedtapp.modeler.create_torus(
         #         [30, 30, 0], major_radius=1, minor_radius=0, axis="Z", name="torus", material_name="Copper"
         #     )
         #     assert "Both major and minor radius must be greater than 0" in str(excinfo.value)
 
         # with pytest.raises(ValueError) as excinfo:
-        #     self.aedtapp.modeler.primitives.create_torus(
+        #     self.aedtapp.modeler.create_torus(
         #         [30, 30, 0], major_radius=1, minor_radius=1.2, axis="Z", name="torus", material_name="Copper"
         #     )
         #     assert "Major radius must be greater than minor radius." in str(excinfo.value)
@@ -953,11 +937,11 @@ class TestClass(BasisTest):
     @pyaedt_unittest_check_desktop_error
     def test_70_create_point(self):
         name = "mypoint"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
-        point = self.aedtapp.modeler.primitives.create_point([30, 30, 0], name)
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
+        point = self.aedtapp.modeler.create_point([30, 30, 0], name)
         point.set_color("(143 175 158)")
-        point2 = self.aedtapp.modeler.primitives.create_point([50, 30, 0], "mypoint2", "(100 100 100)")
+        point2 = self.aedtapp.modeler.create_point([50, 30, 0], "mypoint2", "(100 100 100)")
         point.logger.info("Creation and testing of a point.")
 
         assert point.name == "mypoint"
@@ -965,11 +949,11 @@ class TestClass(BasisTest):
         assert point2.name == "mypoint2"
         assert point2.coordinate_system == "Global"
 
-        assert self.aedtapp.modeler.primitives.points_by_name[point.name] == point
-        assert self.aedtapp.modeler.primitives.points_by_name[point2.name] == point2
+        assert self.aedtapp.modeler.points_by_name[point.name] == point
+        assert self.aedtapp.modeler.points_by_name[point2.name] == point2
 
         # Delete the first point
-        assert len(self.aedtapp.modeler.primitives.points) == 2
-        self.aedtapp.modeler.primitives.points_by_name[point.name].delete()
-        assert len(self.aedtapp.modeler.primitives.points) == 1
-        assert self.aedtapp.modeler.primitives.points[0].name == "mypoint2"
+        assert len(self.aedtapp.modeler.points) == 2
+        self.aedtapp.modeler.points_by_name[point.name].delete()
+        assert len(self.aedtapp.modeler.points) == 1
+        assert self.aedtapp.modeler.points[0].name == "mypoint2"

--- a/_unittest/test_09_Primitives2D.py
+++ b/_unittest/test_09_Primitives2D.py
@@ -19,36 +19,36 @@ class TestClass(BasisTest):
     def create_rectangle(self, name=None):
         if not name:
             name = "MyRectangle"
-        if self.aedtapp.modeler.primitives[name]:
-            self.aedtapp.modeler.primitives.delete(name)
-        o = self.aedtapp.modeler.primitives.create_rectangle([5, 3, 0], [4, 5], name=name)
+        if self.aedtapp.modeler[name]:
+            self.aedtapp.modeler.delete(name)
+        o = self.aedtapp.modeler.create_rectangle([5, 3, 0], [4, 5], name=name)
         return o
 
     @pyaedt_unittest_check_desktop_error
     def test_02_create_primitive(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        o = self.aedtapp.modeler.primitives.create_rectangle(udp, [5, 3], name="Rectangle1", matname="copper")
+        o = self.aedtapp.modeler.create_rectangle(udp, [5, 3], name="Rectangle1", matname="copper")
         assert isinstance(o.id, int)
         assert o.solve_inside
 
     @pyaedt_unittest_check_desktop_error
     def test_03_create_circle(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        o1 = self.aedtapp.modeler.primitives.create_circle(udp, 3, 0, name="Circle1", matname="copper")
+        o1 = self.aedtapp.modeler.create_circle(udp, 3, 0, name="Circle1", matname="copper")
         assert isinstance(o1.id, int)
-        o2 = self.aedtapp.modeler.primitives.create_circle(udp, 3, 8, name="Circle2", matname="copper")
+        o2 = self.aedtapp.modeler.create_circle(udp, 3, 8, name="Circle2", matname="copper")
         assert isinstance(o2.id, int)
 
     @pyaedt_unittest_check_desktop_error
     def test_04_create_ellipse(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        o = self.aedtapp.modeler.primitives.create_ellipse(udp, 3, 2, name="Ellipse1", matname="copper")
+        o = self.aedtapp.modeler.create_ellipse(udp, 3, 2, name="Ellipse1", matname="copper")
         assert isinstance(o.id, int)
 
     @pyaedt_unittest_check_desktop_error
     def test_05_create_poly(self):
         udp = [self.aedtapp.modeler.Position(0, 0, 0), self.aedtapp.modeler.Position(10, 5, 0)]
-        o = self.aedtapp.modeler.primitives.create_polyline(udp, name="Ellipse1", matname="copper")
+        o = self.aedtapp.modeler.create_polyline(udp, name="Ellipse1", matname="copper")
         assert isinstance(o, Polyline)
 
     @pyaedt_unittest_check_desktop_error
@@ -63,17 +63,17 @@ class TestClass(BasisTest):
 
     @pyaedt_unittest_check_desktop_error
     def test_06_create_region(self):
-        if self.aedtapp.modeler.primitives["Region"]:
-            self.aedtapp.modeler.primitives.delete("Region")
-        assert "Region" not in self.aedtapp.modeler.primitives.object_names
-        region = self.aedtapp.modeler.primitives.create_region([100, 100, 100, 100])
+        if self.aedtapp.modeler["Region"]:
+            self.aedtapp.modeler.delete("Region")
+        assert "Region" not in self.aedtapp.modeler.object_names
+        region = self.aedtapp.modeler.create_region([100, 100, 100, 100])
         assert region.solve_inside
         assert region.model
         assert region.display_wireframe
         assert region.object_type == "Sheet"
         assert region.solve_inside
 
-        region = self.aedtapp.modeler.primitives.create_region([100, 100, 100, 100, 100, 100])
+        region = self.aedtapp.modeler.create_region([100, 100, 100, 100, 100, 100])
         assert not region
 
     # TODO Implement parametrize
@@ -83,15 +83,15 @@ class TestClass(BasisTest):
     @pyaedt_unittest_check_desktop_error
     def test_07_assign_material(self, material):
         self.aedtapp.assign_material(["Rectangle1"], material)
-        assert self.aedtapp.modeler.primitives["Rectangle1"].material_name == material
+        assert self.aedtapp.modeler["Rectangle1"].material_name == material
     """
 
     @pyaedt_unittest_check_desktop_error
     def test_07_assign_material_ceramic(self, material="ceramic_material"):
         self.aedtapp.assign_material(["Rectangle1"], material)
-        assert self.aedtapp.modeler.primitives["Rectangle1"].material_name == material
+        assert self.aedtapp.modeler["Rectangle1"].material_name == material
 
     @pyaedt_unittest_check_desktop_error
     def test_07_assign_material(self, material="steel_stainless"):
         self.aedtapp.assign_material(["Rectangle1"], material)
-        assert self.aedtapp.modeler.primitives["Rectangle1"].material_name == material
+        assert self.aedtapp.modeler["Rectangle1"].material_name == material

--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -40,20 +40,20 @@ class TestClass:
     def test_02_create_primitive(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 200
-        o1 = self.aedtapp.modeler.primitives.create_cylinder(self.aedtapp.AXIS.X, udp, 3, coax_dimension, 0, "inner")
+        o1 = self.aedtapp.modeler.create_cylinder(self.aedtapp.AXIS.X, udp, 3, coax_dimension, 0, "inner")
         assert isinstance(o1.id, int)
-        o2 = self.aedtapp.modeler.primitives.create_cylinder(self.aedtapp.AXIS.X, udp, 10, coax_dimension, 0, "outer")
+        o2 = self.aedtapp.modeler.create_cylinder(self.aedtapp.AXIS.X, udp, 10, coax_dimension, 0, "outer")
         assert isinstance(o2.id, int)
         assert self.aedtapp.modeler.subtract(o2, o1, True)
 
     def test_03_2_assign_material(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 200
-        cyl_1 = self.aedtapp.modeler.primitives.create_cylinder(self.aedtapp.AXIS.X, udp, 10, coax_dimension, 0, "die")
+        cyl_1 = self.aedtapp.modeler.create_cylinder(self.aedtapp.AXIS.X, udp, 10, coax_dimension, 0, "die")
         self.aedtapp.modeler.subtract(cyl_1, "inner", True)
-        self.aedtapp.modeler.primitives["inner"].material_name = "Copper"
+        self.aedtapp.modeler["inner"].material_name = "Copper"
         cyl_1.material_name = "teflon_based"
-        assert self.aedtapp.modeler.primitives["inner"].material_name == "copper"
+        assert self.aedtapp.modeler["inner"].material_name == "copper"
         assert cyl_1.material_name == "teflon_based"
 
     @pytest.mark.parametrize(
@@ -77,7 +77,7 @@ class TestClass:
         ],
     )
     def test_04_assign_coating(self, object_name, kwargs):
-        id = self.aedtapp.modeler.primitives.get_obj_id(object_name)
+        id = self.aedtapp.modeler.get_obj_id(object_name)
         coat = self.aedtapp.assign_coating([id], **kwargs)
         coat.name = "Coating1" + object_name
         assert coat.update()
@@ -86,7 +86,7 @@ class TestClass:
 
     def test_05_create_wave_port_from_sheets(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        o5 = self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1")
+        o5 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1")
         self.aedtapp.solution_type = "Terminal"
         port = self.aedtapp.create_wave_port_from_sheet(
             o5, 5, self.aedtapp.AxisDir.XNeg, 40, 2, "sheet1_Port", renorm=False, terminal_references=["outer"]
@@ -97,15 +97,15 @@ class TestClass:
 
         self.aedtapp.solution_type = "Modal"
         udp = self.aedtapp.modeler.Position(200, 0, 0)
-        o6 = self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet2")
+        o6 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet2")
         port = self.aedtapp.create_wave_port_from_sheet(o6, 5, self.aedtapp.AxisDir.XPos, 40, 2, "sheet2_Port", True)
         assert port.name == "sheet2_Port"
         assert port.name in [i.name for i in self.aedtapp.boundaries]
         assert port.props["RenormalizeAllTerminals"] is True
 
-        id6 = self.aedtapp.modeler.primitives.create_box([20, 20, 20], [10, 10, 2], matname="Copper", name="My_Box")
-        id7 = self.aedtapp.modeler.primitives.create_box([20, 25, 30], [10, 2, 2], matname="Copper")
-        rect = self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.PLANE.YZ, [20, 25, 20], [2, 10])
+        id6 = self.aedtapp.modeler.create_box([20, 20, 20], [10, 10, 2], matname="Copper", name="My_Box")
+        id7 = self.aedtapp.modeler.create_box([20, 25, 30], [10, 2, 2], matname="Copper")
+        rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [20, 25, 20], [2, 10])
         ports = self.aedtapp.create_wave_port_from_sheet(rect, 5, self.aedtapp.AxisDir.ZNeg, 40, 2, "sheet3_Port", True)
         assert ports.name in [i.name for i in self.aedtapp.boundaries]
         pass
@@ -236,8 +236,8 @@ class TestClass:
         assert setuptd.name not in self.aedtapp.existing_analysis_setups
 
     def test_06f_sweep_add_subrange(self):
-        box_sweep = self.aedtapp.modeler.primitives.create_box([0, 0, 20], [10, 10, 5], "box_sweep", "Copper")
-        box_sweep2 = self.aedtapp.modeler.primitives.create_box([0, 0, 30], [10, 10, 5], "box_sweep2", "Copper")
+        box_sweep = self.aedtapp.modeler.create_box([0, 0, 20], [10, 10, 5], "box_sweep", "Copper")
+        box_sweep2 = self.aedtapp.modeler.create_box([0, 0, 30], [10, 10, 5], "box_sweep2", "Copper")
         port = self.aedtapp.create_wave_port_between_objects(
             "box_sweep", "box_sweep2", self.aedtapp.AxisDir.XNeg, 50, 1, "WaveForSweep", False
         )
@@ -250,8 +250,8 @@ class TestClass:
         assert sweep.add_subrange("LogScale", 1, 3, 10, "GHz")
 
     def test_06g_sweep_clear_subrange(self):
-        box_sweep3 = self.aedtapp.modeler.primitives.create_box([0, 0, 50], [10, 10, 5], "box_sweep3", "Copper")
-        box_sweep4 = self.aedtapp.modeler.primitives.create_box([0, 0, 60], [10, 10, 5], "box_sweep4", "Copper")
+        box_sweep3 = self.aedtapp.modeler.create_box([0, 0, 50], [10, 10, 5], "box_sweep3", "Copper")
+        box_sweep4 = self.aedtapp.modeler.create_box([0, 0, 60], [10, 10, 5], "box_sweep4", "Copper")
         port = self.aedtapp.create_wave_port_between_objects(
             "box_sweep3", "box_sweep4", self.aedtapp.AxisDir.XNeg, 50, 1, "WaveForSweepWithClear", False
         )
@@ -297,11 +297,11 @@ class TestClass:
 
     def test_08_create_circuit_port_from_edges(self):
         plane = self.aedtapp.PLANE.XY
-        rect_1 = self.aedtapp.modeler.primitives.create_rectangle(plane, [10, 10, 10], [10, 10], name="rect1_for_port")
-        edges1 = self.aedtapp.modeler.primitives.get_object_edges(rect_1.id)
+        rect_1 = self.aedtapp.modeler.create_rectangle(plane, [10, 10, 10], [10, 10], name="rect1_for_port")
+        edges1 = self.aedtapp.modeler.get_object_edges(rect_1.id)
         e1 = edges1[0]
-        rect_2 = self.aedtapp.modeler.primitives.create_rectangle(plane, [30, 10, 10], [10, 10], name="rect2_for_port")
-        edges2 = self.aedtapp.modeler.primitives.get_object_edges(rect_2.id)
+        rect_2 = self.aedtapp.modeler.create_rectangle(plane, [30, 10, 10], [10, 10], name="rect2_for_port")
+        edges2 = self.aedtapp.modeler.get_object_edges(rect_2.id)
         e2 = edges2[0]
 
         self.aedtapp.solution_type = "Modal"
@@ -343,8 +343,8 @@ class TestClass:
         self.aedtapp.solution_type = "Modal"
 
     def test_09_create_waveport_on_objects(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], "BoxWG1", "Copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 10], [10, 10, 5], "BoxWG2", "copper")
+        box1 = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "BoxWG1", "Copper")
+        box2 = self.aedtapp.modeler.create_box([0, 0, 10], [10, 10, 5], "BoxWG2", "copper")
         box2.material_name = "Copper"
         port = self.aedtapp.create_wave_port_between_objects(
             "BoxWG1", "BoxWG2", self.aedtapp.AxisDir.XNeg, 50, 1, "Wave1", False
@@ -357,10 +357,10 @@ class TestClass:
 
     def test_09a_create_waveport_on_true_surface_objects(self):
         cs = self.aedtapp.PLANE.XY
-        o1 = self.aedtapp.modeler.primitives.create_cylinder(
+        o1 = self.aedtapp.modeler.create_cylinder(
             cs, [0, 0, 0], radius=5, height=100, numSides=0, name="inner", matname="Copper"
         )
-        o3 = self.aedtapp.modeler.primitives.create_cylinder(
+        o3 = self.aedtapp.modeler.create_cylinder(
             cs, [0, 0, 0], radius=10, height=100, numSides=0, name="outer", matname="Copper"
         )
 
@@ -370,9 +370,9 @@ class TestClass:
         assert port1.name.startswith("P1")
 
     def test_10_create_lumped_on_objects(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 50], [10, 10, 5], "BoxLumped1")
+        box1 = self.aedtapp.modeler.create_box([0, 0, 50], [10, 10, 5], "BoxLumped1")
         box1.material_name = "Copper"
-        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 60], [10, 10, 5], "BoxLumped2")
+        box2 = self.aedtapp.modeler.create_box([0, 0, 60], [10, 10, 5], "BoxLumped2")
         box2.material_name = "Copper"
         port = self.aedtapp.create_lumped_port_between_objects(
             "BoxLumped1", "BoxLumped2", self.aedtapp.AxisDir.XNeg, 50, "Lump1xx", True, False
@@ -388,8 +388,8 @@ class TestClass:
         assert port.update()
 
     def test_11_create_circuit_on_objects(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 80], [10, 10, 5], "BoxCircuit1", "Copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 100], [10, 10, 5], "BoxCircuit2", "copper")
+        box1 = self.aedtapp.modeler.create_box([0, 0, 80], [10, 10, 5], "BoxCircuit1", "Copper")
+        box2 = self.aedtapp.modeler.create_box([0, 0, 100], [10, 10, 5], "BoxCircuit2", "copper")
         box2.material_name = "Copper"
         port = self.aedtapp.create_circuit_port_between_objects(
             "BoxCircuit1", "BoxCircuit2", self.aedtapp.AxisDir.XNeg, 50, "Circ1", True, 50, False
@@ -400,8 +400,8 @@ class TestClass:
         )
 
     def test_12_create_perfects_on_objects(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], "perfect1", "Copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 10], [10, 10, 5], "perfect2", "copper")
+        box1 = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "perfect1", "Copper")
+        box2 = self.aedtapp.modeler.create_box([0, 0, 10], [10, 10, 5], "perfect2", "copper")
         pe = self.aedtapp.create_perfecth_from_objects(
             "perfect1",
             "perfect2",
@@ -414,15 +414,15 @@ class TestClass:
         assert ph.update()
 
     def test_13_create_impedance_on_objects(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], "imp1", "Copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 10], [10, 10, 5], "imp2", "copper")
+        box1 = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "imp1", "Copper")
+        box2 = self.aedtapp.modeler.create_box([0, 0, 10], [10, 10, 5], "imp2", "copper")
         imp = self.aedtapp.create_impedance_between_objects("imp1", "imp2", self.aedtapp.AxisDir.XPos, "TL2", 50, 25)
         assert imp.name in self.aedtapp.modeler.get_boundaries_name()
         assert imp.update()
 
     def test_14_create_lumpedrlc_on_objects(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 5], "rlc1", "Copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([0, 0, 10], [10, 10, 5], "rlc2", "copper")
+        box1 = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 5], "rlc1", "Copper")
+        box2 = self.aedtapp.modeler.create_box([0, 0, 10], [10, 10, 5], "rlc2", "copper")
         imp = self.aedtapp.create_lumped_rlc_between_objects(
             "rlc1", "rlc2", self.aedtapp.AxisDir.XPos, Rvalue=50, Lvalue=1e-9
         )
@@ -430,7 +430,7 @@ class TestClass:
         assert imp.update()
 
     def test_15_create_perfects_on_sheets(self):
-        rect = self.aedtapp.modeler.primitives.create_rectangle(
+        rect = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="RectBound", matname="Copper"
         )
         pe = self.aedtapp.assign_perfecte_to_sheets(rect.name)
@@ -439,7 +439,7 @@ class TestClass:
         assert ph.name in self.aedtapp.modeler.get_boundaries_name()
 
     def test_16_create_impedance_on_sheets(self):
-        rect = self.aedtapp.modeler.primitives.create_rectangle(
+        rect = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="ImpBound", matname="Copper"
         )
         imp = self.aedtapp.assign_impedance_to_sheet("imp1", "TL2", 50, 25)
@@ -447,7 +447,7 @@ class TestClass:
         assert imp.update()
 
     def test_17_create_lumpedrlc_on_sheets(self):
-        rect = self.aedtapp.modeler.primitives.create_rectangle(
+        rect = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="rlcBound", matname="Copper"
         )
         imp = self.aedtapp.assign_lumped_rlc_to_sheet(rect.name, self.aedtapp.AxisDir.XPos, Rvalue=50, Lvalue=1e-9)
@@ -455,14 +455,14 @@ class TestClass:
         assert imp.name in self.aedtapp.modeler.get_boundaries_name()
 
     def test_17B_update_assignment(self):
-        bound = self.aedtapp.assign_perfecth_to_sheets(self.aedtapp.modeler.primitives["My_Box"].faces[0].id)
+        bound = self.aedtapp.assign_perfecth_to_sheets(self.aedtapp.modeler["My_Box"].faces[0].id)
         assert bound
-        bound.props["Faces"].append(self.aedtapp.modeler.primitives["My_Box"].faces[1])
+        bound.props["Faces"].append(self.aedtapp.modeler["My_Box"].faces[1])
         assert bound.update_assignment()
 
     def test_18_create_sources_on_objects(self):
-        box1 = self.aedtapp.modeler.primitives.create_box([30, 0, 0], [40, 10, 5], "BoxVolt1", "Copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([30, 0, 10], [40, 10, 5], "BoxVolt2", "Copper")
+        box1 = self.aedtapp.modeler.create_box([30, 0, 0], [40, 10, 5], "BoxVolt1", "Copper")
+        box2 = self.aedtapp.modeler.create_box([30, 0, 10], [40, 10, 5], "BoxVolt2", "Copper")
         port = self.aedtapp.create_voltage_source_from_objects(
             box1.name, "BoxVolt2", self.aedtapp.AxisDir.XNeg, "Volt1"
         )
@@ -473,7 +473,7 @@ class TestClass:
         assert port.name in self.aedtapp.modeler.get_excitations_name()
 
     def test_19_create_lumped_on_sheet(self):
-        rect = self.aedtapp.modeler.primitives.create_rectangle(
+        rect = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="lump_port", matname="Copper"
         )
         port = self.aedtapp.create_lumped_port_to_sheet(
@@ -482,7 +482,7 @@ class TestClass:
         assert port.name + ":1" in self.aedtapp.modeler.get_excitations_name()
 
     def test_20_create_voltage_on_sheet(self):
-        rect = self.aedtapp.modeler.primitives.create_rectangle(
+        rect = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="lump_volt", matname="Copper"
         )
         port = self.aedtapp.assign_voltage_source_to_sheet(rect.name, self.aedtapp.AxisDir.XNeg, "LumpVolt1")
@@ -558,16 +558,16 @@ class TestClass:
         assert self.aedtapp.mesh.assign_initial_mesh_from_slider(6)
 
     def test_31_create_microstrip_port(self):
-        ms = self.aedtapp.modeler.primitives.create_box([4, 5, 0], [1, 100, 0.2], name="MS1", matname="copper")
-        sub = self.aedtapp.modeler.primitives.create_box([0, 5, -2], [20, 100, 2], name="SUB1", matname="FR4_epoxy")
-        gnd = self.aedtapp.modeler.primitives.create_box([0, 5, -2.2], [20, 100, 0.2], name="GND1", matname="FR4_epoxy")
+        ms = self.aedtapp.modeler.create_box([4, 5, 0], [1, 100, 0.2], name="MS1", matname="copper")
+        sub = self.aedtapp.modeler.create_box([0, 5, -2], [20, 100, 2], name="SUB1", matname="FR4_epoxy")
+        gnd = self.aedtapp.modeler.create_box([0, 5, -2.2], [20, 100, 0.2], name="GND1", matname="FR4_epoxy")
         port = self.aedtapp.create_wave_port_microstrip_between_objects(gnd.name, ms.name, portname="MS1", axisdir=1)
 
         assert port.name == "MS1"
         assert port.update()
 
     def test_32_get_property_value(self):
-        rect = self.aedtapp.modeler.primitives.create_rectangle(
+        rect = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="RectBound", matname="Copper"
         )
         pe = self.aedtapp.assign_perfecte_to_sheets(rect.name, "PerfectE_1")
@@ -578,7 +578,7 @@ class TestClass:
         project_name = "HfssCopiedProject"
         design_name = "HfssCopiedBodies"
         new_design = Hfss(projectname=project_name, designname=design_name)
-        num_orig_bodies = len(self.aedtapp.modeler.primitives.solid_names)
+        num_orig_bodies = len(self.aedtapp.modeler.solid_names)
         assert new_design.copy_solid_bodies_from(self.aedtapp, no_vacuum=False, no_pec=False)
         assert len(new_design.modeler.solid_bodies) == num_orig_bodies
         new_design.delete_design(design_name)
@@ -593,14 +593,14 @@ class TestClass:
         assert self.aedtapp.set_export_touchstone(False)
 
     def test_36_assign_radiation_to_objects(self):
-        self.aedtapp.modeler.primitives.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box")
+        self.aedtapp.modeler.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box")
         rad = self.aedtapp.assign_radiation_boundary_to_objects("Rad_box")
         rad.name = "Radiation1"
         assert rad.update()
 
     def test_37_assign_radiation_to_objects(self):
-        self.aedtapp.modeler.primitives.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box2")
-        ids = [i.id for i in self.aedtapp.modeler.primitives["Rad_box2"].faces]
+        self.aedtapp.modeler.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box2")
+        ids = [i.id for i in self.aedtapp.modeler["Rad_box2"].faces]
         assert self.aedtapp.assign_radiation_boundary_to_faces(ids)
 
     def test_38_get_all_sources(self):
@@ -611,7 +611,7 @@ class TestClass:
         assert self.aedtapp.set_source_context(["port10", "port11"])
 
     def test_40_assign_current_source_to_sheet(self):
-        sheet = self.aedtapp.modeler.primitives.create_rectangle(
+        sheet = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [0, 0, 0], [5, 1], name="RectangleForSource", matname="Copper"
         )
         assert self.aedtapp.assign_current_source_to_sheet(sheet.name)
@@ -625,14 +625,14 @@ class TestClass:
         self.aedtapp.insert_design("floquet")
         self.aedtapp.solution_type = "Modal"
 
-        box1 = self.aedtapp.modeler.primitives.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box2")
+        box1 = self.aedtapp.modeler.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box2")
         assert self.aedtapp.create_floquet_port(
             box1.faces[0], deembed_dist=1, nummodes=7, reporter_filter=[False, True, False, False, False, False, False]
         )
         assert self.aedtapp.create_floquet_port(
             box1.faces[1], deembed_dist=1, nummodes=7, reporter_filter=[False, True, False, False, False, False, False]
         )
-        sheet = self.aedtapp.modeler.primitives.create_rectangle(
+        sheet = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [-100, -100, -100], [200, 200], name="RectangleForSource", matname="Copper"
         )
         bound = self.aedtapp.create_floquet_port(sheet, deembed_dist=1, nummodes=4, reporter_filter=False)
@@ -642,10 +642,10 @@ class TestClass:
 
     def test_43_autoassign_pairs(self):
         self.aedtapp.insert_design("lattice")
-        box1 = self.aedtapp.modeler.primitives.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box2")
+        box1 = self.aedtapp.modeler.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box2")
         assert len(self.aedtapp.auto_assign_lattice_pairs(box1)) == 2
         box1.delete()
-        box1 = self.aedtapp.modeler.primitives.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box2")
+        box1 = self.aedtapp.modeler.create_box([-100, -100, -100], [200, 200, 200], name="Rad_box2")
         assert self.aedtapp.assign_lattice_pair([box1.faces[2], box1.faces[4]])
         primary = self.aedtapp.assign_primary(box1.faces[1], [100, -100, -100], [100, 100, -100])
         assert primary
@@ -703,10 +703,8 @@ class TestClass:
     def test_45_terminal_port(self):
         self.aedtapp.insert_design("Design_Terminal")
         self.aedtapp.solution_type = "Terminal"
-        box1 = self.aedtapp.modeler.primitives.create_box([-100, -100, 0], [200, 200, 5], name="gnd", matname="copper")
-        box2 = self.aedtapp.modeler.primitives.create_box(
-            [-100, -100, 20], [200, 200, 25], name="sig", matname="copper"
-        )
+        box1 = self.aedtapp.modeler.create_box([-100, -100, 0], [200, 200, 5], name="gnd", matname="copper")
+        box2 = self.aedtapp.modeler.create_box([-100, -100, 20], [200, 200, 25], name="sig", matname="copper")
         sheet = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [-100, -100, 5], [200, 15], "port")
         port = self.aedtapp.create_lumped_port_between_objects(
             box1, box2.name, self.aedtapp.AxisDir.XNeg, 50, "Lump1", True, False
@@ -717,8 +715,8 @@ class TestClass:
         )
         assert port2.name + "_T1" in self.aedtapp.modeler.get_excitations_name()
 
-        box1 = self.aedtapp.modeler.primitives.create_box([-40, -40, -20], [80, 80, 10], name="gnd", matname="copper")
-        box2 = self.aedtapp.modeler.primitives.create_box([-40, -40, 10], [80, 80, 10], name="sig", matname="copper")
+        box1 = self.aedtapp.modeler.create_box([-40, -40, -20], [80, 80, 10], name="gnd", matname="copper")
+        box2 = self.aedtapp.modeler.create_box([-40, -40, 10], [80, 80, 10], name="sig", matname="copper")
         boundaries = len(self.aedtapp.boundaries)
         assert self.aedtapp.create_spiral_lumped_port(box1, box2)
         assert len(self.aedtapp.boundaries) - boundaries == 3

--- a/_unittest/test_27_Maxwell2D.py
+++ b/_unittest/test_27_Maxwell2D.py
@@ -30,18 +30,18 @@ class TestClass(BasisTest):
 
         bounds = self.aedtapp.assign_winding(current_value=20e-3, coil_terminals=["Coil"])
         assert bounds
-        o = self.aedtapp.modeler.primitives.create_rectangle([0, 0, 0], [3, 1], name="Rectangle2", matname="copper")
+        o = self.aedtapp.modeler.create_rectangle([0, 0, 0], [3, 1], name="Rectangle2", matname="copper")
         bounds = self.aedtapp.assign_winding(current_value=20e-3, coil_terminals=o.id)
         assert bounds
 
     @pyaedt_unittest_check_desktop_error
     def test_05_create_vector_potential(self):
-        region = self.aedtapp.modeler.primitives["Region"]
+        region = self.aedtapp.modeler["Region"]
         edge_object = region.edges[0]
         bounds = self.aedtapp.assign_vector_potential(edge_object.id, 3)
         assert bounds
         assert bounds.props["Value"] == "3"
-        line = self.aedtapp.modeler.primitives.create_polyline([[0, 0, 0], [1, 0, 1]], name="myline")
+        line = self.aedtapp.modeler.create_polyline([[0, 0, 0], [1, 0, 1]], name="myline")
         bound2 = self.aedtapp.assign_vector_potential(line.id, 2)
         assert bound2
         assert bound2.props["Value"] == "2"
@@ -71,7 +71,7 @@ class TestClass(BasisTest):
 
     @pyaedt_unittest_check_desktop_error
     def test_12_assign_current_source(self):
-        coil = self.aedtapp.modeler.primitives.create_circle(
+        coil = self.aedtapp.modeler.create_circle(
             position=[0, 0, 0], radius="5", num_sides="8", is_covered=True, name="Coil", matname="Copper"
         )
         assert self.aedtapp.assign_current([coil])
@@ -80,8 +80,8 @@ class TestClass(BasisTest):
     @pyaedt_unittest_check_desktop_error
     def test_13_assign_master_slave(self):
         mas, slave = self.aedtapp.assign_master_slave(
-            self.aedtapp.modeler.primitives["Rectangle2"].edges[0].id,
-            self.aedtapp.modeler.primitives["Rectangle2"].edges[2].id,
+            self.aedtapp.modeler["Rectangle2"].edges[0].id,
+            self.aedtapp.modeler["Rectangle2"].edges[2].id,
         )
         assert "Independent" in mas.name
         assert "Dependent" in slave.name
@@ -97,8 +97,8 @@ class TestClass(BasisTest):
         self.aedtapp.insert_design("Motion")
         self.aedtapp.solution_type = SOLUTIONS.Maxwell2d.TransientZ
         self.aedtapp.xy_plane = True
-        self.aedtapp.modeler.primitives.create_circle([0, 0, 0], 10, name="Circle_inner")
-        self.aedtapp.modeler.primitives.create_circle([0, 0, 0], 30, name="Circle_outer")
+        self.aedtapp.modeler.create_circle([0, 0, 0], 10, name="Circle_inner")
+        self.aedtapp.modeler.create_circle([0, 0, 0], 30, name="Circle_outer")
         bound = self.aedtapp.assign_rotate_motion("Circle_outer", positive_limit=300, mechanical_transient=True)
         assert bound
         assert bound.props["PositivePos"] == "300deg"

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -37,12 +37,8 @@ class TestClass:
         plate_pos = self.aedtapp.modeler.Position(0, 0, 0)
         hole_pos = self.aedtapp.modeler.Position(18, 18, 0)
         # Create plate with hole
-        plate = self.aedtapp.modeler.primitives.create_box(
-            plate_pos, [294, 294, 19], name="Plate"
-        )  # All positions in model units
-        hole = self.aedtapp.modeler.primitives.create_box(
-            hole_pos, [108, 108, 19], name="Hole"
-        )  # All positions in model units
+        plate = self.aedtapp.modeler.create_box(plate_pos, [294, 294, 19], name="Plate")  # All positions in model units
+        hole = self.aedtapp.modeler.create_box(hole_pos, [108, 108, 19], name="Hole")  # All positions in model units
         self.aedtapp.modeler.subtract([plate], [hole])
         plate.material_name = "aluminum"
         assert plate.solve_inside
@@ -51,10 +47,10 @@ class TestClass:
     def test_02_create_coil(self):
         center_hole = self.aedtapp.modeler.Position(119, 25, 49)
         center_coil = self.aedtapp.modeler.Position(94, 0, 49)
-        coil_hole = self.aedtapp.modeler.primitives.create_box(
+        coil_hole = self.aedtapp.modeler.create_box(
             center_hole, [150, 150, 100], name="Coil_Hole"
         )  # All positions in model units
-        coil = self.aedtapp.modeler.primitives.create_box(
+        coil = self.aedtapp.modeler.create_box(
             center_coil, [200, 200, 100], name="Coil"
         )  # All positions in model units
         self.aedtapp.modeler.subtract([coil], [coil_hole])
@@ -69,10 +65,10 @@ class TestClass:
     def test_04_coil_terminal(self):
         self.aedtapp.modeler.section(["Coil"], self.aedtapp.PLANE.ZX)
         self.aedtapp.modeler.separate_bodies(["Coil_Section1"])
-        self.aedtapp.modeler.primitives.delete("Coil_Section1_Separate1")
+        self.aedtapp.modeler.delete("Coil_Section1_Separate1")
         assert self.aedtapp.assign_current(["Coil_Section1"], amplitude=2472)
         self.aedtapp.solution_type = "Magnetostatic"
-        volt = self.aedtapp.assign_voltage(self.aedtapp.modeler.primitives["Coil_Section1"].faces[0].id, amplitude=1)
+        volt = self.aedtapp.assign_voltage(self.aedtapp.modeler["Coil_Section1"].faces[0].id, amplitude=1)
         cur2 = self.aedtapp.assign_current(["Coil_Section1"], amplitude=212)
         assert cur2
         assert cur2.delete()
@@ -81,7 +77,7 @@ class TestClass:
         self.aedtapp.solution_type = "EddyCurrent"
 
     def test_05_winding(self):
-        assert self.aedtapp.assign_winding(self.aedtapp.modeler.primitives["Coil_Section1"].faces[0].id)
+        assert self.aedtapp.assign_winding(self.aedtapp.modeler["Coil_Section1"].faces[0].id)
 
     def test_05_draw_region(self):
         assert self.aedtapp.modeler.create_air_region(*[300] * 6)
@@ -159,7 +155,7 @@ class TestClass:
 
         # Test udp with a custom name.
         my_udpName = "MyClawPoleCore"
-        udp = self.aedtapp.modeler.primitives.create_udp(
+        udp = self.aedtapp.modeler.create_udp(
             udp_dll_name="RMxprt/ClawPoleCore",
             udp_parameters_list=my_udpPairs,
             upd_library="syslib",
@@ -171,7 +167,7 @@ class TestClass:
         assert "MyClawPoleCore" in udp._primitives.object_names
 
         # Test udp with default name -None-.
-        second_udp = self.aedtapp.modeler.primitives.create_udp(
+        second_udp = self.aedtapp.modeler.create_udp(
             udp_dll_name="RMxprt/ClawPoleCore",
             udp_parameters_list=my_udpPairs,
             upd_library="syslib",
@@ -208,7 +204,7 @@ class TestClass:
         mypair = ["Via Thickness (VT)", "0.001mm"]
         my_udmPairs.append(mypair)
 
-        assert self.aedtapp.modeler.primitives.create_udm(
+        assert self.aedtapp.modeler.create_udm(
             udmfullname="Maxwell3D/OnDieSpiralInductor.py", udm_params_list=my_udmPairs, udm_library="syslib"
         )
 
@@ -221,8 +217,8 @@ class TestClass:
     def test_30_assign_movement(self):
         self.aedtapp.insert_design("Motion")
         self.aedtapp.solution_type = SOLUTIONS.Maxwell3d.Transient
-        self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 10], name="Inner_Box")
-        self.aedtapp.modeler.primitives.create_box([0, 0, 0], [30, 20, 20], name="Outer_Box")
+        self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 10], name="Inner_Box")
+        self.aedtapp.modeler.create_box([0, 0, 0], [30, 20, 20], name="Outer_Box")
         bound = self.aedtapp.assign_translate_motion("Outer_Box", mechanical_transient=True, velocity=1)
         assert bound
         assert bound.props["Velocity"] == "1m_per_sec"

--- a/_unittest/test_29_Mechanical.py
+++ b/_unittest/test_29_Mechanical.py
@@ -36,17 +36,17 @@ class TestClass:
     def test_02_create_primitive(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        o = self.aedtapp.modeler.primitives.create_cylinder(
+        o = self.aedtapp.modeler.create_cylinder(
             self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass"
         )
         assert isinstance(o.id, int)
 
     def test_03_assign_convection(self):
-        face = self.aedtapp.modeler.primitives["MyCylinder"].faces[0].id
+        face = self.aedtapp.modeler["MyCylinder"].faces[0].id
         assert self.aedtapp.assign_uniform_convection(face, 3)
 
     def test_04_assign_temperature(self):
-        face = self.aedtapp.modeler.primitives["MyCylinder"].faces[1].id
+        face = self.aedtapp.modeler["MyCylinder"].faces[1].id
         bound = self.aedtapp.assign_uniform_temperature(face, "35deg")
         assert bound.props["Temperature"] == "35deg"
 
@@ -54,13 +54,11 @@ class TestClass:
         hfss = Hfss()
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        id1 = hfss.modeler.primitives.create_cylinder(
-            self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass"
-        )
+        id1 = hfss.modeler.create_cylinder(self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         setup = hfss.create_setup()
         freq = "1GHz"
         setup.props["Frequency"] = freq
-        ids_faces = [i.id for i in hfss.modeler.primitives["MyCylinder"].faces]
+        ids_faces = [i.id for i in hfss.modeler["MyCylinder"].faces]
         assert self.aedtapp.assign_em_losses(
             hfss.design_name,
             hfss.setups[0].name,
@@ -78,19 +76,19 @@ class TestClass:
         ipk = Icepak(solution_type=self.aedtapp.SOLUTIONS.Icepak.SteadyTemperatureAndFlow)
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        id1 = ipk.modeler.primitives.create_cylinder(ipk.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        id1 = ipk.modeler.create_cylinder(ipk.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         setup = ipk.create_setup()
         mech = Mechanical(solution_type=self.aedtapp.SOLUTIONS.Mechanical.Structural)
-        mech.modeler.primitives.create_cylinder(mech.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        mech.modeler.create_cylinder(mech.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
         assert mech.assign_thermal_map("MyCylinder", ipk.design_name)
 
     def test_07_assign_mechanical_boundaries(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
         mech = Mechanical(solution_type=self.aedtapp.SOLUTIONS.Mechanical.Modal)
-        mech.modeler.primitives.create_cylinder(mech.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
-        assert mech.assign_fixed_support(mech.modeler.primitives["MyCylinder"].faces[0].id)
-        assert mech.assign_frictionless_support(mech.modeler.primitives["MyCylinder"].faces[1].id)
+        mech.modeler.create_cylinder(mech.PLANE.XY, udp, 3, coax_dimension, 0, "MyCylinder", "brass")
+        assert mech.assign_fixed_support(mech.modeler["MyCylinder"].faces[0].id)
+        assert mech.assign_frictionless_support(mech.modeler["MyCylinder"].faces[1].id)
 
     def test_08_mesh_settings(self):
         assert self.aedtapp.mesh.initial_mesh_settings

--- a/_unittest/test_30_Q2D.py
+++ b/_unittest/test_30_Q2D.py
@@ -31,7 +31,7 @@ class TestClass:
 
     def test_02_create_primitive(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        o = self.aedtapp.modeler.primitives.create_rectangle(udp, [5, 3], name="Rectangle1")
+        o = self.aedtapp.modeler.create_rectangle(udp, [5, 3], name="Rectangle1")
         assert isinstance(o.id, int)
 
     def test_02a_create_rectangle(self):
@@ -45,7 +45,7 @@ class TestClass:
 
     def test_07_single_signal_line(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
-        o = self.aedtapp.modeler.primitives.create_rectangle(udp, [5, 3], name="Rectangle1")
+        o = self.aedtapp.modeler.create_rectangle(udp, [5, 3], name="Rectangle1")
         assert self.aedtapp.assign_single_conductor(target_objects=o, solve_option="SolveOnBoundary")
 
     def test_08_assign_huray_finitecond_to_edges(self):

--- a/_unittest/test_31_Q3D.py
+++ b/_unittest/test_31_Q3D.py
@@ -35,7 +35,7 @@ class TestClass:
     def test_02_create_primitive(self):
         udp = self.aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 30
-        o = self.aedtapp.modeler.primitives.create_cylinder(
+        o = self.aedtapp.modeler.create_cylinder(
             self.aedtapp.PLANE.XY, udp, 3, coax_dimension, 0, matname="brass", name="MyCylinder"
         )
         assert isinstance(o.id, int)
@@ -74,16 +74,16 @@ class TestClass:
         assert sink.name == "Sink1"
 
     def test_07B_create_source_tosheet(self):
-        self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.XY, [0, 0, 0], 4, name="Source1")
-        self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.XY, [10, 10, 10], 4, name="Sink1")
+        self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.XY, [0, 0, 0], 4, name="Source1")
+        self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.XY, [10, 10, 10], 4, name="Sink1")
 
         source = self.aedtapp.assign_source_to_sheet("Source1", sourcename="Source3")
         sink = self.aedtapp.assign_sink_to_sheet("Sink1", sinkname="Sink3")
         assert source.name == "Source3"
         assert sink.name == "Sink3"
 
-        self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.XY, [0, 0, 0], 4, name="Source1")
-        self.aedtapp.modeler.primitives.create_circle(self.aedtapp.PLANE.XY, [10, 10, 10], 4, name="Sink1")
+        self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.XY, [0, 0, 0], 4, name="Source1")
+        self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.XY, [10, 10, 10], 4, name="Sink1")
 
         source = self.aedtapp.assign_source_to_sheet("Source1", netname="GND", objectname="Cylinder1")
         sink = self.aedtapp.assign_sink_to_sheet("Sink1", netname="GND", objectname="Cylinder1")

--- a/_unittest/test_40_3dlayout_edb.py
+++ b/_unittest/test_40_3dlayout_edb.py
@@ -35,7 +35,7 @@ class TestClass:
         gc.collect()
 
     def test_01_get_components(self):
-        comp = self.aedtapp.modeler.primitives.components
+        comp = self.aedtapp.modeler.components
         assert len(comp) > 0
         assert comp["L3A1"].object_units == "mm"
         assert comp["L3A1"].get_angle()
@@ -46,7 +46,7 @@ class TestClass:
         assert comp["L3A1"].set_property_value("Angle", "0deg")
 
     def test_02_get_geometries(self):
-        geo = self.aedtapp.modeler.primitives.geometries
+        geo = self.aedtapp.modeler.geometries
         assert len(geo) > 0
         assert geo["line_1983"].object_units == "mm"
         assert geo["line_1983"].get_placement_layer()
@@ -56,7 +56,7 @@ class TestClass:
         assert geo["line_1983"].set_net_name("VCC")
 
     def test_03_get_pins(self):
-        pins = self.aedtapp.modeler.primitives.pins
+        pins = self.aedtapp.modeler.pins
         assert len(pins) > 0
         assert pins["L3A1-1"].object_units == "mm"
         assert pins["L3A1-1"].get_angle()

--- a/_unittest/test_41_3dlayout_modeler.py
+++ b/_unittest/test_41_3dlayout_modeler.py
@@ -126,40 +126,40 @@ class TestClass:
         s1.update_stackup_layer()
 
     def test_03_create_circle(self):
-        n1 = self.aedtapp.modeler.primitives.create_circle("Top", 0, 5, 40, "mycircle")
+        n1 = self.aedtapp.modeler.create_circle("Top", 0, 5, 40, "mycircle")
         assert n1 == "mycircle"
 
     def test_04_create_create_rectangle(self):
-        n2 = self.aedtapp.modeler.primitives.create_rectangle("Top", [0, 0], [6, 8], 3, 2, "myrectangle")
+        n2 = self.aedtapp.modeler.create_rectangle("Top", [0, 0], [6, 8], 3, 2, "myrectangle")
         assert n2 == "myrectangle"
 
     def test_05_subtract(self):
         assert self.aedtapp.modeler.subtract("mycircle", "myrectangle")
 
     def test_06_unite(self):
-        n1 = self.aedtapp.modeler.primitives.create_circle("Top", 0, 5, 8, "mycircle2")
-        n2 = self.aedtapp.modeler.primitives.create_rectangle("Top", [0, 0], [6, 8], 3, 2, "myrectangle2")
+        n1 = self.aedtapp.modeler.create_circle("Top", 0, 5, 8, "mycircle2")
+        n2 = self.aedtapp.modeler.create_rectangle("Top", [0, 0], [6, 8], 3, 2, "myrectangle2")
         assert self.aedtapp.modeler.unite([n1, n2])
 
     def test_07_intersect(self):
-        n1 = self.aedtapp.modeler.primitives.create_circle("Top", 0, 5, 8, "mycircle3")
-        n2 = self.aedtapp.modeler.primitives.create_rectangle("Top", [0, 0], [6, 8], 3, 2, "myrectangle3")
+        n1 = self.aedtapp.modeler.create_circle("Top", 0, 5, 8, "mycircle3")
+        n2 = self.aedtapp.modeler.create_rectangle("Top", [0, 0], [6, 8], 3, 2, "myrectangle3")
         assert self.aedtapp.modeler.intersect([n1, n2])
 
     def test_08_objectlist(self):
-        a = self.aedtapp.modeler.primitives.geometries
+        a = self.aedtapp.modeler.geometries
         assert len(a) > 0
 
     def test_09_modify_padstack(self):
-        pad_0 = self.aedtapp.modeler.primitives.padstacks["PlanarEMVia"]
-        assert self.aedtapp.modeler.primitives.padstacks["PlanarEMVia"].plating != 55
+        pad_0 = self.aedtapp.modeler.padstacks["PlanarEMVia"]
+        assert self.aedtapp.modeler.padstacks["PlanarEMVia"].plating != 55
         pad_0.plating = 55
         pad_0.update()
-        self.aedtapp.modeler.primitives.init_padstacks()
-        assert self.aedtapp.modeler.primitives.padstacks["PlanarEMVia"].plating == "55"
+        self.aedtapp.modeler.init_padstacks()
+        assert self.aedtapp.modeler.padstacks["PlanarEMVia"].plating == "55"
 
     def test_10_create_padstack(self):
-        pad1 = self.aedtapp.modeler.primitives.new_padstack("My_padstack2")
+        pad1 = self.aedtapp.modeler.new_padstack("My_padstack2")
         hole1 = pad1.add_hole()
         pad1.add_layer("Start", pad_hole=hole1, thermal_hole=hole1)
         hole2 = pad1.add_hole(holetype="Rct", sizes=[0.5, 0.8])
@@ -170,13 +170,13 @@ class TestClass:
         assert pad1.create()
 
     def test_11_create_via(self):
-        via = self.aedtapp.modeler.primitives.create_via("My_padstack2", x=0, y=0)
+        via = self.aedtapp.modeler.create_via("My_padstack2", x=0, y=0)
         assert type(via) is str
-        via = self.aedtapp.modeler.primitives.create_via("My_padstack2", x=10, y=10, name="Via123", netname="VCC")
+        via = self.aedtapp.modeler.create_via("My_padstack2", x=10, y=10, name="Via123", netname="VCC")
         assert via == "Via123"
 
     def test_12_create_line(self):
-        line = self.aedtapp.modeler.primitives.create_line(
+        line = self.aedtapp.modeler.create_line(
             "Bottom", [[0, 0], [10, 30], [20, 30]], lw=1, name="line1", netname="VCC"
         )
         assert line == "line1"
@@ -383,14 +383,14 @@ class TestClass:
         assert new_material.name == "secondmaterial"
 
     def test30_expand(self):
-        self.aedtapp.modeler.primitives.create_rectangle("Bottom", [20, 20], [50, 50], name="rect_1")
-        self.aedtapp.modeler.primitives.create_line("Bottom", [[25, 25], [40, 40]], name="line_3")
+        self.aedtapp.modeler.create_rectangle("Bottom", [20, 20], [50, 50], name="rect_1")
+        self.aedtapp.modeler.create_line("Bottom", [[25, 25], [40, 40]], name="line_3")
         out1 = self.aedtapp.modeler.expand("line_3", size=1, expand_type="ROUND", replace_original=False)
         assert isinstance(out1, str)
 
     def test31_heal(self):
-        l1 = self.aedtapp.modeler.primitives.create_line("Bottom", [[0, 0], [100, 0]], 0.5, name="poly_1111")
-        l2 = self.aedtapp.modeler.primitives.create_line("Bottom", [[100, 0], [120, -35]], 0.5, name="poly_2222")
+        l1 = self.aedtapp.modeler.create_line("Bottom", [[0, 0], [100, 0]], 0.5, name="poly_1111")
+        l2 = self.aedtapp.modeler.create_line("Bottom", [[100, 0], [120, -35]], 0.5, name="poly_2222")
         self.aedtapp.modeler.unite([l1, l2])
         assert self.aedtapp.modeler.colinear_heal("poly_2222", tolerance=0.25)
 

--- a/_unittest/test_97_SBR.py
+++ b/_unittest/test_97_SBR.py
@@ -89,12 +89,12 @@ class TestClass:
         self.aedtapp.insert_design("Environment_test")
         self.aedtapp.solution_type = "SBR+"
         env_folder = os.path.join(local_path, "example_models", "library", "environment_library", "tunnel1")
-        road1 = self.aedtapp.modeler.primitives.add_environment(env_folder)
+        road1 = self.aedtapp.modeler.add_environment(env_folder)
         assert road1.name
 
     def test_05_add_person(self):
         person_folder = os.path.join(local_path, "example_models", "library", "actor_library", "person3")
-        person1 = self.aedtapp.modeler.primitives.add_person(person_folder, 1.0, [25, 1.5, 0], 180)
+        person1 = self.aedtapp.modeler.add_person(person_folder, 1.0, [25, 1.5, 0], 180)
         assert person1.offset == [25, 1.5, 0]
         assert person1.yaw == "180deg"
         assert person1.pitch == "0deg"
@@ -102,7 +102,7 @@ class TestClass:
 
     def test_06_add_car(self):
         car_folder = os.path.join(local_path, "example_models", "library", "actor_library", "vehicle1")
-        car1 = self.aedtapp.modeler.primitives.add_vehicle(car_folder, 1.0, [3, -2.5, 0])
+        car1 = self.aedtapp.modeler.add_vehicle(car_folder, 1.0, [3, -2.5, 0])
         assert car1.offset == [3, -2.5, 0]
         assert car1.yaw == "0deg"
         assert car1.pitch == "0deg"
@@ -110,7 +110,7 @@ class TestClass:
 
     def test_07_add_bird(self):
         bird_folder = os.path.join(local_path, "example_models", "library", "actor_library", "bird1")
-        bird1 = self.aedtapp.modeler.primitives.add_bird(bird_folder, 1.0, [19, 4, 3], 120, -5, flapping_rate=30)
+        bird1 = self.aedtapp.modeler.add_bird(bird_folder, 1.0, [19, 4, 3], 120, -5, flapping_rate=30)
         assert bird1.offset == [19, 4, 3]
         assert bird1.yaw == "120deg"
         assert bird1.pitch == "-5deg"

--- a/_unittest/test_98_Icepak.py
+++ b/_unittest/test_98_Icepak.py
@@ -200,17 +200,17 @@ class TestClass:
         assert test
 
     def test_13a_assign_openings(self):
-        airfaces = [self.aedtapp.modeler.primitives["Region"].top_face_x.id]
+        airfaces = [self.aedtapp.modeler["Region"].top_face_x.id]
         openings = self.aedtapp.assign_openings(airfaces)
         openings.name = "Test_Opening"
         assert openings.update()
 
     def test_13b_assign_grille(self):
-        airfaces = [self.aedtapp.modeler.primitives["Region"].top_face_y.id]
+        airfaces = [self.aedtapp.modeler["Region"].top_face_y.id]
         grille = self.aedtapp.assign_grille(airfaces)
         grille.props["Free Area Ratio"] = 0.7
         assert grille.update()
-        airfaces = [self.aedtapp.modeler.primitives["Region"].bottom_face_x.id]
+        airfaces = [self.aedtapp.modeler["Region"].bottom_face_x.id]
         grille2 = self.aedtapp.assign_grille(
             airfaces, free_loss_coeff=False, x_curve=["0", "3", "5"], y_curve=["0", "2", "3"]
         )
@@ -228,13 +228,13 @@ class TestClass:
         assert self.aedtapp.problem_type == "FlowOnly"
         self.aedtapp.problem_type = "TemperatureAndFlow"
         assert self.aedtapp.problem_type == "TemperatureAndFlow"
-        self.aedtapp.modeler.primitives.create_box([0, 0, 0], [10, 10, 10], "box", "copper")
-        self.aedtapp.modeler.primitives.create_box([9, 9, 9], [5, 5, 5], "box2", "copper")
+        self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 10], "box", "copper")
+        self.aedtapp.modeler.create_box([9, 9, 9], [5, 5, 5], "box2", "copper")
         self.aedtapp.create_source_block("box", "1W", False)
         setup = self.aedtapp.create_setup("SetupIPK")
         new_props = {"Convergence Criteria - Max Iterations": 3}
         assert setup.update(update_dictionary=new_props)
-        airfaces = [i.id for i in self.aedtapp.modeler.primitives["Region"].faces]
+        airfaces = [i.id for i in self.aedtapp.modeler["Region"].faces]
         self.aedtapp.assign_openings(airfaces)
 
     def test_16_check_priorities(self):
@@ -257,7 +257,7 @@ class TestClass:
         assert self.aedtapp.export_summary()
 
     def test_19_eval_htc(self):
-        box = [i.id for i in self.aedtapp.modeler.primitives["box"].faces]
+        box = [i.id for i in self.aedtapp.modeler["box"].faces]
         assert os.path.exists(self.aedtapp.eval_surface_quantity_from_field_summary(box, savedir=scratch_path))
 
     def test_20_eval_tempc(self):
@@ -274,14 +274,14 @@ class TestClass:
         assert os.path.exists(fld_file)
 
     def test_22_create_source_blocks_from_list(self):
-        self.aedtapp.modeler.primitives.create_box([1, 1, 1], [3, 3, 3], "box3", "copper")
+        self.aedtapp.modeler.create_box([1, 1, 1], [3, 3, 3], "box3", "copper")
         result = self.aedtapp.create_source_blocks_from_list([["box2", 2], ["box3", 3]])
         assert result[1].props["Total Power"] == "2W"
         assert result[3].props["Total Power"] == "3W"
 
     def test_23_create_network_blocks(self):
-        self.aedtapp.modeler.primitives.create_box([1, 2, 3], [10, 10, 10], "network_box", "copper")
-        self.aedtapp.modeler.primitives.create_box([4, 5, 6], [5, 5, 5], "network_box2", "copper")
+        self.aedtapp.modeler.create_box([1, 2, 3], [10, 10, 10], "network_box", "copper")
+        self.aedtapp.modeler.create_box([4, 5, 6], [5, 5, 5], "network_box2", "copper")
         result = self.aedtapp.create_network_blocks(
             [["network_box", 20, 10, 3], ["network_box2", 4, 10, 3]], self.aedtapp.GravityDirection.ZNeg, 1.05918, False
         )
@@ -326,8 +326,8 @@ class TestClass:
         assert mat.thermal_conductivity.type == "anisotropic"
 
     def test_33_create_region(self):
-        self.aedtapp.modeler.primitives.delete("Region")
-        assert isinstance(self.aedtapp.modeler.primitives.create_region([100, 100, 100, 100, 100, 100]).id, int)
+        self.aedtapp.modeler.delete("Region")
+        assert isinstance(self.aedtapp.modeler.create_region([100, 100, 100, 100, 100, 100]).id, int)
 
     def test_34_automatic_mesh_pcb(self):
         assert self.aedtapp.mesh.automatic_mesh_pcb()
@@ -337,18 +337,16 @@ class TestClass:
         assert self.aedtapp.mesh.automatic_mesh_3D(accuracy2=1)
 
     def test_36_create_source(self):
-        self.aedtapp.modeler.primitives.create_box([0, 0, 0], [20, 20, 20], name="boxSource")
+        self.aedtapp.modeler.create_box([0, 0, 0], [20, 20, 20], name="boxSource")
+        assert self.aedtapp.create_source_power(self.aedtapp.modeler["boxSource"].top_face_z.id, input_power="2W")
         assert self.aedtapp.create_source_power(
-            self.aedtapp.modeler.primitives["boxSource"].top_face_z.id, input_power="2W"
-        )
-        assert self.aedtapp.create_source_power(
-            self.aedtapp.modeler.primitives["boxSource"].bottom_face_z.id,
+            self.aedtapp.modeler["boxSource"].bottom_face_z.id,
             thermal_condtion="Fixed Temperature",
             temperature="28cel",
         )
 
     def test_37_surface_monitor(self):
-        self.aedtapp.modeler.primitives.create_rectangle(self.aedtapp.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
+        self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.XY, [0, 0, 0], [10, 20], name="surf1")
         assert self.aedtapp.assign_surface_monitor("surf1")
 
     def test_38_point_monitor(self):
@@ -382,9 +380,9 @@ class TestClass:
     def test_89_check_bounding_box(self):
 
         self.aedtapp.insert_design("Bbox")
-        obj_1 = self.aedtapp.modeler.primitives.get_object_from_name("Region")
+        obj_1 = self.aedtapp.modeler.get_object_from_name("Region")
         obj_1_bbox = obj_1.bounding_box
-        obj_2 = self.aedtapp.modeler.primitives.create_box([0.2, 0.2, 0.2], [0.3, 0.4, 0.2], name="Box1")
+        obj_2 = self.aedtapp.modeler.create_box([0.2, 0.2, 0.2], [0.3, 0.4, 0.2], name="Box1")
         obj_2_bbox = obj_2.bounding_box
         count = 0
         tol = 1e-9

--- a/examples/01-Modeling-Setup/HFSS_CoordinateSystem.py
+++ b/examples/01-Modeling-Setup/HFSS_CoordinateSystem.py
@@ -146,8 +146,8 @@ cs_selected.delete()
 # ------------------------------------------------------
 # A point coordinate can be translated in respect to any coordinate system.
 
-hfss.modeler.primitives.create_box([-10, -10, -10], [20, 20, 20], "Box1")
-p = hfss.modeler.primitives["Box1"].faces[0].vertices[0].position
+hfss.modeler.create_box([-10, -10, -10], [20, 20, 20], "Box1")
+p = hfss.modeler["Box1"].faces[0].vertices[0].position
 print("Global: ", p)
 p2 = hfss.modeler.global_to_cs(p, "CS5")
 print("CS5 :", p2)

--- a/examples/01-Modeling-Setup/Polyline_Primitives.py
+++ b/examples/01-Modeling-Setup/Polyline_Primitives.py
@@ -23,7 +23,7 @@ M3D = Maxwell3d(
     solution_type="Transient", designname="test_polyline_3D", specified_version="2021.2", new_desktop_session=True
 )
 M3D.modeler.model_units = "mm"
-prim3D = M3D.modeler.primitives
+prim3D = M3D.modeler
 
 ###############################################################################
 # Clear Existing Objects

--- a/examples/02-HFSS/EDB_in_3DLayout.py
+++ b/examples/02-HFSS/EDB_in_3DLayout.py
@@ -73,14 +73,14 @@ h3d.boundaries
 # ~~~~~~~~~~~~~
 # This example hides all nets.
 
-h3d.modeler.primitives.change_net_visibility(visible=False)
+h3d.modeler.change_net_visibility(visible=False)
 
 ###############################################################################
 # Show Only Two Nets
 # ~~~~~~~~~~~~~~~~~~
 # This examples shows only the two specified nets.
 
-h3d.modeler.primitives.change_net_visibility(["A0_GPIO", "A0_MUX"], visible=True)
+h3d.modeler.change_net_visibility(["A0_GPIO", "A0_MUX"], visible=True)
 
 ###############################################################################
 # Show All Layers

--- a/examples/02-HFSS/HFSS3DLayout_Via.py
+++ b/examples/02-HFSS/HFSS3DLayout_Via.py
@@ -41,21 +41,21 @@ h3d.modeler.layers.add_layer("TOP", "signal", thickness="0.035mm", elevation="0.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This example create a signal net and ground planes.
 
-h3d.modeler.primitives.create_line("TOP", [[0, 0], ["len", 0]], lw="w1", netname="microstrip", name="microstrip")
-h3d.modeler.primitives.create_rectangle("TOP", [0, "-w1/2-sp"], ["len", "-w1/2-sp-20mm"])
-h3d.modeler.primitives.create_rectangle("TOP", [0, "w1/2+sp"], ["len", "w1/2+sp+20mm"])
+h3d.modeler.create_line("TOP", [[0, 0], ["len", 0]], lw="w1", netname="microstrip", name="microstrip")
+h3d.modeler.create_rectangle("TOP", [0, "-w1/2-sp"], ["len", "-w1/2-sp-20mm"])
+h3d.modeler.create_rectangle("TOP", [0, "w1/2+sp"], ["len", "w1/2+sp+20mm"])
 
 ###############################################################################
 # Create Vias with Parametric Positions
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This example creates vias with parametric positions.
 
-h3d.modeler.primitives.create_via(x="viatovia", y="-viatotrace", name="via1")
-h3d.modeler.primitives.create_via(x="viatovia", y="viatotrace", name="via2")
-h3d.modeler.primitives.create_via(x="2*viatovia", y="-viatotrace")
-h3d.modeler.primitives.create_via(x="2*viatovia", y="viatotrace")
-h3d.modeler.primitives.create_via(x="3*viatovia", y="-viatotrace")
-h3d.modeler.primitives.create_via(x="3*viatovia", y="viatotrace")
+h3d.modeler.create_via(x="viatovia", y="-viatotrace", name="via1")
+h3d.modeler.create_via(x="viatovia", y="viatotrace", name="via2")
+h3d.modeler.create_via(x="2*viatovia", y="-viatotrace")
+h3d.modeler.create_via(x="2*viatovia", y="viatotrace")
+h3d.modeler.create_via(x="3*viatovia", y="-viatotrace")
+h3d.modeler.create_via(x="3*viatovia", y="viatotrace")
 
 ###############################################################################
 # Add Circuit Ports

--- a/examples/02-HFSS/HFSS_Dipole.py
+++ b/examples/02-HFSS/HFSS_Dipole.py
@@ -48,7 +48,7 @@ hfss["l_dipole"] = "13.5cm"
 compfile = hfss.components3d["Dipole_Antenna_DM"]
 geometryparams = hfss.get_components3d_vars("Dipole_Antenna_DM")
 geometryparams["dipole_length"] = "l_dipole"
-hfss.modeler.primitives.insert_3d_component(compfile, geometryparams)
+hfss.modeler.insert_3d_component(compfile, geometryparams)
 
 ###############################################################################
 # Create Boundaries

--- a/examples/02-HFSS/HFSS_Spiral.py
+++ b/examples/02-HFSS/HFSS_Spiral.py
@@ -18,7 +18,7 @@ from pyaedt import Hfss, constants
 # Change units to micron
 hfss = Hfss(specified_version="2021.2", non_graphical=False, designname="A1")
 hfss.modeler.model_units = "um"
-p = hfss.modeler.primitives
+p = hfss.modeler
 
 #############################################################
 # Input Variables. Edit it to change your inductor.

--- a/examples/02-HFSS/SBR_Doppler_Example.py
+++ b/examples/02-HFSS/SBR_Doppler_Example.py
@@ -71,27 +71,25 @@ bird_folder = os.path.join(actor_lib, "bird1")
 # ~~~~~~~~~~~~~~
 # Define background environment
 
-road1 = app.modeler.primitives.add_environment(env_folder=env_folder, environment_name="Bari")
-prim = app.modeler.primitives
+road1 = app.modeler.add_environment(env_folder=env_folder, environment_name="Bari")
+prim = app.modeler
 
 ###############################################################################
 # Actors
 # ~~~~~~~~~~~~~~~~~~~~~
 # Put Actors in environment. This example has persons, birds, bikes and cars.
 
-person1 = app.modeler.primitives.add_person(
+person1 = app.modeler.add_person(
     actor_folder=person_folder, speed=1.0, global_offset=[25, 1.5, 0], yaw=180, actor_name="Massimo"
 )
-person2 = app.modeler.primitives.add_person(
+person2 = app.modeler.add_person(
     actor_folder=person_folder, speed=1.0, global_offset=[25, 2.5, 0], yaw=180, actor_name="Devin"
 )
-car1 = app.modeler.primitives.add_vehicle(
-    actor_folder=car_folder, speed=8.7, global_offset=[3, -2.5, 0], actor_name="LuxuryCar"
-)
-bike1 = app.modeler.primitives.add_vehicle(
+car1 = app.modeler.add_vehicle(actor_folder=car_folder, speed=8.7, global_offset=[3, -2.5, 0], actor_name="LuxuryCar")
+bike1 = app.modeler.add_vehicle(
     actor_folder=bike_folder, speed=2.1, global_offset=[24, 3.6, 0], yaw=180, actor_name="Alberto_in_bike"
 )
-bird1 = app.modeler.primitives.add_bird(
+bird1 = app.modeler.add_bird(
     actor_folder=bird_folder,
     speed=1.0,
     global_offset=[19, 4, 3],
@@ -100,7 +98,7 @@ bird1 = app.modeler.primitives.add_bird(
     flapping_rate=30,
     actor_name="Pigeon",
 )
-bird2 = app.modeler.primitives.add_bird(
+bird2 = app.modeler.add_bird(
     actor_folder=bird_folder, speed=1.0, global_offset=[6, 2, 3], yaw=-60, pitch=10, actor_name="Eagle"
 )
 

--- a/examples/02-Maxwell/Maxwell2D_Eddy.py
+++ b/examples/02-Maxwell/Maxwell2D_Eddy.py
@@ -29,8 +29,8 @@ M3D.modeler.model_units = "mm"
 # ~~~~~~~~~~~~~~~~
 # This example creates a box that is to be used in the simulation.
 
-plate = M3D.modeler.primitives.create_box([0, 0, 0], [294, 294, 19], name="Plate", matname="aluminum")
-hole = M3D.modeler.primitives.create_box([18, 18, 0], [108, 108, 19], name="Hole")
+plate = M3D.modeler.create_box([0, 0, 0], [294, 294, 19], name="Plate", matname="aluminum")
+hole = M3D.modeler.create_box([18, 18, 0], [108, 108, 19], name="Hole")
 
 ###############################################################################
 # Perform Modeler Operations
@@ -56,10 +56,8 @@ M3D.save_project(project_name)
 
 center_hole = M3D.modeler.Position(119, 25, 49)
 center_coil = M3D.modeler.Position(94, 0, 49)
-coil_hole = M3D.modeler.primitives.create_box(
-    center_hole, [150, 150, 100], name="Coil_Hole"
-)  # All positions in model units
-coil = M3D.modeler.primitives.create_box(center_coil, [200, 200, 100], name="Coil")  # All positions in model units
+coil_hole = M3D.modeler.create_box(center_hole, [150, 150, 100], name="Coil_Hole")  # All positions in model units
+coil = M3D.modeler.create_box(center_coil, [200, 200, 100], name="Coil")  # All positions in model units
 M3D.modeler.subtract([coil], [coil_hole])
 coil.material_name = "copper"
 coil.solve_inside = True
@@ -79,7 +77,7 @@ M3D.modeler.create_coordinate_system(origin=[200, 100, 0], mode="view", view="XY
 
 M3D.modeler.section(["Coil"], M3D.PLANE.ZX)
 M3D.modeler.separate_bodies(["Coil_Section1"])
-M3D.modeler.primitives.delete("Coil_Section1_Separate1")
+M3D.modeler.delete("Coil_Section1_Separate1")
 M3D.assign_current(["Coil_Section1"], amplitude=2472)
 
 ###############################################################################

--- a/examples/02-Maxwell/Maxwell2D_Transient.py
+++ b/examples/02-Maxwell/Maxwell2D_Transient.py
@@ -44,16 +44,16 @@ maxwell_2d.save_project(os.path.join(project_dir, "M2d.aedt"))
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This example creates a rectangle and then duplicates it.
 
-rect1 = maxwell_2d.modeler.primitives.create_rectangle([0, 0, 0], [10, 20], name="winding", matname="copper")
+rect1 = maxwell_2d.modeler.create_rectangle([0, 0, 0], [10, 20], name="winding", matname="copper")
 added = rect1.duplicate_along_line([14, 0, 0])
-rect2 = maxwell_2d.modeler.primitives[added[0]]
+rect2 = maxwell_2d.modeler[added[0]]
 
 ###############################################################################
 # Create an Air Region
 # ~~~~~~~~~~~~~~~~~~~~
 # This command creates an air region.
 
-region = maxwell_2d.modeler.primitives.create_region([100, 100, 100, 100, 100, 100])
+region = maxwell_2d.modeler.create_region([100, 100, 100, 100, 100, 100])
 
 ###############################################################################
 # Assign Windings to Sheets and a Balloon to the Air Region

--- a/examples/02-Maxwell/Maxwell3DTeam3.py
+++ b/examples/02-Maxwell/Maxwell3DTeam3.py
@@ -30,7 +30,7 @@ M3D = Maxwell3d(
     new_desktop_session=True,
 )
 uom = M3D.modeler.model_units = "mm"
-primitives = M3D.modeler.primitives
+primitives = M3D.modeler
 
 ###############################################################################
 # Add the variable Coil Position, it will later be used to adjust position of the coil
@@ -51,9 +51,9 @@ M3D.modeler.create_air_region(x_pos=100, y_pos=100, z_pos=100, x_neg=100, y_neg=
 
 ################################################################################
 # Draw ladder plate and assign 'team3_aluminium'
-M3D.modeler.primitives.create_box([-30, -55, 0], [60, 110, -6.35], name="LadderPlate", matname="team3_aluminium")
-M3D.modeler.primitives.create_box([-20, -35, 0], [40, 30, -6.35], name="CutoutTool1")
-M3D.modeler.primitives.create_box([-20, 5, 0], [40, 30, -6.35], name="CutoutTool2")
+M3D.modeler.create_box([-30, -55, 0], [60, 110, -6.35], name="LadderPlate", matname="team3_aluminium")
+M3D.modeler.create_box([-20, -35, 0], [40, 30, -6.35], name="CutoutTool1")
+M3D.modeler.create_box([-20, 5, 0], [40, 30, -6.35], name="CutoutTool2")
 M3D.modeler.subtract("LadderPlate", ["CutoutTool1", "CutoutTool2"], keepOriginals=False)
 
 ################################################################################
@@ -63,16 +63,16 @@ M3D.mesh.assign_length_mesh("LadderPlate", maxlength=3, maxel=None, meshop_name=
 ################################################################################
 # Draw Search Coil and Assign a Stranded Current Excitation
 # The 'stranded' type forces current density to be constant in the coil
-M3D.modeler.primitives.create_cylinder(
+M3D.modeler.create_cylinder(
     cs_axis="Z", position=[0, "Coil_Position", 15], radius=40, height=20, name="SearchCoil", matname="copper"
 )
-M3D.modeler.primitives.create_cylinder(
+M3D.modeler.create_cylinder(
     cs_axis="Z", position=[0, "Coil_Position", 15], radius=20, height=20, name="Bore", matname="copper"
 )
 M3D.modeler.subtract("SearchCoil", "Bore", keepOriginals=False)
 M3D.modeler.section("SearchCoil", "YZ")
 M3D.modeler.separate_bodies("SearchCoil_Section1")
-M3D.modeler.primitives.delete("SearchCoil_Section1_Separate1")
+M3D.modeler.delete("SearchCoil_Section1_Separate1")
 M3D.assign_current(["SearchCoil_Section1"], amplitude=1260, solid=False, name="SearchCoil_Excitation")
 
 ################################################################################

--- a/examples/02-Maxwell/Maxwell3D_TEAM7.py
+++ b/examples/02-Maxwell/Maxwell3D_TEAM7.py
@@ -29,8 +29,8 @@ M3D.modeler.model_units = "mm"
 # ~~~~~~~~~~~~~~~~
 # This example creates a box that is to be used in the simulation.
 
-plate = M3D.modeler.primitives.create_box([0, 0, 0], [294, 294, 19], name="Plate", matname="aluminum")
-hole = M3D.modeler.primitives.create_box([18, 18, 0], [108, 108, 19], name="Hole")
+plate = M3D.modeler.create_box([0, 0, 0], [294, 294, 19], name="Plate", matname="aluminum")
+hole = M3D.modeler.create_box([18, 18, 0], [108, 108, 19], name="Hole")
 
 ###############################################################################
 # Perform Modeler Operations
@@ -56,10 +56,8 @@ M3D.save_project(project_name)
 
 center_hole = M3D.modeler.Position(119, 25, 49)
 center_coil = M3D.modeler.Position(94, 0, 49)
-coil_hole = M3D.modeler.primitives.create_box(
-    center_hole, [150, 150, 100], name="Coil_Hole"
-)  # All positions in model units
-coil = M3D.modeler.primitives.create_box(center_coil, [200, 200, 100], name="Coil")  # All positions in model units
+coil_hole = M3D.modeler.create_box(center_hole, [150, 150, 100], name="Coil_Hole")  # All positions in model units
+coil = M3D.modeler.create_box(center_coil, [200, 200, 100], name="Coil")  # All positions in model units
 M3D.modeler.subtract([coil], [coil_hole])
 coil.material_name = "copper"
 coil.solve_inside = True
@@ -79,7 +77,7 @@ M3D.modeler.create_coordinate_system(origin=[200, 100, 0], mode="view", view="XY
 
 M3D.modeler.section(["Coil"], M3D.PLANE.ZX)
 M3D.modeler.separate_bodies(["Coil_Section1"])
-M3D.modeler.primitives.delete("Coil_Section1_Separate1")
+M3D.modeler.delete("Coil_Section1_Separate1")
 M3D.assign_current(["Coil_Section1"], amplitude=2472)
 
 ###############################################################################

--- a/examples/02-Maxwell/Maxwell_Magnet.py
+++ b/examples/02-Maxwell/Maxwell_Magnet.py
@@ -31,7 +31,7 @@ m3d.solution_type = m3d.SOLUTIONS.Maxwell3d.ElectroDCConduction
 # Create Magnet
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-magnet = m3d.modeler.primitives.create_box([7, 4, 22], [10, 5, 30], name="Magnet", matname="copper")
+magnet = m3d.modeler.create_box([7, 4, 22], [10, 5, 30], name="Magnet", matname="copper")
 
 
 ###############################################################################

--- a/examples/04-Icepak/Icepak_Example.py
+++ b/examples/04-Icepak/Icepak_Example.py
@@ -55,7 +55,7 @@ ipk.create_source_block(["MEMORY1", "MEMORY1_1"], "5W")
 # ~~~~~~~~~~~~~~~~~
 # Assign Opening and Grille
 
-region = ipk.modeler.primitives["Region"]
+region = ipk.modeler["Region"]
 ipk.assign_openings(air_faces=region.bottom_face_x.id)
 ipk.assign_grille(air_faces=region.top_face_x.id, free_area_ratio=0.8)
 
@@ -93,10 +93,10 @@ ipk.save_project(r"C:\temp\Graphic_card.aedt")
 # Solve Project and plot Temperatures
 
 quantity_name = "SurfTemperature"
-surflist = [i.id for i in ipk.modeler.primitives["CPU"].faces]
-surflist += [i.id for i in ipk.modeler.primitives["MEMORY1"].faces]
-surflist += [i.id for i in ipk.modeler.primitives["MEMORY1_1"].faces]
-surflist += [i.id for i in ipk.modeler.primitives["ALPHA_MAIN_PCB"].faces]
+surflist = [i.id for i in ipk.modeler["CPU"].faces]
+surflist += [i.id for i in ipk.modeler["MEMORY1"].faces]
+surflist += [i.id for i in ipk.modeler["MEMORY1_1"].faces]
+surflist += [i.id for i in ipk.modeler["ALPHA_MAIN_PCB"].faces]
 
 plot5 = ipk.post.create_fieldplot_surface(surflist, "SurfTemperature")
 

--- a/examples/04-Icepak/Sherlock_Example.py
+++ b/examples/04-Icepak/Sherlock_Example.py
@@ -72,7 +72,7 @@ ipk = Icepak()
 # This example remove the region and disables autosave to speed up the import.
 
 d.disable_autosave()
-ipk.modeler.primitives.delete("Region")
+ipk.modeler.delete("Region")
 component_name = "from_ODB"
 
 ###############################################################################
@@ -121,7 +121,7 @@ ipk.plot(show=False, export_path=os.path.join(temp_folder, "Sherlock_Example.jpg
 # ~~~~~~~~~~~~~~~~~~
 # This command removes the PCB objects.
 
-ipk.modeler.primitives.delete_objects_containing("pcb", False)
+ipk.modeler.delete_objects_containing("pcb", False)
 
 ###############################################################################
 # Create a Region
@@ -142,8 +142,8 @@ ipk.assignmaterial_from_sherlock_files(component_list, material_list)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This example deletes objects that have no materials assigned.
 
-no_material_objs = ipk.modeler.primitives.get_objects_by_material("")
-ipk.modeler.primitives.delete(no_material_objs)
+no_material_objs = ipk.modeler.get_objects_by_material("")
+ipk.modeler.delete(no_material_objs)
 ipk.save_project()
 
 ###############################################################################
@@ -151,7 +151,7 @@ ipk.save_project()
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # This command assigns power to component blocks.
 
-all_objects = ipk.modeler.primitives.object_names
+all_objects = ipk.modeler.object_names
 
 ###############################################################################
 # Assign Power Blocks
@@ -182,7 +182,7 @@ setup1.props["Radiation Model"] = "Discrete Ordinates Model"
 setup1.props["Include Gravity"] = True
 setup1.props["Secondary Gradient"] = True
 setup1.update()
-ipk.assign_openings(ipk.modeler.primitives.get_object_faces("Region"))
+ipk.assign_openings(ipk.modeler.get_object_faces("Region"))
 
 ###############################################################################
 # Check for Intersection

--- a/examples/05-Q3D/Q3D_Example.py
+++ b/examples/05-Q3D/Q3D_Example.py
@@ -33,7 +33,7 @@ q = Q3d(specified_version="2021.2", non_graphical=NonGraphical, new_desktop_sess
 # ~~~~~~~~~~~~~~~~~
 # Create polylines for three busbars and a box for the substrate.
 
-b1 = q.modeler.primitives.create_polyline(
+b1 = q.modeler.create_polyline(
     [[0, 0, 0], [-100, 0, 0]],
     name="Bar1",
     matname="copper",
@@ -43,7 +43,7 @@ b1 = q.modeler.primitives.create_polyline(
 )
 q.modeler["Bar1"].color = (255, 0, 0)
 
-q.modeler.primitives.create_polyline(
+q.modeler.create_polyline(
     [[0, -15, 0], [-150, -15, 0]],
     name="Bar2",
     matname="aluminum",
@@ -53,7 +53,7 @@ q.modeler.primitives.create_polyline(
 )
 q.modeler["Bar2"].color = (0, 255, 0)
 
-q.modeler.primitives.create_polyline(
+q.modeler.create_polyline(
     [[0, -30, 0], [-175, -30, 0], [-175, -10, 0]],
     name="Bar3",
     matname="copper",
@@ -63,7 +63,7 @@ q.modeler.primitives.create_polyline(
 )
 q.modeler["Bar3"].color = (0, 0, 255)
 
-q.modeler.primitives.create_box([50, 30, -0.5], [-250, -100, -3], name="substrate", matname="FR4_epoxy")
+q.modeler.create_box([50, 30, -0.5], [-250, -100, -3], name="substrate", matname="FR4_epoxy")
 q.modeler["substrate"].color = (128, 128, 128)
 q.modeler["substrate"].transparency = 0.8
 

--- a/examples/06-Multiphysics/Hfss_Mechanical.py
+++ b/examples/06-Multiphysics/Hfss_Mechanical.py
@@ -135,9 +135,7 @@ mech.assign_em_losses(
 )
 diels = ["1_pd", "2_pd", "3_pd", "4_pd", "5_pd"]
 for el in diels:
-    mech.assign_uniform_convection(
-        [mech.modeler.primitives[el].top_face_y, mech.modeler.primitives[el].bottom_face_y], 3
-    )
+    mech.assign_uniform_convection([mech.modeler[el].top_face_y, mech.modeler[el].bottom_face_y], 3)
 
 
 ###############################################################################
@@ -155,7 +153,7 @@ mech.save_project()
 mech.analyze_nominal()
 surfaces = []
 for name in mech.get_all_conductors_names():
-    surfaces.extend(mech.modeler.primitives.get_object_faces(name))
+    surfaces.extend(mech.modeler.get_object_faces(name))
 mech.post.create_fieldplot_surface(surfaces, "Temperature")
 
 

--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -1314,7 +1314,7 @@ class Analysis(Design, object):
             if not isinstance(object_list, list):
                 object_list = [object_list]
         else:
-            object_list = self.modeler.primitives.object_names
+            object_list = self.modeler.object_names
 
         if prop_names:
             if not isinstance(prop_names, list):
@@ -1322,7 +1322,7 @@ class Analysis(Design, object):
 
         dict = {}
         for entry in object_list:
-            mat_name = self.modeler.primitives[entry].material_name
+            mat_name = self.modeler[entry].material_name
             mat_props = self._materials[mat_name]
             if prop_names is None:
                 dict[entry] = mat_props._props

--- a/pyaedt/application/Analysis2D.py
+++ b/pyaedt/application/Analysis2D.py
@@ -245,12 +245,12 @@ class FieldAnalysis2D(Analysis):
                 Mat.update()
             self.logger.info("Assign Material " + mat + " to object " + str(selections))
             for el in selections:
-                self.modeler.primitives[el].material_name = mat
-                self.modeler.primitives[el].color = self.materials.material_keys[mat].material_appearance
+                self.modeler[el].material_name = mat
+                self.modeler[el].color = self.materials.material_keys[mat].material_appearance
                 if Mat.is_dielectric():
-                    self.modeler.primitives[el].solve_inside = True
+                    self.modeler[el].solve_inside = True
                 else:
-                    self.modeler.primitives[el].solve_inside = False
+                    self.modeler[el].solve_inside = False
             return True
         else:
             self.logger.error("Material does not exist.")

--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -387,11 +387,11 @@ class FieldAnalysis3D(Analysis, object):
         >>> oEditor.Copy
         >>> oEditor.Paste
         """
-        body_list = design.modeler.primitives.solid_names
+        body_list = design.modeler.solid_names
         if include_sheets:
-            body_list += design.modeler.primitives.sheet_names
+            body_list += design.modeler.sheet_names
         selection_list = []
-        material_properties = design.modeler.primitives.objects
+        material_properties = design.modeler.objects
         if object_list:
             selection_list = [i for i in object_list if i in body_list]
         else:
@@ -407,7 +407,7 @@ class FieldAnalysis3D(Analysis, object):
                     selection_list.append(body)
         design.modeler.oeditor.Copy(["NAME:Selections", "Selections:=", ",".join(selection_list)])
         self.modeler.oeditor.Paste()
-        self.modeler.primitives.refresh_all_ids()
+        self.modeler.refresh_all_ids()
         return True
 
     @aedt_exception_handler
@@ -471,7 +471,7 @@ class FieldAnalysis3D(Analysis, object):
         >>> oEditor.Export
         """
         if not object_list:
-            allObjects = self.modeler.primitives.object_names
+            allObjects = self.modeler.object_names
             if removed_objects:
                 for rem in removed_objects:
                     allObjects.remove(rem)
@@ -582,10 +582,10 @@ class FieldAnalysis3D(Analysis, object):
 
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
-        >>> box1 = hfss.modeler.primitives.create_box([10, 10, 10], [4, 5, 5])
-        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 0], [2, 3, 4])
-        >>> cylinder1 = hfss.modeler.primitives.create_cylinder(cs_axis="X", position=[5, 0, 0], radius=1, height=20)
-        >>> cylinder2 = hfss.modeler.primitives.create_cylinder(cs_axis="Z", position=[0, 0, 5], radius=1, height=10)
+        >>> box1 = hfss.modeler.create_box([10, 10, 10], [4, 5, 5])
+        >>> box2 = hfss.modeler.create_box([0, 0, 0], [2, 3, 4])
+        >>> cylinder1 = hfss.modeler.create_cylinder(cs_axis="X", position=[5, 0, 0], radius=1, height=20)
+        >>> cylinder2 = hfss.modeler.create_cylinder(cs_axis="Z", position=[0, 0, 5], radius=1, height=10)
 
         Assign the material ``"copper"`` to all the objects.
 
@@ -609,12 +609,12 @@ class FieldAnalysis3D(Analysis, object):
                 Mat.update()
             self.logger.info("Assign Material " + mat + " to object " + str(selections))
             for el in selections:
-                self.modeler.primitives[el].material_name = mat
-                self.modeler.primitives[el].color = self.materials.material_keys[mat].material_appearance
+                self.modeler[el].material_name = mat
+                self.modeler[el].color = self.materials.material_keys[mat].material_appearance
                 if Mat.is_dielectric():
-                    self.modeler.primitives[el].solve_inside = True
+                    self.modeler[el].solve_inside = True
                 else:
-                    self.modeler.primitives[el].solve_inside = False
+                    self.modeler[el].solve_inside = False
             return True
         else:
             self.logger.error("Material does not exist.")

--- a/pyaedt/application/AnalysisIcepak.py
+++ b/pyaedt/application/AnalysisIcepak.py
@@ -290,7 +290,7 @@ class FieldAnalysisIcepak(Analysis, object):
         >>> oEditor.Export
         """
         if not object_list:
-            allObjects = self.modeler.primitives.object_names
+            allObjects = self.modeler.object_names
             if removed_objects:
                 for rem in removed_objects:
                     allObjects.remove(rem)
@@ -426,7 +426,7 @@ class FieldAnalysisIcepak(Analysis, object):
         """
         body_list = design.modeler.solid_bodies
         selection_list = []
-        material_properties = design.modeler.primitives.objects
+        material_properties = design.modeler.objects
         for body in body_list:
             include_object = True
             if object_list:
@@ -478,12 +478,12 @@ class FieldAnalysisIcepak(Analysis, object):
                 Mat.update()
             self.logger.info("Assign Material " + mat + " to object " + str(selections))
             for el in selections:
-                self.modeler.primitives[el].material_name = mat
-                self.modeler.primitives[el].color = self.materials.material_keys[mat].material_appearance
+                self.modeler[el].material_name = mat
+                self.modeler[el].color = self.materials.material_keys[mat].material_appearance
                 if Mat.is_dielectric():
-                    self.modeler.primitives[el].solve_inside = True
+                    self.modeler[el].solve_inside = True
                 else:
-                    self.modeler.primitives[el].solve_inside = False
+                    self.modeler[el].solve_inside = False
             return True
         else:
             self.logger.error("Material does not exist.")
@@ -627,7 +627,7 @@ class FieldAnalysisIcepak(Analysis, object):
             for el in component_header:
                 component_data[el] = [i[k] for i in data]
                 k += 1
-        all_objs = self.modeler.primitives.object_names
+        all_objs = self.modeler.object_names
         i = 0
         for mat in material_data["Name"]:
             list_mat_obj = [
@@ -696,8 +696,8 @@ class FieldAnalysisIcepak(Analysis, object):
                 self.assign_material(list_mat_obj, mat)
 
                 for obj_name in list_mat_obj:
-                    if not self.modeler.primitives[obj_name].surface_material_name:
-                        self.modeler.primitives[obj_name].surface_material_name = "Steel-oxidised-surface"
+                    if not self.modeler[obj_name].surface_material_name:
+                        self.modeler[obj_name].surface_material_name = "Steel-oxidised-surface"
             i += 1
             all_objs = [ao for ao in all_objs if ao not in list_mat_obj]
         return True
@@ -713,7 +713,7 @@ class FieldAnalysisIcepak(Analysis, object):
         """
         cond = [i.lower() for i in list(self.materials.conductors)]
         obj_names = []
-        for el, obj in self.modeler.primitives.objects.items():
+        for el, obj in self.modeler.objects.items():
             if obj.material_name in cond:
                 obj_names.append(obj.name)
         return obj_names
@@ -730,7 +730,7 @@ class FieldAnalysisIcepak(Analysis, object):
         """
         diel = [i.lower() for i in list(self.materials.dielectrics)]
         obj_names = []
-        for el, obj in self.modeler.primitives.objects.items():
+        for el, obj in self.modeler.objects.items():
             if obj.material_name in diel:
                 obj_names.append(obj.name)
         return obj_names

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -194,9 +194,9 @@ class DesignCache(object):
             Snapshot object.
         """
         snapshot = {
-            "Solids:": self._app.modeler.primitives.solid_names,
-            "Lines:": self._app.modeler.primitives.line_names,
-            "Sheets": self._app.modeler.primitives.sheet_names,
+            "Solids:": self._app.modeler.solid_names,
+            "Lines:": self._app.modeler.line_names,
+            "Sheets": self._app.modeler.sheet_names,
             "DesignName": self._app.design_name,
         }
         return snapshot
@@ -2847,7 +2847,7 @@ class Design(object):
             self.oproject.Save()
         if refresh_obj_ids_after_save:
             self.modeler.refresh_all_ids()
-            self.modeler.primitives._refresh_all_ids_from_aedt_file()
+            self.modeler._refresh_all_ids_from_aedt_file()
         return True
 
     @aedt_exception_handler

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -270,8 +270,8 @@ class Hfss(FieldAnalysis3D, object):
 
     @aedt_exception_handler
     def _create_lumped_driven(self, objectname, int_line_start, int_line_stop, impedance, portname, renorm, deemb):
-        start = [str(i) + self.modeler.primitives.model_units for i in int_line_start]
-        stop = [str(i) + self.modeler.primitives.model_units for i in int_line_stop]
+        start = [str(i) + self.modeler.model_units for i in int_line_start]
+        stop = [str(i) + self.modeler.model_units for i in int_line_stop]
         props = OrderedDict({})
         if isinstance(objectname, str):
             props["Objects"] = [objectname]
@@ -386,8 +386,8 @@ class Hfss(FieldAnalysis3D, object):
         start = None
         stop = None
         if int_line_start and int_line_stop:
-            start = [str(i) + self.modeler.primitives.model_units for i in int_line_start]
-            stop = [str(i) + self.modeler.primitives.model_units for i in int_line_stop]
+            start = [str(i) + self.modeler.model_units for i in int_line_start]
+            stop = [str(i) + self.modeler.model_units for i in int_line_stop]
             useintline = True
         else:
             useintline = False
@@ -550,10 +550,10 @@ class Hfss(FieldAnalysis3D, object):
         Create a cylinder at the XY working plane and assign a copper coating of 0.2 mm to it.
 
         >>> origin = hfss.modeler.Position(0, 0, 0)
-        >>> inner = hfss.modeler.primitives.create_cylinder(
+        >>> inner = hfss.modeler.create_cylinder(
         ...     hfss.PLANE.XY, origin, 3, 200, 0, "inner"
         ... )
-        >>> inner_id = hfss.modeler.primitives.get_obj_id("inner")
+        >>> inner_id = hfss.modeler.get_obj_id("inner")
         >>> coat = hfss.assign_coating([inner_id], "copper", usethickness=True, thickness="0.2mm")
 
         """
@@ -1494,10 +1494,10 @@ class Hfss(FieldAnalysis3D, object):
         Create two boxes that will be used to create a circuit port
         named ``'CircuitExample'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([0, 0, 80], [10, 10, 5],
-        ...                                           "BoxCircuit1", "copper")
-        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 100], [10, 10, 5],
-        ...                                           "BoxCircuit2", "copper")
+        >>> box1 = hfss.modeler.create_box([0, 0, 80], [10, 10, 5],
+        ...                                "BoxCircuit1", "copper")
+        >>> box2 = hfss.modeler.create_box([0, 0, 100], [10, 10, 5],
+        ...                                "BoxCircuit2", "copper")
         >>> hfss.create_circuit_port_between_objects("BoxCircuit1", "BoxCircuit2",
         ...                                          hfss.AxisDir.XNeg, 50,
         ...                                          "CircuitExample", True, 50, False)
@@ -1505,13 +1505,11 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects doesn't exists. Check and retry.")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
-            out, parallel = self.modeler.primitives.find_closest_edges(startobj, endobject, axisdir)
+            out, parallel = self.modeler.find_closest_edges(startobj, endobject, axisdir)
             port_edges = []
             if not portname:
                 portname = generate_unique_name("Port")
@@ -1564,10 +1562,10 @@ class Hfss(FieldAnalysis3D, object):
         Create two boxes that will be used to create a lumped port
         named ``'LumpedPort'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([0, 0, 50], [10, 10, 5],
-        ...                                           "BoxLumped1","copper")
-        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 60], [10, 10, 5],
-        ...                                           "BoxLumped2", "copper")
+        >>> box1 = hfss.modeler.create_box([0, 0, 50], [10, 10, 5],
+        ...                                "BoxLumped1","copper")
+        >>> box2 = hfss.modeler.create_box([0, 0, 60], [10, 10, 5],
+        ...                                "BoxLumped2", "copper")
         >>> hfss.create_lumped_port_between_objects("BoxLumped1", "BoxLumped2",
         ...                                         hfss.AxisDir.XNeg, 50,
         ...                                         "LumpedPort", True, False)
@@ -1577,9 +1575,7 @@ class Hfss(FieldAnalysis3D, object):
         """
         startobj = self.modeler.convert_to_selections(startobj)
         endobject = self.modeler.convert_to_selections(endobject)
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects do not exist. Check and retry.")
             return False
 
@@ -1595,7 +1591,7 @@ class Hfss(FieldAnalysis3D, object):
             if "Modal" in self.solution_type:
                 return self._create_lumped_driven(sheet_name, point0, point1, impedance, portname, renorm, deemb)
             else:
-                faces = self.modeler.primitives.get_object_faces(sheet_name)
+                faces = self.modeler.get_object_faces(sheet_name)
                 return self._create_port_terminal(faces[0], endobject, portname, renorm=renorm, iswaveport=False)
         return False
 
@@ -1838,10 +1834,10 @@ class Hfss(FieldAnalysis3D, object):
         Create two boxes that will be used to create a voltage source
         named ``'VoltageSource'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([30, 0, 0], [40, 10, 5],
-        ...                                           "BoxVolt1", "copper")
-        >>> box2 = hfss.modeler.primitives.create_box([30, 0, 10], [40, 10, 5],
-        ...                                           "BoxVolt2", "copper")
+        >>> box1 = hfss.modeler.create_box([30, 0, 0], [40, 10, 5],
+        ...                                "BoxVolt1", "copper")
+        >>> box2 = hfss.modeler.create_box([30, 0, 10], [40, 10, 5],
+        ...                                "BoxVolt2", "copper")
         >>> v1 = hfss.create_voltage_source_from_objects("BoxVolt1", "BoxVolt2",
         ...                                         hfss.AxisDir.XNeg,
         ...                                         "VoltageSource")
@@ -1849,9 +1845,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects doesn't exists. Check and retry")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
@@ -1900,10 +1894,10 @@ class Hfss(FieldAnalysis3D, object):
         Create two boxes that will be used to create a current source
         named ``'CurrentSource'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([30, 0, 20], [40, 10, 5],
-        ...                                           "BoxCurrent1", "copper")
-        >>> box2 = hfss.modeler.primitives.create_box([30, 0, 30], [40, 10, 5],
-        ...                                           "BoxCurrent2", "copper")
+        >>> box1 = hfss.modeler.create_box([30, 0, 20], [40, 10, 5],
+        ...                                "BoxCurrent1", "copper")
+        >>> box2 = hfss.modeler.create_box([30, 0, 30], [40, 10, 5],
+        ...                                "BoxCurrent2", "copper")
         >>> i1 = hfss.create_current_source_from_objects("BoxCurrent1", "BoxCurrent2",
         ...                                         hfss.AxisDir.XPos,
         ...                                         "CurrentSource")
@@ -1911,9 +1905,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects do not exist. Check and retry.")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
@@ -2018,9 +2010,9 @@ class Hfss(FieldAnalysis3D, object):
         Create two boxes that will be used to create a wave port
         named ``'WavePort'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([0,0,0], [10,10,5],
+        >>> box1 = hfss.modeler.create_box([0,0,0], [10,10,5],
         ...                                           "BoxWave1", "copper")
-        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 10], [10, 10, 5],
+        >>> box2 = hfss.modeler.create_box([0, 0, 10], [10, 10, 5],
         ...                                           "BoxWave2", "copper")
         >>> wave_port = hfss.create_wave_port_between_objects("BoxWave1", "BoxWave2",
         ...                                                   hfss.AxisDir.XNeg, 50, 1,
@@ -2029,9 +2021,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects do not exist. Check and retry.")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
@@ -2050,7 +2040,7 @@ class Hfss(FieldAnalysis3D, object):
                     sheet_name, point0, point1, impedance, portname, renorm, nummodes, deembed_dist
                 )
             else:
-                faces = self.modeler.primitives.get_object_faces(sheet_name)
+                faces = self.modeler.get_object_faces(sheet_name)
                 return self._create_port_terminal(faces[0], endobject, portname, renorm=renorm, iswaveport=True)
         return False
 
@@ -2119,7 +2109,7 @@ class Hfss(FieldAnalysis3D, object):
         props["NumModes"] = nummodes
         if deembed_dist:
             props["DoDeembed"] = True
-            props["DeembedDist"] = self.modeler.primitives._arg_with_dim(deembed_dist)
+            props["DeembedDist"] = self.modeler._arg_with_dim(deembed_dist)
         else:
             props["DoDeembed"] = False
             props["DeembedDist"] = "0mm"
@@ -2368,10 +2358,10 @@ class Hfss(FieldAnalysis3D, object):
 
     def _create_pec_cap(self, sheet_name, obj_name, pecthick):
         # TODO check method
-        obj = self.modeler.primitives[sheet_name].clone()
+        obj = self.modeler[sheet_name].clone()
         out_obj = self.modeler.thicken_sheet(obj, pecthick, False)
         bounding2 = out_obj.bounding_box
-        bounding1 = self.modeler.primitives[obj_name].bounding_box
+        bounding1 = self.modeler[obj_name].bounding_box
         tol = 1e-9
         i = 0
         internal = False
@@ -2384,7 +2374,7 @@ class Hfss(FieldAnalysis3D, object):
             i += 1
         if internal:
             self.odesign.Undo()
-            self.modeler.primitives.cleanup_objects()
+            self.modeler.cleanup_objects()
             out_obj = self.modeler.thicken_sheet(obj, -pecthick, False)
 
         out_obj.material_name = "pec"
@@ -2447,21 +2437,19 @@ class Hfss(FieldAnalysis3D, object):
 
         Create a wave port supported by a microstrip line.
 
-        >>> ms = hfss.modeler.primitives.create_box([4, 5, 0], [1, 100, 0.2],
-        ...                                         name="MS1", matname="copper")
-        >>> sub = hfss.modeler.primitives.create_box([0, 5, -2], [20, 100, 2],
-        ...                                          name="SUB1", matname="FR4_epoxy")
-        >>> gnd = hfss.modeler.primitives.create_box([0, 5, -2.2], [20, 100, 0.2],
-        ...                                          name="GND1", matname="FR4_epoxy")
+        >>> ms = hfss.modeler.create_box([4, 5, 0], [1, 100, 0.2],
+        ...                               name="MS1", matname="copper")
+        >>> sub = hfss.modeler.create_box([0, 5, -2], [20, 100, 2],
+        ...                               name="SUB1", matname="FR4_epoxy")
+        >>> gnd = hfss.modeler.create_box([0, 5, -2.2], [20, 100, 0.2],
+        ...                               name="GND1", matname="FR4_epoxy")
         >>> port = hfss.create_wave_port_microstrip_between_objects("GND1", "MS1",
         ...                                                         portname="MS1",
         ...                                                         axisdir=1)
         pyaedt info: Connection Correctly created
 
         """
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects do not exist. Check and retry.")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
@@ -2479,7 +2467,7 @@ class Hfss(FieldAnalysis3D, object):
                     sheet_name, point0, point1, impedance, portname, renorm, nummodes, deembed_dist
                 )
             else:
-                faces = self.modeler.primitives.get_object_faces(sheet_name)
+                faces = self.modeler.get_object_faces(sheet_name)
                 return self._create_port_terminal(faces[0], endobject, portname, renorm=renorm, iswaveport=True)
         return False
 
@@ -2523,10 +2511,10 @@ class Hfss(FieldAnalysis3D, object):
 
         Create two boxes that will be used to create a Perfect E named ``'PerfectE'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([0,0,0], [10,10,5],
-        ...                                           "perfect1", "Copper")
-        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 10], [10, 10, 5],
-        ...                                           "perfect2", "copper")
+        >>> box1 = hfss.modeler.create_box([0,0,0], [10,10,5],
+        ...                                "perfect1", "Copper")
+        >>> box2 = hfss.modeler.create_box([0, 0, 10], [10, 10, 5],
+        ...                                "perfect2", "copper")
         >>> perfect_e = hfss.create_perfecte_from_objects("perfect1", "perfect2",
         ...                                               hfss.AxisDir.ZNeg, "PerfectE")
         pyaedt info: Connection Correctly created
@@ -2535,9 +2523,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects do not exist. Check and retry.")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
@@ -2586,10 +2572,10 @@ class Hfss(FieldAnalysis3D, object):
 
         Create two boxes that will be used to create a Perfect H named ``'PerfectH'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([0,0,20], [10,10,5],
-        ...                                           "perfect1", "Copper")
-        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 30], [10, 10, 5],
-        ...                                           "perfect2", "copper")
+        >>> box1 = hfss.modeler.create_box([0,0,20], [10,10,5],
+        ...                                "perfect1", "Copper")
+        >>> box2 = hfss.modeler.create_box([0, 0, 30], [10, 10, 5],
+        ...                                "perfect2", "copper")
         >>> perfect_h = hfss.create_perfecth_from_objects("perfect1", "perfect2",
         ...                                               hfss.AxisDir.ZNeg, "PerfectH")
         pyaedt info: Connection Correctly created
@@ -2598,9 +2584,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects do not exist. Check and retry.")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
@@ -2750,9 +2734,9 @@ class Hfss(FieldAnalysis3D, object):
         Create two boxes that will be used to create a lumped RLC named
         ``'LumpedRLC'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([0, 0, 50], [10, 10, 5],
+        >>> box1 = hfss.modeler.create_box([0, 0, 50], [10, 10, 5],
         ...                                           "rlc1", "copper")
-        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 60], [10, 10, 5],
+        >>> box2 = hfss.modeler.create_box([0, 0, 60], [10, 10, 5],
         ...                                           "rlc2", "copper")
         >>> rlc = hfss.create_lumped_rlc_between_objects("rlc1", "rlc2", hfss.AxisDir.XPos,
         ...                                              "LumpedRLC", Rvalue=50,
@@ -2761,9 +2745,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects do not exist. Check and retry.")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"] and (Rvalue or Lvalue or Cvalue):
@@ -2775,8 +2757,8 @@ class Hfss(FieldAnalysis3D, object):
                 sourcename = generate_unique_name("Lump")
             elif sourcename in self.modeler.get_boundaries_name():
                 sourcename = generate_unique_name(sourcename)
-            start = [str(i) + self.modeler.primitives.model_units for i in point0]
-            stop = [str(i) + self.modeler.primitives.model_units for i in point1]
+            start = [str(i) + self.modeler.model_units for i in point0]
+            stop = [str(i) + self.modeler.model_units for i in point1]
 
             props = OrderedDict()
             props["Objects"] = [sheet_name]
@@ -2849,9 +2831,9 @@ class Hfss(FieldAnalysis3D, object):
         Create two boxes that will be used to create an impedance named
         named ``'ImpedanceExample'``.
 
-        >>> box1 = hfss.modeler.primitives.create_box([0, 0, 70], [10, 10, 5],
+        >>> box1 = hfss.modeler.create_box([0, 0, 70], [10, 10, 5],
         ...                                           "box1", "copper")
-        >>> box2 = hfss.modeler.primitives.create_box([0, 0, 80], [10, 10, 5],
+        >>> box2 = hfss.modeler.create_box([0, 0, 80], [10, 10, 5],
         ...                                           "box2", "copper")
         >>> impedance = hfss.create_impedance_between_objects("box1", "box2", hfss.AxisDir.XPos,
         ...                                                   "ImpedanceExample", 100, 50)
@@ -2859,9 +2841,7 @@ class Hfss(FieldAnalysis3D, object):
 
         """
 
-        if not self.modeler.primitives.does_object_exists(startobj) or not self.modeler.primitives.does_object_exists(
-            endobject
-        ):
+        if not self.modeler.does_object_exists(startobj) or not self.modeler.does_object_exists(endobject):
             self.logger.error("One or both objects do not exist. Check and retry.")
             return False
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
@@ -2940,8 +2920,8 @@ class Hfss(FieldAnalysis3D, object):
             sheet = obj_name
         else:
             objID = self.modeler.oeditor.GetFaceIDs(sheet)
-        face_edges = self.modeler.primitives.get_face_edges(objID[0])
-        mid_points = [self.modeler.primitives.get_edge_midpoint(i) for i in face_edges]
+        face_edges = self.modeler.get_face_edges(objID[0])
+        mid_points = [self.modeler.get_edge_midpoint(i) for i in face_edges]
         if axisdir < 3:
             min_point = [1e6, 1e6, 1e6]
             max_point = [-1e6, -1e6, -1e6]
@@ -2959,7 +2939,7 @@ class Hfss(FieldAnalysis3D, object):
                 if el[axisdir - 3] < max_point[axisdir - 3]:
                     max_point = el
 
-        refid = self.modeler.primitives.get_bodynames_from_position(min_point)
+        refid = self.modeler.get_bodynames_from_position(min_point)
         refid.remove(sheet)
         diels = self.get_all_dielectrics_names()
         for el in refid:
@@ -3025,7 +3005,7 @@ class Hfss(FieldAnalysis3D, object):
         ``'WavePortFromSheet'``.
 
         >>> origin_position = hfss.modeler.Position(0, 0, 0)
-        >>> circle = hfss.modeler.primitives.create_circle(hfss.PLANE.YZ,
+        >>> circle = hfss.modeler.create_circle(hfss.PLANE.YZ,
         ...                                                origin_position, 10, name="WaveCircle")
         >>> hfss.solution_type = "Modal"
         >>> port = hfss.create_wave_port_from_sheet(circle, 5, hfss.AxisDir.XNeg, 40, 2,
@@ -3060,7 +3040,7 @@ class Hfss(FieldAnalysis3D, object):
             if isinstance(sheet, int):
                 faces = sheet
             else:
-                faces = self.modeler.primitives.get_object_faces(sheet)[0]
+                faces = self.modeler.get_object_faces(sheet)[0]
             if not faces:
                 self.logger.error("Wrong Input object. it has to be a face id or a sheet.")
                 return False
@@ -3115,7 +3095,7 @@ class Hfss(FieldAnalysis3D, object):
         Create a rectangle sheet that will be used to create a lumped port named
         ``'LumpedPortFromSheet'``.
 
-        >>> rectangle = hfss.modeler.primitives.create_rectangle(hfss.PLANE.XY,
+        >>> rectangle = hfss.modeler.create_rectangle(hfss.PLANE.XY,
         ...                                                      [0, 0, 0], [10, 2], name="lump_port",
         ...                                                      matname="copper")
         >>> h1 = hfss.create_lumped_port_to_sheet(rectangle.name, hfss.AxisDir.XNeg, 50,
@@ -3124,7 +3104,7 @@ class Hfss(FieldAnalysis3D, object):
         """
         sheet_name = self.modeler.convert_to_selections(sheet_name, False)
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
-            point0, point1 = self.modeler.primitives.get_mid_points_on_dir(sheet_name, axisdir)
+            point0, point1 = self.modeler.get_mid_points_on_dir(sheet_name, axisdir)
 
             if not portname:
                 portname = generate_unique_name("Port")
@@ -3136,7 +3116,7 @@ class Hfss(FieldAnalysis3D, object):
             else:
                 if not reference_object_list:
                     cond = self.get_all_conductors_names()
-                    touching = self.modeler.primitives.get_bodynames_from_position(point0)
+                    touching = self.modeler.get_bodynames_from_position(point0)
                     reference_object_list = []
                     for el in touching:
                         if el in cond:
@@ -3144,7 +3124,7 @@ class Hfss(FieldAnalysis3D, object):
                 if isinstance(sheet_name, int):
                     faces = sheet_name
                 else:
-                    faces = self.modeler.primitives.get_object_faces(sheet_name)[0]
+                    faces = self.modeler.get_object_faces(sheet_name)[0]
                 if not faces:
                     self.logger.error("Wrong Input object. it has to be a face id or a sheet.")
                     return False
@@ -3200,7 +3180,7 @@ class Hfss(FieldAnalysis3D, object):
 
         Create a sheet and assign to it some voltage.
 
-        >>> sheet = hfss.modeler.primitives.create_rectangle(hfss.PLANE.XY,
+        >>> sheet = hfss.modeler.create_rectangle(hfss.PLANE.XY,
         ...                                                  [0, 0, -70], [10, 2], name="VoltageSheet",
         ...                                                  matname="copper")
         >>> v1 = hfss.assign_voltage_source_to_sheet(sheet.name, hfss.AxisDir.XNeg, "VoltageSheetExample")
@@ -3208,7 +3188,7 @@ class Hfss(FieldAnalysis3D, object):
         """
 
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
-            point0, point1 = self.modeler.primitives.get_mid_points_on_dir(sheet_name, axisdir)
+            point0, point1 = self.modeler.get_mid_points_on_dir(sheet_name, axisdir)
             if not sourcename:
                 sourcename = generate_unique_name("Voltage")
             elif sourcename + ":1" in self.modeler.get_excitations_name():
@@ -3246,7 +3226,7 @@ class Hfss(FieldAnalysis3D, object):
 
         Create a sheet and assign to it some current.
 
-        >>> sheet = hfss.modeler.primitives.create_rectangle(hfss.PLANE.XY, [0, 0, -50],
+        >>> sheet = hfss.modeler.create_rectangle(hfss.PLANE.XY, [0, 0, -50],
         ...                                                  [5, 1], name="CurrentSheet", matname="copper")
         >>> hfss.assign_current_source_to_sheet(sheet.name, hfss.AxisDir.XNeg, "CurrentSheetExample")
         'CurrentSheetExample'
@@ -3254,7 +3234,7 @@ class Hfss(FieldAnalysis3D, object):
         """
 
         if self.solution_type in ["Modal", "Terminal", "Transient Network"]:
-            point0, point1 = self.modeler.primitives.get_mid_points_on_dir(sheet_name, axisdir)
+            point0, point1 = self.modeler.get_mid_points_on_dir(sheet_name, axisdir)
             if not sourcename:
                 sourcename = generate_unique_name("Current")
             elif sourcename + ":1" in self.modeler.get_excitations_name():

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -264,7 +264,7 @@ class Icepak(FieldAnalysisIcepak):
 
         Create an opening boundary for the faces of the ``"USB_GND"`` object.
 
-        >>> faces = icepak.modeler.primitives["USB_GND"].faces
+        >>> faces = icepak.modeler["USB_GND"].faces
         >>> face_names = [face.id for face in faces]
         >>> boundary = icepak.assign_openings(face_names)
         pyaedt info: Face List boundary_faces created
@@ -374,8 +374,8 @@ class Icepak(FieldAnalysisIcepak):
 
         Create block boundaries from each box in the list.
 
-        >>> box1 = icepak.modeler.primitives.create_box([1, 1, 1], [3, 3, 3], "BlockBox1", "copper")
-        >>> box2 = icepak.modeler.primitives.create_box([2, 2, 2], [4, 4, 4], "BlockBox2", "copper")
+        >>> box1 = icepak.modeler.create_box([1, 1, 1], [3, 3, 3], "BlockBox1", "copper")
+        >>> box2 = icepak.modeler.create_box([2, 2, 2], [4, 4, 4], "BlockBox2", "copper")
         >>> blocks = icepak.create_source_blocks_from_list([["BlockBox1", 2], ["BlockBox2", 4]])
         pyaedt info: Block on ...
         >>> blocks[1].props
@@ -383,7 +383,7 @@ class Icepak(FieldAnalysisIcepak):
         >>> blocks[3].props
         {'Objects': ['BlockBox2'], 'Block Type': 'Solid', 'Use External Conditions': False, 'Total Power': '4W'}
         """
-        oObjects = self.modeler.primitives.solid_names
+        oObjects = self.modeler.solid_names
         listmcad = []
         num_power = None
         for row in list_powers:
@@ -435,7 +435,7 @@ class Icepak(FieldAnalysisIcepak):
         Examples
         --------
 
-        >>> box = icepak.modeler.primitives.create_box([5, 5, 5], [1, 2, 3], "BlockBox3", "copper")
+        >>> box = icepak.modeler.create_box([5, 5, 5], [1, 2, 3], "BlockBox3", "copper")
         >>> block = icepak.create_source_block("BlockBox3", "1W", False)
         pyaedt info: Block on ...
         >>> block.props
@@ -445,9 +445,9 @@ class Icepak(FieldAnalysisIcepak):
         if assign_material:
             if isinstance(object_name, list):
                 for el in object_name:
-                    self.modeler.primitives[el].material_name = material_name
+                    self.modeler[el].material_name = material_name
             else:
-                self.modeler.primitives[object_name].material_name = material_name
+                self.modeler[object_name].material_name = material_name
         props = {}
         if not isinstance(object_name, list):
             object_name = [object_name]
@@ -513,7 +513,7 @@ class Icepak(FieldAnalysisIcepak):
 
         Create two source boundaries from one box, one on the top face and one on the bottom face.
 
-        >>> box = icepak.modeler.primitives.create_box([0, 0, 0], [20, 20, 20], name="SourceBox")
+        >>> box = icepak.modeler.create_box([0, 0, 0], [20, 20, 20], name="SourceBox")
         >>> source1 = icepak.create_source_power(box.top_face_z.id, input_power="2W")
         >>> source1.props["Total Power"]
         '2W'
@@ -587,13 +587,13 @@ class Icepak(FieldAnalysisIcepak):
         Examples
         --------
 
-        >>> box = icepak.modeler.primitives.create_box([4, 5, 6], [5, 5, 5], "NetworkBox1", "copper")
+        >>> box = icepak.modeler.create_box([4, 5, 6], [5, 5, 5], "NetworkBox1", "copper")
         >>> block = icepak.create_network_block("NetworkBox1", "2W", 20, 10, icepak.GravityDirection.ZNeg, 1.05918)
         >>> block.props["Nodes"]["Internal"][0]
         '2W'
         """
-        if object_name in self.modeler.primitives.object_names:
-            faces = self.modeler.primitives.get_object_faces(object_name)
+        if object_name in self.modeler.object_names:
+            faces = self.modeler.get_object_faces(object_name)
             k = 0
             faceCenter = {}
             for f in faces:
@@ -617,7 +617,7 @@ class Icepak(FieldAnalysisIcepak):
                 fcrjc = fcrjb
                 fcrjb = app
             if assign_material:
-                self.modeler.primitives[object_name].material_name = default_material
+                self.modeler[object_name].material_name = default_material
             props = {}
             if use_object_for_name:
                 boundary_name = object_name
@@ -641,7 +641,7 @@ class Icepak(FieldAnalysisIcepak):
             bound = BoundaryObject(self, boundary_name, props, "Network")
             if bound.create():
                 self.boundaries.append(bound)
-                self.modeler.primitives[object_name].solve_inside = False
+                self.modeler[object_name].solve_inside = False
                 return bound
             return None
 
@@ -680,14 +680,14 @@ class Icepak(FieldAnalysisIcepak):
 
         Create network boundaries from each box in the list.
 
-        >>> box1 = icepak.modeler.primitives.create_box([1, 2, 3], [10, 10, 10], "NetworkBox2", "copper")
-        >>> box2 = icepak.modeler.primitives.create_box([4, 5, 6], [5, 5, 5], "NetworkBox3", "copper")
+        >>> box1 = icepak.modeler.create_box([1, 2, 3], [10, 10, 10], "NetworkBox2", "copper")
+        >>> box2 = icepak.modeler.create_box([4, 5, 6], [5, 5, 5], "NetworkBox3", "copper")
         >>> blocks = icepak.create_network_blocks([["NetworkBox2", 20, 10, 3], ["NetworkBox3", 4, 10, 2]],
         ...                                        icepak.GravityDirection.ZNeg, 1.05918, False)
         >>> blocks[0].props["Nodes"]["Internal"]
         ['3W']
         """
-        objs = self.modeler.primitives.solid_names
+        objs = self.modeler.solid_names
         countpow = len(input_list[0]) - 3
         networks = []
         for row in input_list:
@@ -746,8 +746,8 @@ class Icepak(FieldAnalysisIcepak):
 
         Create a rectangle named ``"Surface1"`` and assign a temperature monitor to that surface.
 
-        >>> surface = icepak.modeler.primitives.create_rectangle(icepak.PLANE.XY,
-        ...                                                      [0, 0, 0], [10, 20], name="Surface1")
+        >>> surface = icepak.modeler.create_rectangle(icepak.PLANE.XY,
+        ...                                           [0, 0, 0], [10, 20], name="Surface1")
         >>> icepak.assign_surface_monitor("Surface1")
         True
         """
@@ -795,11 +795,11 @@ class Icepak(FieldAnalysisIcepak):
             [
                 "NAME:PointParameters",
                 "PointX:=",
-                self.modeler.primitives._arg_with_dim(point_position[0]),
+                self.modeler._arg_with_dim(point_position[0]),
                 "PointY:=",
-                self.modeler.primitives._arg_with_dim(point_position[1]),
+                self.modeler._arg_with_dim(point_position[1]),
                 "PointZ:=",
-                self.modeler.primitives._arg_with_dim(point_position[2]),
+                self.modeler._arg_with_dim(point_position[2]),
             ],
             ["NAME:Attributes", "Name:=", point_name, "Color:=", "(143 175 143)"],
         )
@@ -839,7 +839,7 @@ class Icepak(FieldAnalysisIcepak):
                 k += 1
         total_power = 0
         i = 0
-        all_objects = self.modeler.primitives.object_names
+        all_objects = self.modeler.object_names
         for power in component_data["Applied Power (W)"]:
             try:
                 float(power)
@@ -1021,28 +1021,28 @@ class Icepak(FieldAnalysisIcepak):
             ``True`` when successful, ``False`` when failed.
 
         """
-        all_objs = self.modeler.primitives.object_names
-        self["FinPitch"] = self.modeler.primitives._arg_with_dim(pitch)
-        self["FinThickness"] = self.modeler.primitives._arg_with_dim(thick)
-        self["FinLength"] = self.modeler.primitives._arg_with_dim(length)
-        self["FinHeight"] = self.modeler.primitives._arg_with_dim(height)
+        all_objs = self.modeler.object_names
+        self["FinPitch"] = self.modeler._arg_with_dim(pitch)
+        self["FinThickness"] = self.modeler._arg_with_dim(thick)
+        self["FinLength"] = self.modeler._arg_with_dim(length)
+        self["FinHeight"] = self.modeler._arg_with_dim(height)
         self["DraftAngle"] = draftangle
         self["PatternAngle"] = patternangle
-        self["FinSeparation"] = self.modeler.primitives._arg_with_dim(separation)
-        self["VerticalSeparation"] = self.modeler.primitives._arg_with_dim(vertical_separation)
-        self["HSHeight"] = self.modeler.primitives._arg_with_dim(hs_height)
-        self["HSWidth"] = self.modeler.primitives._arg_with_dim(hs_width)
-        self["HSBaseThick"] = self.modeler.primitives._arg_with_dim(hs_basethick)
+        self["FinSeparation"] = self.modeler._arg_with_dim(separation)
+        self["VerticalSeparation"] = self.modeler._arg_with_dim(vertical_separation)
+        self["HSHeight"] = self.modeler._arg_with_dim(hs_height)
+        self["HSWidth"] = self.modeler._arg_with_dim(hs_width)
+        self["HSBaseThick"] = self.modeler._arg_with_dim(hs_basethick)
         if numcolumn_perside > 1:
             self["NumColumnsPerSide"] = numcolumn_perside
         if symmetric:
-            self["SymSeparation"] = self.modeler.primitives._arg_with_dim(symmetric_separation)
+            self["SymSeparation"] = self.modeler._arg_with_dim(symmetric_separation)
         # ipk['PatternDirection'] = 'Y'
         # ipk['LengthDirection'] = 'X'
         # ipk['HeightDirection'] = 'Z'
-        self["Tolerance"] = self.modeler.primitives._arg_with_dim(tolerance)
+        self["Tolerance"] = self.modeler._arg_with_dim(tolerance)
 
-        self.modeler.primitives.create_box(
+        self.modeler.create_box(
             ["-HSWidth/200", "-HSHeight/200", "-HSBaseThick"],
             ["HSWidth*1.01", "HSHeight*1.01", "HSBaseThick+Tolerance"],
             "HSBase",
@@ -1054,7 +1054,7 @@ class Icepak(FieldAnalysisIcepak):
         Fin_Line.append(self.Position("FinLength", "FinThickness + FinLength*sin(PatternAngle*3.14/180)", 0))
         Fin_Line.append(self.Position("FinLength", "FinLength*sin(PatternAngle*3.14/180)", 0))
         Fin_Line.append(self.Position(0, 0, 0))
-        self.modeler.primitives.create_polyline(Fin_Line, cover_surface=True, name="Fin")
+        self.modeler.create_polyline(Fin_Line, cover_surface=True, name="Fin")
         Fin_Line2 = []
         Fin_Line2.append(self.Position(0, "sin(DraftAngle*3.14/180)*FinThickness", "FinHeight"))
         Fin_Line2.append(self.Position(0, "FinThickness-sin(DraftAngle*3.14/180)*FinThickness", "FinHeight"))
@@ -1071,15 +1071,15 @@ class Icepak(FieldAnalysisIcepak):
             )
         )
         Fin_Line2.append(self.Position(0, "sin(DraftAngle*3.14/180)*FinThickness", "FinHeight"))
-        self.modeler.primitives.create_polyline(Fin_Line2, cover_surface=True, name="Fin_top")
+        self.modeler.create_polyline(Fin_Line2, cover_surface=True, name="Fin_top")
         self.modeler.connect(["Fin", "Fin_top"])
-        self.modeler.primitives["Fin"].material_name = matname
+        self.modeler["Fin"].material_name = matname
         # self.modeler.thicken_sheet("Fin",'-FinHeight')
         num = int((hs_width / (separation + thick)) / (max(1 - math.sin(patternangle * 3.14 / 180), 0.1)))
         self.modeler.duplicate_along_line("Fin", self.Position(0, "FinSeparation+FinThickness", 0), num, True)
         self.modeler.duplicate_along_line("Fin", self.Position(0, "-FinSeparation-FinThickness", 0), num / 4, True)
 
-        all_names = self.modeler.primitives.object_names
+        all_names = self.modeler.object_names
         list = [i for i in all_names if "Fin" in i]
         if numcolumn_perside > 0:
             self.modeler.duplicate_along_line(
@@ -1089,10 +1089,10 @@ class Icepak(FieldAnalysisIcepak):
                 True,
             )
 
-        all_names = self.modeler.primitives.object_names
+        all_names = self.modeler.object_names
         list = [i for i in all_names if "Fin" in i]
         self.modeler.split(list, self.PLANE.ZX, "PositiveOnly")
-        all_names = self.modeler.primitives.object_names
+        all_names = self.modeler.object_names
         list = [i for i in all_names if "Fin" in i]
         self.modeler.create_coordinate_system(self.Position(0, "HSHeight", 0), mode="view", view="XY", name="TopRight")
 
@@ -1123,9 +1123,9 @@ class Icepak(FieldAnalysisIcepak):
             Center_Line.append(self.Position("VerticalSeparation", "-HSHeight-Tolerance", "-Tolerance"))
             Center_Line.append(self.Position("-VerticalSeparation", "-HSHeight-Tolerance", "-Tolerance"))
             Center_Line.append(self.Position("-SymSeparation", "Tolerance", "-Tolerance"))
-            self.modeler.primitives.create_polyline(Center_Line, cover_surface=True, name="Center")
+            self.modeler.create_polyline(Center_Line, cover_surface=True, name="Center")
             self.modeler.thicken_sheet("Center", "-FinHeight-2*Tolerance")
-            all_names = self.modeler.primitives.object_names
+            all_names = self.modeler.object_names
             list = [i for i in all_names if "Fin" in i]
             self.modeler.subtract(list, "Center", False)
         else:
@@ -1133,7 +1133,7 @@ class Icepak(FieldAnalysisIcepak):
                 self.Position("HSWidth", 0, 0), mode="view", view="XY", name="BottomRight", reference_cs="TopRight"
             )
             self.modeler.split(list, self.PLANE.YZ, "NegativeOnly")
-        all_objs2 = self.modeler.primitives.object_names
+        all_objs2 = self.modeler.object_names
         list_to_move = [i for i in all_objs2 if i not in all_objs]
         center[0] -= hs_width / 2
         center[1] -= hs_height / 2
@@ -1149,7 +1149,7 @@ class Icepak(FieldAnalysisIcepak):
             self.modeler.rotate(list_to_move, self.AXIS.Y, 90)
             self.modeler.rotate(list_to_move, self.AXIS.Z, rotation)
         self.modeler.unite(list_to_move)
-        self.modeler.primitives[list_to_move[0]].name = "HeatSink1"
+        self.modeler[list_to_move[0]].name = "HeatSink1"
         return True
 
     @aedt_exception_handler
@@ -1328,7 +1328,7 @@ class Icepak(FieldAnalysisIcepak):
                 component_lib,
             ]
         )
-        self.modeler.primitives.add_new_objects()
+        self.modeler.add_new_objects()
         return True
 
     @aedt_exception_handler
@@ -1469,7 +1469,7 @@ class Icepak(FieldAnalysisIcepak):
         # Generate a list of model objects from the lists made previously and use to map the HFSS losses into Icepak
         #
         if not object_list:
-            allObjects = self.modeler.primitives.object_names
+            allObjects = self.modeler.object_names
             if "Region" in allObjects:
                 allObjects.remove("Region")
         else:
@@ -2002,7 +2002,7 @@ class Icepak(FieldAnalysisIcepak):
         native = NativeComponentObject(self, "Fan", name, native_props)
         if native.create():
             new_name = [i for i in list(self.modeler.oeditor.Get3DComponentInstanceNames(name)) if i not in insts][0]
-            self.modeler.primitives.refresh_all_ids()
+            self.modeler.refresh_all_ids()
             self.materials._load_from_project()
             self.native_components.append(native)
             if origin:
@@ -2115,7 +2115,7 @@ class Icepak(FieldAnalysisIcepak):
         native_props["TargetCS"] = PCB_CS
         native = NativeComponentObject(self, "PCB", compName, native_props)
         if native.create():
-            self.modeler.primitives.refresh_all_ids()
+            self.modeler.refresh_all_ids()
             self.materials._load_from_project()
             self.native_components.append(native)
             return native
@@ -2228,7 +2228,7 @@ class Icepak(FieldAnalysisIcepak):
         oEditor.Copy(["NAME:Selections", "Selections:=", groupName])
 
         self.modeler.oeditor.Paste()
-        self.modeler.primitives.refresh_all_ids()
+        self.modeler.refresh_all_ids()
         self.materials._load_from_project()
         return True
 
@@ -2388,9 +2388,9 @@ class Icepak(FieldAnalysisIcepak):
         dis_z = str(float(z_max) - float(z_min))
 
         min_position = self.modeler.Position(str(x_min) + "mm", str(y_min) + "mm", str(z_min) + "mm")
-        mesh_box = self.modeler.primitives.create_box(min_position, [dis_x + "mm", dis_y + "mm", dis_z + "mm"], name)
+        mesh_box = self.modeler.create_box(min_position, [dis_x + "mm", dis_y + "mm", dis_z + "mm"], name)
 
-        self.modeler.primitives[name].model = False
+        self.modeler[name].model = False
 
         self.modeler.edit_region_dimensions(restore_padding_values)
         return dis_x, dis_y, dis_z

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -961,7 +961,7 @@ class Maxwell(object):
 
         >>> oEditor.ChangeProperty
         """
-        self.modeler.primitives[name].solve_inside = activate
+        self.modeler[name].solve_inside = activate
         return True
 
     @aedt_exception_handler
@@ -1294,9 +1294,9 @@ class Maxwell2d(Maxwell, FieldAnalysis2D, object):
 
         solid_bodies = self.modeler.solid_bodies
         if objectfilter:
-            solid_ids = [i for i, j in self.modeler.primitives.object_id_dict.items() if j.name in objectfilter]
+            solid_ids = [i for i, j in self.modeler.object_id_dict.items() if j.name in objectfilter]
         else:
-            solid_ids = [i for i in list(self.modeler.primitives.object_id_dict.keys())]
+            solid_ids = [i for i in list(self.modeler.object_id_dict.keys())]
         self.design_data = {
             "Project Directory": self.project_path,
             "Working Directory": self.working_directory,

--- a/pyaedt/modeler/Model3D.py
+++ b/pyaedt/modeler/Model3D.py
@@ -123,7 +123,7 @@ class Modeler3D(GeometryModeler, Primitives3D, object):
             "ComponentOutline:=",
             "None",
         ]
-        objs = self.primitives.object_names
+        objs = self.object_names
         for el in objs:
             if "Region" in el and exclude_region:
                 objs.remove(el)

--- a/pyaedt/modeler/Model3DLayout.py
+++ b/pyaedt/modeler/Model3DLayout.py
@@ -314,8 +314,8 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
         >>> from pyaedt import Hfss3dLayout
         >>> h3d=Hfss3dLayout(specified_version="2021.2")
         >>> h3d.modeler.layers.add_layer("TOP")
-        >>> l1=h3d.modeler.primitives.create_line("TOP", [[0,0],[100,0]],  0.5, name="poly_1")
-        >>> l2=h3d.modeler.primitives.create_line("TOP", [[100,0],[120,-35]],  0.5, name="poly_2")
+        >>> l1=h3d.modeler.create_line("TOP", [[0,0],[100,0]],  0.5, name="poly_1")
+        >>> l2=h3d.modeler.create_line("TOP", [[100,0],[120,-35]],  0.5, name="poly_2")
         >>> h3d.modeler.unite([l1,l2])
         >>> h3d.modeler.colinear_heal("poly_2", 0.25)
         True
@@ -330,7 +330,7 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
                 "Type:=",
                 "Colinear",
                 "Tol:=",
-                self.primitives.arg_with_dim(tolerance),
+                self.arg_with_dim(tolerance),
             ]
         )
         return True
@@ -368,8 +368,8 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
         >>> from pyaedt import Hfss3dLayout
         >>> h3d=Hfss3dLayout(specified_version="2021.2")
         >>> h3d.modeler.layers.add_layer("TOP")
-        >>> h3d.modeler.primitives.create_rectangle("TOP", [20,20],[50,50], name="rect_1")
-        >>> h3d.modeler.primitives.create_line("TOP",[[25,25],[40,40]], name="line_3")
+        >>> h3d.modeler.create_rectangle("TOP", [20,20],[50,50], name="rect_1")
+        >>> h3d.modeler.create_line("TOP",[[25,25],[40,40]], name="line_3")
         >>> out1 = h3d.modeler.expand("line_3")
         >>> print(out1)
         line_4
@@ -379,17 +379,15 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
         poly = self.oeditor.GetPolygonDef(object_to_expand).GetPoints()
         pos = [poly[0].GetX(), poly[0].GetY()]
         geom_names = self.oeditor.FindObjectsByPoint(self.oeditor.Point().Set(pos[0], pos[1]), layer)
-        self.oeditor.Expand(
-            self.primitives.arg_with_dim(size), expand_type, replace_original, ["NAME:elements", object_to_expand]
-        )
+        self.oeditor.Expand(self.arg_with_dim(size), expand_type, replace_original, ["NAME:elements", object_to_expand])
         if not replace_original:
             new_geom_names = [
                 i
                 for i in self.oeditor.FindObjectsByPoint(self.oeditor.Point().Set(pos[0], pos[1]), layer)
                 if i not in geom_names
             ]
-            if self.primitives.is_outside_desktop:
-                self.primitives._geometries[new_geom_names[0]] = Geometries3DLayout(self.primitives, new_geom_names[0])
+            if self.is_outside_desktop:
+                self._geometries[new_geom_names[0]] = Geometries3DLayout(self, new_geom_names[0])
             return new_geom_names[0]
         return object_to_expand
 
@@ -515,11 +513,11 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
             self.oeditor.Subtract(vArg1)
         if isinstance(tool, list):
             for el in tool:
-                if self.primitives.is_outside_desktop:
-                    self.primitives._geometries.pop(el)
+                if self.is_outside_desktop:
+                    self._geometries.pop(el)
         else:
-            if self.primitives.is_outside_desktop:
-                self.primitives._geometries.pop(tool)
+            if self.is_outside_desktop:
+                self._geometries.pop(tool)
         return True
 
     @aedt_exception_handler
@@ -548,8 +546,8 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
             self.oeditor.Unite(vArg1)
             for el in objectlists:
                 if not self.oeditor.FindObjects("Name", el):
-                    if self.primitives.is_outside_desktop:
-                        self.primitives._geometries.pop(el)
+                    if self.is_outside_desktop:
+                        self._geometries.pop(el)
             return True
         else:
             self.logger.error("Input list must contain at least two elements.")
@@ -581,8 +579,8 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
             self.oeditor.Intersect(vArg1)
             for el in objectlists:
                 if not self.oeditor.FindObjects("Name", el):
-                    if self.primitives.is_outside_desktop:
-                        self.primitives._geometries.pop(el)
+                    if self.is_outside_desktop:
+                        self._geometries.pop(el)
             return True
         else:
             self.logger.error("Input list must contain at least two elements.")

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -665,8 +665,8 @@ class GeometryModeler(Modeler, object):
             elif type(el) is EdgePrimitive or type(el) is FacePrimitive or type(el) is VertexPrimitive:
                 output_list = [i.id for i in input_list]
             elif type(el) is int and convert_objects_ids_to_name:
-                if el in list(self.primitives.objects.keys()):
-                    output_list.append(self.primitives.objects[el].name)
+                if el in list(self.objects.keys()):
+                    output_list.append(self.objects[el].name)
                 else:
                     output_list.append(el)
             else:
@@ -876,7 +876,7 @@ class GeometryModeler(Modeler, object):
     def _find_perpendicular_points(self, face):
 
         if isinstance(face, str):
-            vertices = [i.position for i in self.primitives[face].vertices]
+            vertices = [i.position for i in self[face].vertices]
         else:
             vertices = []
             for vertex in list(self.oeditor.GetVertexIDsFromFace(face)):
@@ -1185,7 +1185,7 @@ class GeometryModeler(Modeler, object):
         ]
         vargs2 = []
         for obj in objects:
-            mat = self.primitives[obj].material_name
+            mat = self[obj].material_name
             th = self._app.materials.check_thermal_modifier(mat)
             if th:
                 vargs2.append(obj)
@@ -1227,12 +1227,12 @@ class GeometryModeler(Modeler, object):
             List of the points.
 
         """
-        out, parallel = self.primitives.find_closest_edges(startobj, endobject, axisdir)
-        port_edges = self.primitives.get_equivalent_parallel_edges(out, portonplane, axisdir, startobj, endobject)
+        out, parallel = self.find_closest_edges(startobj, endobject, axisdir)
+        port_edges = self.get_equivalent_parallel_edges(out, portonplane, axisdir, startobj, endobject)
         if port_edges is None or port_edges is False:
             port_edges = []
             for e in out:
-                edge = self.primitives.create_object_from_edge(e)
+                edge = self.create_object_from_edge(e)
                 port_edges.append(edge)
         edge_0 = port_edges[0].edges[0]
         edge_1 = port_edges[1].edges[0]
@@ -1272,7 +1272,7 @@ class GeometryModeler(Modeler, object):
             while angle <= 360:
                 position[0] = startposition[0] + offset * math.cos(math.pi * angle / 180)
                 position[1] = startposition[1] + offset * math.sin(math.pi * angle / 180)
-                if objectname in self.primitives.get_bodynames_from_position(startposition):
+                if objectname in self.get_bodynames_from_position(startposition):
                     angle = 400
                 else:
                     angle += 90
@@ -1280,7 +1280,7 @@ class GeometryModeler(Modeler, object):
             while angle <= 360:
                 position[1] = startposition[1] + offset * math.cos(math.pi * angle / 180)
                 position[2] = startposition[2] + offset * math.sin(math.pi * angle / 180)
-                if objectname in self.primitives.get_bodynames_from_position(startposition):
+                if objectname in self.get_bodynames_from_position(startposition):
                     angle = 400
                 else:
                     angle += 90
@@ -1288,7 +1288,7 @@ class GeometryModeler(Modeler, object):
             while angle <= 360:
                 position[0] = startposition[0] + offset * math.cos(math.pi * angle / 180)
                 position[2] = startposition[2] + offset * math.sin(math.pi * angle / 180)
-                if objectname in self.primitives.get_bodynames_from_position(startposition):
+                if objectname in self.get_bodynames_from_position(startposition):
                     angle = 400
                 else:
                     angle += 90
@@ -1328,7 +1328,7 @@ class GeometryModeler(Modeler, object):
         else:
             obj_cent = [1e6, 1e6, 1e6]
         face_ob = None
-        for face in self.primitives[objectname].faces:
+        for face in self[objectname].faces:
             center = face.center
             if not center:
                 continue
@@ -1343,7 +1343,7 @@ class GeometryModeler(Modeler, object):
 
         if not groundname:
             gnd_cent = []
-            bounding = self.primitives.get_model_bounding_box()
+            bounding = self.get_model_bounding_box()
             if axisdir < 3:
                 for i in bounding[0:3]:
                     gnd_cent.append(float(i))
@@ -1351,7 +1351,7 @@ class GeometryModeler(Modeler, object):
                 for i in bounding[3:]:
                     gnd_cent.append(float(i))
         else:
-            ground_plate = self.primitives[groundname]
+            ground_plate = self[groundname]
             if axisdir > 2:
                 gnd_cent = [1e6, 1e6, 1e6]
             else:
@@ -1381,7 +1381,7 @@ class GeometryModeler(Modeler, object):
             vector = [0, 0, axisdist]
 
         offset = self.find_point_around(objectname, start, sheet_dim, cs)
-        p1 = self.primitives.create_polyline([start, offset])
+        p1 = self.create_polyline([start, offset])
         p2 = p1.clone().translate(vector)
         self.connect([p1, p2])
 
@@ -1404,12 +1404,12 @@ class GeometryModeler(Modeler, object):
             ID of the face.
 
         """
-        faces = self.primitives.get_object_faces(objname)
+        faces = self.get_object_faces(objname)
         face = None
         center = None
         for f in faces:
             try:
-                c = self.primitives.get_face_center(f)
+                c = self.get_face_center(f)
                 if not face and c:
                     face = f
                     center = c
@@ -1433,8 +1433,8 @@ class GeometryModeler(Modeler, object):
             self.unite(list_unite)
 
         tol = 1e-6
-        out, parallel = self.primitives.find_closest_edges(startobj, endobject, axisdir)
-        port_edges = self.primitives.get_equivalent_parallel_edges(out, True, axisdir, startobj, endobject)
+        out, parallel = self.find_closest_edges(startobj, endobject, axisdir)
+        port_edges = self.get_equivalent_parallel_edges(out, True, axisdir, startobj, endobject)
         if port_edges is None:
             return False
         sheet_name = port_edges[0].name
@@ -1531,7 +1531,7 @@ class GeometryModeler(Modeler, object):
         """
         selections = self.convert_to_selections(obj_list, True)
         for obj in selections:
-            self.primitives[obj].model = model
+            self[obj].model = model
         return True
 
     @aedt_exception_handler
@@ -1586,11 +1586,11 @@ class GeometryModeler(Modeler, object):
         group_objs = list(self.oeditor.GetObjectsInGroup(group))
         if not group_objs:
             return None
-        all_objs = self.primitives.object_names
+        all_objs = self.object_names
         objs_to_unmodel = [i for i in all_objs if i not in group_objs]
         if objs_to_unmodel:
             vArg1 = ["NAME:Model", "Value:=", False]
-            self.primitives._change_geometry_property(vArg1, objs_to_unmodel)
+            self._change_geometry_property(vArg1, objs_to_unmodel)
             bounding = self.get_model_bounding_box()
             self._odesign.Undo()
         else:
@@ -1625,8 +1625,8 @@ class GeometryModeler(Modeler, object):
             objtosplit = [objtosplit]
         objnames = []
         for el in objtosplit:
-            if isinstance(el, int) and el in list(self.primitives.objects.keys()):
-                objnames.append(self.primitives.objects[el].name)
+            if isinstance(el, int) and el in list(self.objects.keys()):
+                objnames.append(self.objects[el].name)
             elif isinstance(el, int):
                 objnames.append(el)
             elif isinstance(el, Object3d):
@@ -1689,7 +1689,7 @@ class GeometryModeler(Modeler, object):
                 True,
             ],
         )
-        self.primitives.refresh_all_ids()
+        self.refresh_all_ids()
         return True
 
     @aedt_exception_handler
@@ -1720,8 +1720,8 @@ class GeometryModeler(Modeler, object):
         >>> oEditor.DuplicateMirror
         """
         selections = self.convert_to_selections(objid)
-        Xpos, Ypos, Zpos = self.primitives._pos_with_arg(position)
-        Xnorm, Ynorm, Znorm = self.primitives._pos_with_arg(vector)
+        Xpos, Ypos, Zpos = self._pos_with_arg(position)
+        Xnorm, Ynorm, Znorm = self._pos_with_arg(vector)
 
         vArg1 = ["NAME:Selections", "Selections:=", selections, "NewPartsModelFlag:=", "Model"]
         vArg2 = ["NAME:DuplicateToMirrorParameters"]
@@ -1733,11 +1733,11 @@ class GeometryModeler(Modeler, object):
         vArg2.append("DuplicateMirrorNormalZ:="), vArg2.append(Znorm)
         vArg3 = ["NAME:Options", "DuplicateAssignments:=", False]
         if is_3d_comp:
-            orig_3d = [i for i in self.primitives.components_3d_names]
+            orig_3d = [i for i in self.components_3d_names]
         added_objs = self.oeditor.DuplicateMirror(vArg1, vArg2, vArg3)
-        self.primitives.add_new_objects()
+        self.add_new_objects()
         if is_3d_comp:
-            added_3d_comps = [i for i in self.primitives.components_3d_names if i not in orig_3d]
+            added_3d_comps = [i for i in self.components_3d_names if i not in orig_3d]
             if added_3d_comps:
                 self.logger.info("Found 3D Components Duplication")
                 return True, added_3d_comps
@@ -1769,8 +1769,8 @@ class GeometryModeler(Modeler, object):
         >>> oEditor.Mirror
         """
         selections = self.convert_to_selections(objid)
-        Xpos, Ypos, Zpos = self.primitives._pos_with_arg(position)
-        Xnorm, Ynorm, Znorm = self.primitives._pos_with_arg(vector)
+        Xpos, Ypos, Zpos = self._pos_with_arg(position)
+        Xnorm, Ynorm, Znorm = self._pos_with_arg(vector)
 
         vArg1 = ["NAME:Selections", "Selections:=", selections, "NewPartsModelFlag:=", "Model"]
         vArg2 = ["NAME:MirrorParameters"]
@@ -1807,7 +1807,7 @@ class GeometryModeler(Modeler, object):
 
         >>> oEditor.Move
         """
-        Xvec, Yvec, Zvec = self.primitives._pos_with_arg(vector)
+        Xvec, Yvec, Zvec = self._pos_with_arg(vector)
         szSelections = self.convert_to_selections(objid)
 
         vArg1 = ["NAME:Selections", "Selections:=", szSelections, "NewPartsModelFlag:=", "Model"]
@@ -1859,17 +1859,17 @@ class GeometryModeler(Modeler, object):
             "WhichAxis:=",
             GeometryOperators.cs_axis_str(cs_axis),
             "AngleStr:=",
-            self.primitives._arg_with_dim(angle, "deg"),
+            self._arg_with_dim(angle, "deg"),
             "Numclones:=",
             str(nclones),
         ]
         vArg3 = ["NAME:Options", "DuplicateBoundaries:=", "true"]
         if is_3d_comp:
-            orig_3d = [i for i in self.primitives.components_3d_names]
+            orig_3d = [i for i in self.components_3d_names]
         added_objs = self.oeditor.DuplicateAroundAxis(vArg1, vArg2, vArg3)
         self._duplicate_added_objects_tuple()
         if is_3d_comp:
-            added_3d_comps = [i for i in self.primitives.components_3d_names if i not in orig_3d]
+            added_3d_comps = [i for i in self.components_3d_names if i not in orig_3d]
             if added_3d_comps:
                 self.logger.info("Found 3D Components Duplication")
                 return True, added_3d_comps
@@ -1877,7 +1877,7 @@ class GeometryModeler(Modeler, object):
         return True, list(added_objs)
 
     def _duplicate_added_objects_tuple(self):
-        added_objects = self.primitives.add_new_objects()
+        added_objects = self.add_new_objects()
         if added_objects:
             return True, added_objects
         else:
@@ -1910,7 +1910,7 @@ class GeometryModeler(Modeler, object):
         >>> oEditor.DuplicateAlongLine
         """
         selections = self.convert_to_selections(objid)
-        Xpos, Ypos, Zpos = self.primitives._pos_with_arg(vector)
+        Xpos, Ypos, Zpos = self._pos_with_arg(vector)
 
         vArg1 = ["NAME:Selections", "Selections:=", selections, "NewPartsModelFlag:=", "Model"]
         vArg2 = ["NAME:DuplicateToAlongLineParameters"]
@@ -1921,11 +1921,11 @@ class GeometryModeler(Modeler, object):
         vArg2.append("Numclones:="), vArg2.append(str(nclones))
         vArg3 = ["NAME:Options", "DuplicateBoundaries:=", "true"]
         if is_3d_comp:
-            orig_3d = [i for i in self.primitives.components_3d_names]
+            orig_3d = [i for i in self.components_3d_names]
         added_objs = self.oeditor.DuplicateAlongLine(vArg1, vArg2, vArg3)
         self._duplicate_added_objects_tuple()
         if is_3d_comp:
-            added_3d_comps = [i for i in self.primitives.components_3d_names if i not in orig_3d]
+            added_3d_comps = [i for i in self.components_3d_names if i not in orig_3d]
             if added_3d_comps:
                 self.logger.info("Found 3D Components Duplication")
                 return True, added_3d_comps
@@ -1958,11 +1958,11 @@ class GeometryModeler(Modeler, object):
 
         vArg1 = ["NAME:Selections", "Selections:=", selections, "NewPartsModelFlag:=", "Model"]
         vArg2 = ["NAME:SheetThickenParameters"]
-        vArg2.append("Thickness:="), vArg2.append(self.primitives._arg_with_dim(thickness))
+        vArg2.append("Thickness:="), vArg2.append(self._arg_with_dim(thickness))
         vArg2.append("BothSides:="), vArg2.append(bBothSides)
 
         self.oeditor.ThickenSheet(vArg1, vArg2)
-        return self.primitives.update_object(objid)
+        return self.update_object(objid)
 
     @aedt_exception_handler
     def sweep_along_normal(self, obj_name, face_id, sweep_value=0.1):
@@ -1995,19 +1995,19 @@ class GeometryModeler(Modeler, object):
                 "FacesToDetach:=",
                 [face_id],
                 "LengthOfSweep:=",
-                self.primitives._arg_with_dim(sweep_value),
+                self._arg_with_dim(sweep_value),
             ]
         )
 
-        objs = self.primitives._all_object_names
+        objs = self._all_object_names
         self.oeditor.SweepFacesAlongNormal(vArg1, vArg2)
-        self.primitives.cleanup_objects()
-        objs2 = self.primitives._all_object_names
+        self.cleanup_objects()
+        objs2 = self._all_object_names
         obj = [i for i in objs2 if i not in objs]
         for el in obj:
-            self.primitives._create_object(el)
+            self._create_object(el)
         if obj:
-            return self.primitives.update_object(self.primitives[obj[0]])
+            return self.update_object(self[obj[0]])
         return False
 
     @aedt_exception_handler
@@ -2038,10 +2038,10 @@ class GeometryModeler(Modeler, object):
         >>> oEditor.SweepAlongVector
         """
         selections = self.convert_to_selections(objid)
-        vectorx, vectory, vectorz = self.primitives._pos_with_arg(sweep_vector)
+        vectorx, vectory, vectorz = self._pos_with_arg(sweep_vector)
         vArg1 = ["NAME:Selections", "Selections:=", selections, "NewPartsModelFlag:=", "Model"]
         vArg2 = ["NAME:VectorSweepParameters"]
-        vArg2.append("DraftAngle:="), vArg2.append(self.primitives._arg_with_dim(draft_angle, "deg"))
+        vArg2.append("DraftAngle:="), vArg2.append(self._arg_with_dim(draft_angle, "deg"))
         vArg2.append("DraftType:="), vArg2.append(GeometryOperators.draft_type_str(draft_type))
         vArg2.append("SweepVectorX:="), vArg2.append(vectorx)
         vArg2.append("SweepVectorY:="), vArg2.append(vectory)
@@ -2049,7 +2049,7 @@ class GeometryModeler(Modeler, object):
 
         self.oeditor.SweepAlongVector(vArg1, vArg2)
 
-        return self.primitives.update_object(objid)
+        return self.update_object(objid)
 
     @aedt_exception_handler
     def sweep_along_path(
@@ -2086,14 +2086,14 @@ class GeometryModeler(Modeler, object):
         selections = self.convert_to_selections(objid) + "," + self.convert_to_selections(sweep_object)
         vArg1 = ["NAME:Selections", "Selections:=", selections, "NewPartsModelFlag:=", "Model"]
         vArg2 = ["NAME:PathSweepParameters"]
-        vArg2.append("DraftAngle:="), vArg2.append(self.primitives._arg_with_dim(draft_angle, "deg"))
+        vArg2.append("DraftAngle:="), vArg2.append(self._arg_with_dim(draft_angle, "deg"))
         vArg2.append("DraftType:="), vArg2.append(GeometryOperators.draft_type_str(draft_type))
         vArg2.append("CheckFaceFaceIntersection:="), vArg2.append(is_check_face_intersection)
         vArg2.append("TwistAngle:="), vArg2.append(str(twist_angle) + "deg")
 
         self.oeditor.SweepAlongPath(vArg1, vArg2)
 
-        return self.primitives.update_object(objid)
+        return self.update_object(objid)
 
     @aedt_exception_handler
     def sweep_around_axis(self, objid, cs_axis, sweep_angle=360, draft_angle=0):
@@ -2126,7 +2126,7 @@ class GeometryModeler(Modeler, object):
         vArg2 = [
             "NAME:AxisSweepParameters",
             "DraftAngle:=",
-            self.primitives._arg_with_dim(draft_angle, "deg"),
+            self._arg_with_dim(draft_angle, "deg"),
             "DraftType:=",
             "Round",
             "CheckFaceFaceIntersection:=",

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -735,7 +735,7 @@ class Object3d(object):
 
     >>> from pyaedt import Hfss
     >>> aedtapp = Hfss()
-    >>> prim = aedtapp.modeler.primitives
+    >>> prim = aedtapp.modeler
 
     Create a part, such as box, to return an :class:`pyaedt.modeler.Object3d.Object3d`.
 

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -508,7 +508,7 @@ class Polyline(Object3d):
 
         Examples
         --------
-        >>> primitives = self.aedtapp.modeler.primitives
+        >>> primitives = self.aedtapp.modeler
         >>> P1 = primitives.create_polyline([[0, 1, 2], [0, 2, 3], [2, 1, 4]])
         >>> P2 = P1.clone()
 
@@ -862,7 +862,7 @@ class Primitives(object):
 
     >>> from pyaedt import Hfss
     >>> aedtapp = Hfss()
-    >>> prim = aedtapp.modeler.primitives
+    >>> prim = aedtapp.modeler
     """
 
     def __init__(self):
@@ -1397,7 +1397,7 @@ class Primitives(object):
         >>> desktop=Desktop(specified_version="2021.2", new_desktop_session=False)
         >>> aedtapp = Maxwell3D()
         >>> aedtapp.modeler.model_units = "mm"
-        >>> primitives = aedtapp.modeler.primitives
+        >>> primitives = aedtapp.modeler
 
         Define some test data points.
 

--- a/pyaedt/modeler/Primitives2D.py
+++ b/pyaedt/modeler/Primitives2D.py
@@ -6,7 +6,7 @@ class Primitives2D(Primitives, object):
     """Manages primitives in 2D tools.
 
     This class is inherited in the caller application and is accessible through the primitives variable part
-    of the modeler object (for example, ``hfss.modeler.primitives`` or ``icepak.modeler.primitives``).
+    of the modeler object (for example, ``hfss.modeler`` or ``icepak.modeler``).
 
 
     Examples
@@ -15,7 +15,7 @@ class Primitives2D(Primitives, object):
 
     >>> from pyaedt import Q2d
     >>> aedtapp = Q2d()
-    >>> prim = aedtapp.modeler.primitives
+    >>> prim = aedtapp.modeler
     """
 
     @property
@@ -63,9 +63,9 @@ class Primitives2D(Primitives, object):
 
         Examples
         --------
-        >>> circle1 = aedtapp.modeler.primitives.create_circle([0, -2, -2], 3)
-        >>> circle2 = aedtapp.modeler.primitives.create_circle(position=[0, -2, -2], radius=3, num_sides=6,
-        ...                                                     name="MyCircle", matname="Copper")
+        >>> circle1 = aedtapp.modeler.create_circle([0, -2, -2], 3)
+        >>> circle2 = aedtapp.modeler.create_circle(position=[0, -2, -2], radius=3, num_sides=6,
+        ...                                         name="MyCircle", matname="Copper")
 
 
         """
@@ -119,9 +119,9 @@ class Primitives2D(Primitives, object):
 
         Examples
         --------
-        >>> ellipse1 = aedtapp.modeler.primitives.create_ellipse([0, -2, -2], 4.0, 0.2)
-        >>> ellipse2 = aedtapp.modeler.primitives.create_ellipse(position=[0, -2, -2], major_radius=4.0, ratio=0.2,
-        ...                                                     name="MyEllipse", matname="Copper")
+        >>> ellipse1 = aedtapp.modeler.create_ellipse([0, -2, -2], 4.0, 0.2)
+        >>> ellipse2 = aedtapp.modeler.create_ellipse(position=[0, -2, -2], major_radius=4.0, ratio=0.2,
+        ...                                           name="MyEllipse", matname="Copper")
         """
         szAxis = self.plane2d
         XStart, YStart, ZStart = self._pos_with_arg(position)
@@ -170,9 +170,9 @@ class Primitives2D(Primitives, object):
         Examples
         --------
 
-        >>> rect1 = aedtapp.modeler.primitives.create_rectangle([0, -2, -2], [3, 4])
-        >>> rect2 = aedtapp.modeler.primitives.create_rectangle(position=[0, -2, -2], dimension_list=[3, 4],
-        ...                                                     name="MyCircle", matname="Copper")
+        >>> rect1 = aedtapp.modeler.create_rectangle([0, -2, -2], [3, 4])
+        >>> rect2 = aedtapp.modeler.create_rectangle(position=[0, -2, -2], dimension_list=[3, 4],
+        ...                                          name="MyCircle", matname="Copper")
 
         """
         axis = self.plane2d
@@ -226,9 +226,9 @@ class Primitives2D(Primitives, object):
         Examples
         --------
 
-        >>> pg1 = aedtapp.modeler.primitives.create_regular_polygon([0, 0, 0], [0, 2, 0])
-        >>> pg2 = aedtapp.modeler.primitives.create_regular_polygon(position=[0, 0, 0], start_point=[0, 2, 0],
-        ...                                                     name="MyPolygon", matname="Copper")
+        >>> pg1 = aedtapp.modeler.create_regular_polygon([0, 0, 0], [0, 2, 0])
+        >>> pg2 = aedtapp.modeler.create_regular_polygon(position=[0, 0, 0], start_point=[0, 2, 0],
+        ...                                              name="MyPolygon", matname="Copper")
 
         """
         x_center, y_center, z_center = self._pos_with_arg(position)

--- a/pyaedt/modeler/Primitives3D.py
+++ b/pyaedt/modeler/Primitives3D.py
@@ -16,7 +16,7 @@ class Primitives3D(Primitives, object):
 
     This class is inherited in the caller application and is
     accessible through the primitives variable part of modeler object(
-    e.g. ``hfss.modeler.primitives`` or ``icepak.modeler.primitives``).
+    e.g. ``hfss.modeler`` or ``icepak.modeler``).
 
     Parameters
     ----------
@@ -29,7 +29,7 @@ class Primitives3D(Primitives, object):
 
     >>> from pyaedt import Hfss
     >>> aedtapp = Hfss()
-    >>> prim = aedtapp.modeler.primitives
+    >>> prim = aedtapp.modeler
     """
 
     def __init__(self):
@@ -190,9 +190,9 @@ class Primitives3D(Primitives, object):
         --------
         >>> from pyaedt import Hfss
         >>> aedtapp = Hfss()
-        >>> cylinder_object = aedtapp.modeler.primitives.create_cylinder(cs_axis='Z', position=[0,0,0],
-        ...                                                              radius=2, height=3, name="mycyl",
-        ...                                                              matname="vacuum")
+        >>> cylinder_object = aedtapp.modeler..create_cylinder(cs_axis='Z', position=[0,0,0],
+        ...                                                   radius=2, height=3, name="mycyl",
+        ...                                                   matname="vacuum")
 
         """
         if isinstance(radius, (int, float)) and radius < 0:
@@ -265,9 +265,9 @@ class Primitives3D(Primitives, object):
         --------
         >>> from pyaedt import Hfss
         >>> aedtapp = Hfss()
-        >>> ret_obj = aedtapp.modeler.primitives.create_polyhedron(cs_axis='X', center_position=[0, 0, 0],
-        ...                                                        start_position=[0,5,0], height=0.5,
-        ...                                                        num_sides=8, name="mybox", matname="copper")
+        >>> ret_obj = aedtapp.modeler.create_polyhedron(cs_axis='X', center_position=[0, 0, 0],
+        ...                                             start_position=[0,5,0], height=0.5,
+        ...                                              num_sides=8, name="mybox", matname="copper")
 
         """
         test = cs_axis
@@ -330,9 +330,9 @@ class Primitives3D(Primitives, object):
         --------
         >>> from pyaedt import Hfss
         >>> aedtapp = Hfss()
-        >>> cone_object = aedtapp.modeler.primitives.create_cone(cs_axis='Z', position=[0, 0, 0],
-        ...                                                      bottom_radius=2, top_radius=3, height=4,
-        ...                                                      name="mybox", matname="copper")
+        >>> cone_object = aedtapp.modeler.create_cone(cs_axis='Z', position=[0, 0, 0],
+        ...                                           bottom_radius=2, top_radius=3, height=4,
+        ...                                           name="mybox", matname="copper")
 
         """
         if bottom_radius == top_radius:
@@ -394,8 +394,8 @@ class Primitives3D(Primitives, object):
         --------
         >>> from pyaedt import Hfss
         >>> aedtapp = Hfss()
-        >>> ret_object = aedtapp.modeler.primitives.create_sphere(position=[0,0,0], radius=2,
-        ...                                                      name="mysphere", matname="copper")
+        >>> ret_object = aedtapp.modeler.create_sphere(position=[0,0,0], radius=2,
+        ...                                            name="mysphere", matname="copper")
 
         """
         if len(position) != 3:
@@ -456,9 +456,9 @@ class Primitives3D(Primitives, object):
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> origin = [0, 0, 0]
-        >>> torus = hfss.modeler.primitives.create_torus(origin, major_radius=1,
-        ...                                              minor_radius=0.5, axis="Z",
-        ...                                              name="mytorus", material_name="copper")
+        >>> torus = hfss.modeler.create_torus(origin, major_radius=1,
+        ...                                   minor_radius=0.5, axis="Z",
+        ...                                    name="mytorus", material_name="copper")
 
         """
         if len(center) != 3:
@@ -1470,7 +1470,7 @@ class Primitives3D(Primitives, object):
         >>> from pyaedt import Hfss
         >>> app = Hfss()
         >>> bird_dir = "path/to/bird/directory"
-        >>> bird1 = app.modeler.primitives.add_bird(bird_dir, 1.0, [19, 4, 3], 120, -5, flapping_rate=30)
+        >>> bird1 = app.modeler.add_bird(bird_dir, 1.0, [19, 4, 3], 120, -5, flapping_rate=30)
 
         """
         self._initialize_multipart()

--- a/pyaedt/modeler/Primitives3DLayout.py
+++ b/pyaedt/modeler/Primitives3DLayout.py
@@ -23,7 +23,7 @@ class Primitives3DLayout(object):
     """Manages primitives in HFSS 3D Layout.
 
     This class is inherited in the caller application and is accessible through the primitives variable part
-    of modeler object( eg. ``hfss3dlayout.modeler.primitives``).
+    of modeler object( eg. ``hfss3dlayout.modeler``).
 
     Parameters
     ----------
@@ -36,7 +36,7 @@ class Primitives3DLayout(object):
 
     >>> from pyaedt import Hfss3dLayout
     >>> aedtapp = Hfss3dLayout()
-    >>> prim = aedtapp.modeler.primitives
+    >>> prim = aedtapp.modeler
     """
 
     @aedt_exception_handler

--- a/pyaedt/modeler/parts.py
+++ b/pyaedt/modeler/parts.py
@@ -413,11 +413,9 @@ class Part(object):
         # TODO: Why the inconsistent syntax for cs commands?
         if self._do_offset:
             self.set_relative_cs(app)  # Create coordinate system, if needed.
-            aedt_objects.append(app.modeler.primitives.insert_3d_component(self.file_name, targetCS=self.cs_name))
+            aedt_objects.append(app.modeler.insert_3d_component(self.file_name, targetCS=self.cs_name))
         else:
-            aedt_objects.append(
-                app.modeler.primitives.insert_3d_component(self.file_name, targetCS=self._multiparts.cs_name)
-            )
+            aedt_objects.append(app.modeler.insert_3d_component(self.file_name, targetCS=self._multiparts.cs_name))
         if self._do_rotate:
             self.do_rotate(app, aedt_objects[0])
 

--- a/pyaedt/modules/Boundary.py
+++ b/pyaedt/modules/Boundary.py
@@ -235,8 +235,8 @@ class BoundaryObject(BoundaryCommon, object):
     >>> from pyaedt import Hfss
     >>> hfss =Hfss()
     >>> origin = hfss.modeler.Position(0, 0, 0)
-    >>> inner = hfss.modeler.primitives.create_cylinder(hfss.PLANE.XY, origin, 3, 200, 0, "inner")
-    >>> inner_id = hfss.modeler.primitives.get_obj_id("inner")
+    >>> inner = hfss.modeler.create_cylinder(hfss.PLANE.XY, origin, 3, 200, 0, "inner")
+    >>> inner_id = hfss.modeler.get_obj_id("inner")
     >>> coat = hfss.assign_coating([inner_id], "copper", usethickness=True, thickness="0.2mm")
     """
 

--- a/pyaedt/modules/LayerStackup.py
+++ b/pyaedt/modules/LayerStackup.py
@@ -94,7 +94,7 @@ class Layer(object):
     --------
     >>> from pyaedt import Hfss3dLayout
     >>> app = Hfss3dLayout()
-    >>> layers = app.modeler.primitives.layers["Top"]
+    >>> layers = app.modeler.layers["Top"]
     """
 
     def __init__(self, app, layertype="signal", negative=False):
@@ -575,7 +575,7 @@ class Layers(object):
     --------
     >>> from pyaedt import Hfss3dLayout
     >>> app = Hfss3dLayout()
-    >>> layers = app.modeler.primitives.layers
+    >>> layers = app.modeler.layers
     """
 
     def __init__(self, modeler, roughnessunits="um"):

--- a/pyaedt/modules/MeshIcepak.py
+++ b/pyaedt/modules/MeshIcepak.py
@@ -519,14 +519,14 @@ class IcepakMesh(object):
         meshregion.Level = level
         meshregion.name = name
         if not objectlist:
-            objectlist = [i for i in self.modeler.primitives.object_names]
+            objectlist = [i for i in self.modeler.object_names]
         if is_submodel:
             meshregion.SubModels = objectlist
         else:
             meshregion.Objects = objectlist
-        all_objs = [i for i in self.modeler.primitives.object_names]
+        all_objs = [i for i in self.modeler.object_names]
         meshregion.create()
-        objectlist2 = self.modeler.primitives.object_names
+        objectlist2 = self.modeler.object_names
         added_obj = [i for i in objectlist2 if i not in all_objs]
         meshregion.Objects = added_obj
         meshregion.SubModels = None

--- a/pyaedt/modules/PostProcessor.py
+++ b/pyaedt/modules/PostProcessor.py
@@ -1556,7 +1556,7 @@ class PostProcessor(PostProcessorCommon, object):
             Primitives object.
 
         """
-        return self._app._modeler.primitives
+        return self._app._modeler
 
     @property
     def model_units(self):
@@ -2704,7 +2704,7 @@ class PostProcessor(PostProcessorCommon, object):
             export_path = self._app.working_directory
         if not obj_list:
             self._app.modeler.refresh_all_ids()
-            obj_list = self._app.modeler.primitives.object_names
+            obj_list = self._app.modeler.object_names
             if not air_objects:
                 obj_list = [
                     i
@@ -2751,14 +2751,14 @@ class PostProcessor(PostProcessorCommon, object):
         if not setup_name:
             setup_name = self._app.nominal_adaptive
         face_lists = []
-        obj_list = self._app.modeler.primitives.object_names
+        obj_list = self._app.modeler.object_names
         for el in obj_list:
-            obj_id = self._app.modeler.primitives.get_obj_id(el)
-            if not self._app.modeler.primitives.objects[obj_id].is3d or (
-                self._app.modeler.primitives.objects[obj_id].material_name != "vacuum"
-                and self._app.modeler.primitives.objects[obj_id].material_name != "air"
+            obj_id = self._app.modeler.get_obj_id(el)
+            if not self._app.modeler.objects[obj_id].is3d or (
+                self._app.modeler.objects[obj_id].material_name != "vacuum"
+                and self._app.modeler.objects[obj_id].material_name != "air"
             ):
-                face_lists += self._app.modeler.primitives.get_object_faces(obj_id)
+                face_lists += self._app.modeler.get_object_faces(obj_id)
         plot = self.create_fieldplot_surface(face_lists, "Mesh", setup_name, intrinsic_dict)
         if plot:
             file_to_add = self.export_field_plot(plot.name, project_path)

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -776,9 +776,7 @@ class Q2d(QExtractor, object):
 
         >>> oEditor.CreateRectangle
         """
-        return self.modeler.primitives.create_rectangle(
-            position, dimension_list=dimension_list, name=name, matname=matname
-        )
+        return self.modeler.create_rectangle(position, dimension_list=dimension_list, name=name, matname=matname)
 
     @aedt_exception_handler
     def assign_single_signal_line(self, target_objects, name="", solve_option="SolveInside", thickness=None, unit="um"):


### PR DESCRIPTION
…ecated and now any methods from primitives can be called directly from modeler

eg. modeler.primitives.create_box becomes modeler.create_box