### PR TITLE
Update an existing user-defined primitive (UDP).

### DIFF
--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -186,6 +186,7 @@ class TestClass:
             upd_library="syslib",
             udptye="Solid",
         )
+
         assert second_udp
         assert second_udp.name == "ClawPoleCore"
         assert "ClawPoleCore" in udp._primitives.object_names

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -173,7 +173,7 @@ class TestClass:
             object_name="MyClawPoleCore",
             operation_name="CreateUserDefinedPart",
             udp_parameters_list=[["Length", "110mm"]],
-            )
+        )
 
         assert int(udp.bounding_dimension[0]) == 102
         assert int(udp.bounding_dimension[1]) == 102

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -195,7 +195,7 @@ class TestClass:
             object_name="ClawPoleCore",
             operation_name="CreateUserDefinedPart",
             udp_parameters_list=[["Length", "110mm"], ["DiaGap", "125mm"]],
-            )
+        )
 
         assert int(second_udp.bounding_dimension[0]) == 125
         assert int(second_udp.bounding_dimension[1]) == 125

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -162,9 +162,22 @@ class TestClass:
             name=my_udpName,
             udptye="Solid",
         )
+
         assert udp
         assert udp.name == "MyClawPoleCore"
         assert "MyClawPoleCore" in udp._primitives.object_names
+        assert int(udp.bounding_dimension[2]) == 100
+
+        # Modify one of the 'MyClawPoleCore' udp properties.
+        assert self.aedtapp.modeler.update_udp(
+            object_name="MyClawPoleCore",
+            operation_name="CreateUserDefinedPart",
+            udp_parameters_list=[["Length","110mm"]],
+            )
+
+        assert int(udp.bounding_dimension[0]) == 102
+        assert int(udp.bounding_dimension[1]) == 102
+        assert int(udp.bounding_dimension[2]) == 110
 
         # Test udp with default name -None-.
         second_udp = self.aedtapp.modeler.create_udp(
@@ -176,6 +189,18 @@ class TestClass:
         assert second_udp
         assert second_udp.name == "ClawPoleCore"
         assert "ClawPoleCore" in udp._primitives.object_names
+
+        # Modify two of the 'MyClawPoleCore' udp properties.
+        assert self.aedtapp.modeler.update_udp(
+            object_name="ClawPoleCore",
+            operation_name="CreateUserDefinedPart",
+            udp_parameters_list=[["Length","110mm"], ["DiaGap","125mm"]],
+            )
+
+        assert int(second_udp.bounding_dimension[0]) == 125
+        assert int(second_udp.bounding_dimension[1]) == 125
+        assert int(second_udp.bounding_dimension[2]) == 110
+
 
     @pytest.mark.skipif(os.name == "posix", reason="Feature not supported in Linux")
     def test_27_create_udm(self):

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -172,7 +172,7 @@ class TestClass:
         assert self.aedtapp.modeler.update_udp(
             object_name="MyClawPoleCore",
             operation_name="CreateUserDefinedPart",
-            udp_parameters_list=[["Length","110mm"]],
+            udp_parameters_list=[["Length", "110mm"]],
             )
 
         assert int(udp.bounding_dimension[0]) == 102
@@ -194,13 +194,12 @@ class TestClass:
         assert self.aedtapp.modeler.update_udp(
             object_name="ClawPoleCore",
             operation_name="CreateUserDefinedPart",
-            udp_parameters_list=[["Length","110mm"], ["DiaGap","125mm"]],
+            udp_parameters_list=[["Length", "110mm"], ["DiaGap", "125mm"]],
             )
 
         assert int(second_udp.bounding_dimension[0]) == 125
         assert int(second_udp.bounding_dimension[1]) == 125
         assert int(second_udp.bounding_dimension[2]) == 110
-
 
     @pytest.mark.skipif(os.name == "posix", reason="Feature not supported in Linux")
     def test_27_create_udm(self):

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -1656,7 +1656,7 @@ class Primitives(object):
 
         cmd_tab.append(changed_props)
         vArg1.append(cmd_tab)
-        obj_name = self._oeditor.ChangeProperty(vArg1)
+        self._oeditor.ChangeProperty(vArg1)
         return True
 
     @aedt_exception_handler

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -1641,7 +1641,7 @@ class Primitives(object):
         vArg1 = ["NAME:AllTabs"]
 
         prop_servers = ["NAME:PropServers"]
-        prop_servers.append(f"{object_name}:{operation_name}:1")
+        prop_servers.append("{0}:{1}:1".format(object_name, operation_name))
 
         cmd_tab = ["NAME:Geometry3DCmdTab"]
         cmd_tab.append(prop_servers)
@@ -1650,7 +1650,7 @@ class Primitives(object):
 
         for pair in udp_parameters_list:
             if isinstance(pair, list):
-                changed_props.append([f"NAME:{pair[0]}", "Value:=", pair[1]])
+                changed_props.append(["NAME:{0}".format(pair[0]), "Value:=", pair[1]])
             else:
                 changed_props.append(["NAME:", pair.Name, "Value:=", pair.Value])
 

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -1600,7 +1600,7 @@ class Primitives(object):
 
     @aedt_exception_handler
     def update_udp(self, object_name, operation_name, udp_parameters_list):
-        """Create a user-defined primitive (UDP).
+        """Update an existing geometrical object that was originally created using a user-defined primitive (UDP).
 
         Parameters
         ----------

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -1563,6 +1563,14 @@ class Primitives(object):
         :class:`pyaedt.modeler.Object3d.Object3d`
             UDP object created.
 
+        Examples
+        --------
+        >>> my_udp = self.aedtapp.modeler.create_udp(udp_dll_name="RMxprt/ClawPoleCore",
+        ...                                          udp_parameters_list=my_udpPairs,
+        ...                                          upd_library="syslib",
+        ...                                          udptye="Solid")
+        <class 'pyaedt.modeler.Object3d.Object3d'>
+
         References
         ----------
 
@@ -1609,12 +1617,19 @@ class Primitives(object):
         operation_name : str
             Name of the operation used to create the object.
         udp_parameters_list : list
-            List of the UDP parameters to update.
+            List of the UDP parameters to update and their value.
 
         Returns
         -------
         bool
-            ``True`` when successful,
+            ``True`` when successful.
+
+        Examples
+        --------
+        >>> self.aedtapp.modeler.update_udp(object_name="ClawPoleCore",
+        ...                                 operation_name="CreateUserDefinedPart",
+        ...                                 udp_parameters_list=[["Length","110mm"], ["DiaGap","125mm"]])
+        True
 
         References
         ----------

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -1563,6 +1563,11 @@ class Primitives(object):
         :class:`pyaedt.modeler.Object3d.Object3d`
             UDP object created.
 
+        References
+        ----------
+
+        >>> oEditor.CreateUserDefinedPart
+
         Examples
         --------
         >>> my_udp = self.aedtapp.modeler.create_udp(udp_dll_name="RMxprt/ClawPoleCore",
@@ -1570,11 +1575,6 @@ class Primitives(object):
         ...                                          upd_library="syslib",
         ...                                          udptye="Solid")
         <class 'pyaedt.modeler.Object3d.Object3d'>
-
-        References
-        ----------
-
-        >>> oEditor.CreateUserDefinedPart
 
         """
         if ".dll" not in udp_dll_name:
@@ -1624,17 +1624,17 @@ class Primitives(object):
         bool
             ``True`` when successful.
 
+        References
+        ----------
+
+        >>> oEditor.CreateUserDefinedPart
+
         Examples
         --------
         >>> self.aedtapp.modeler.update_udp(object_name="ClawPoleCore",
         ...                                 operation_name="CreateUserDefinedPart",
         ...                                 udp_parameters_list=[["Length","110mm"], ["DiaGap","125mm"]])
         True
-
-        References
-        ----------
-
-        >>> oEditor.CreateUserDefinedPart
 
         """
 

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -1599,6 +1599,52 @@ class Primitives(object):
         return self._create_object(obj_name)
 
     @aedt_exception_handler
+    def update_udp(self, object_name, operation_name, udp_parameters_list):
+        """Create a user-defined primitive (UDP).
+
+        Parameters
+        ----------
+        object_name : str
+            Name of the object to update.
+        operation_name : str
+            Name of the operation used to create the object.
+        udp_parameters_list : list
+            List of the UDP parameters to update.
+
+        Returns
+        -------
+        bool
+            ``True`` when successful,
+
+        References
+        ----------
+
+        >>> oEditor.CreateUserDefinedPart
+
+        """
+
+        vArg1 = ["NAME:AllTabs"]
+
+        prop_servers = ["NAME:PropServers"]
+        prop_servers.append(f"{object_name}:{operation_name}:1")
+
+        cmd_tab = ["NAME:Geometry3DCmdTab"]
+        cmd_tab.append(prop_servers)
+
+        changed_props = ["NAME:ChangedProps"]
+
+        for pair in udp_parameters_list:
+            if isinstance(pair, list):
+                changed_props.append([f"NAME:{pair[0]}", "Value:=", pair[1]])
+            else:
+                changed_props.append(["NAME:", pair.Name, "Value:=", pair.Value])
+
+        cmd_tab.append(changed_props)
+        vArg1.append(cmd_tab)
+        obj_name = self._oeditor.ChangeProperty(vArg1)
+        return True
+
+    @aedt_exception_handler
     def delete(self, objects=None):
         """Delete objects or groups.
 


### PR DESCRIPTION
It is now possible to update an existing geometry object that was originally created using UDP.
Add unit tests for the UDP updates.
Fix #847 .