### PR TITLE
add badges to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,26 @@
+|pypi| |PyPIact| |GH-CI| |codecov| |MIT| |black|
+
+
+.. |pypi| image:: https://img.shields.io/pypi/v/pyaedt.svg?logo=python&logoColor=white
+   :target: https://pypi.org/project/pyaedt/
+
+.. |PyPIact| image:: https://img.shields.io/pypi/dm/pyaedt.svg?label=PyPI%20downloads
+   :target: https://pypi.org/project/pyaedt/
+
+.. |GH-CI| image:: https://github.com/pyansys/pyaedt/actions/workflows/unit_tests.yml/badge.svg
+   :target: https://github.com/pyansys/pyaedt/actions/workflows/unit_tests.yml
+
+.. |codecov| image:: https://codecov.io/gh/pyansys/pyaedt/branch/main/graph/badge.svg
+   :target: https://codecov.io/gh/pyansys/pyaedt
+
+.. |MIT| image:: https://img.shields.io/badge/License-MIT-yellow.svg
+   :target: https://opensource.org/licenses/MIT
+
+.. |black| image:: https://img.shields.io/badge/code%20style-black-000000.svg?style=flat
+  :target: https://github.com/psf/black
+  :alt: black
+
+
 Introduction
 ------------
 PyAEDT is part of the larger `PyAnsys <https://docs.pyansys.com>`_


### PR DESCRIPTION
Adds badges to our README.

![image](https://user-images.githubusercontent.com/11981631/154794024-d8cc5f07-efda-4441-88f6-df93499fbbc8.png)

Since it's in the README, this will also automatically be included within our online documentation at aedtdocs.pyansys.com on the next release.