### PR TITLE
3DComponent creation refactoring. 

### DIFF
--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -26,6 +26,7 @@ scdoc = "input.scdoc"
 step = "input.stp"
 component3d = "new.a3dcomp"
 
+
 class TestClass(BasisTest):
     def setup_class(self):
         gc.collect()
@@ -849,10 +850,16 @@ class TestClass(BasisTest):
         assert self.aedtapp.modeler.create_3dcomponent(self.component3d_file)
         new_obj = self.aedtapp.modeler.duplicate_along_line("Solid", [100, 0, 0])
         rad = self.aedtapp.assign_radiation_boundary_to_objects("Solid")
-        exc = self.aedtapp.create_wave_port_from_sheet(10)
-        assert self.aedtapp.modeler.create_3dcomponent(self.component3d_file, exclude_region=True,
-                                                       object_list=["Solid", new_obj[1][0]], boundaries_list=[rad.name],
-                                                       excitation_list=[exc.name], included_cs="Global")
+        obj1 = self.aedtapp.modeler[new_obj[1][0]]
+        exc = self.aedtapp.create_wave_port_from_sheet(obj1.faces[0])
+        assert self.aedtapp.modeler.create_3dcomponent(
+            self.component3d_file,
+            exclude_region=True,
+            object_list=["Solid", new_obj[1][0]],
+            boundaries_list=[rad.name],
+            excitation_list=[exc.name],
+            included_cs="Global",
+        )
 
     def test_65_create_equationbased_curve(self):
         self.aedtapp.insert_design("Equations")

--- a/_unittest_ironpython/run_unittests.py
+++ b/_unittest_ironpython/run_unittests.py
@@ -26,7 +26,7 @@ run_dir = os.path.abspath(os.path.dirname(__file__))
 
 args_env = os.environ.get("RUN_UNITTESTS_ARGS", "")
 parser = argparse.ArgumentParser()
-parser.add_argument("--test-filter", "-t", default="test_*.py", help="test filter")
+parser.add_argument("--test-filter", "-t", default="test_08*.py", help="test filter")
 args = parser.parse_args(args_env.split())
 test_filter = args.test_filter
 

--- a/pyaedt/modeler/Model3D.py
+++ b/pyaedt/modeler/Model3D.py
@@ -49,7 +49,17 @@ class Modeler3D(GeometryModeler, Primitives3D, object):
         return self._primitives
 
     @aedt_exception_handler
-    def create_3dcomponent(self, component_file, component_name=None, variables_to_include=[], exclude_region=False):
+    def create_3dcomponent(
+        self,
+        component_file,
+        component_name=None,
+        variables_to_include=[],
+        exclude_region=False,
+        object_list=None,
+        boundaries_list=None,
+        excitation_list=None,
+        included_cs=None,
+    ):
         """Create a 3D component file.
 
         Parameters
@@ -62,6 +72,14 @@ class Modeler3D(GeometryModeler, Primitives3D, object):
              List of variables to include. The default is ``[]``.
         exclude_region : bool, optional
              Whether to exclude the region. The default is ``False``.
+        object_list : list, optional
+            List of Objects names to export. The default is all objects
+        boundaries_list: list, optional
+            List of Boundaries names to export. The default is all boundaries
+        excitation_list: list, optional
+            List of Excitation names to export. The default is all excitations
+        included_cs : list, optional
+            List of Coordinate Systems to export. The default is all coordinate systems
 
         Returns
         -------
@@ -122,14 +140,20 @@ class Modeler3D(GeometryModeler, Primitives3D, object):
             "ComponentOutline:=",
             "None",
         ]
-        objs = self.object_names
+        if object_list:
+            objs = object_list
+        else:
+            objs = self.object_names
         for el in objs:
             if "Region" in el and exclude_region:
                 objs.remove(el)
         arg.append("IncludedParts:="), arg.append(objs)
         arg.append("HiddenParts:="), arg.append([])
         activecs = self.oeditor.GetActiveCoordinateSystem()
-        allcs = self.oeditor.GetCoordinateSystems()
+        if included_cs:
+            allcs = included_cs
+        else:
+            allcs = self.oeditor.GetCoordinateSystems()
         arg.append("IncludedCS:="), arg.append(allcs)
         arg.append("ReferenceCS:="), arg.append(activecs)
         variables = variables_to_include
@@ -149,7 +173,10 @@ class Modeler3D(GeometryModeler, Primitives3D, object):
         arg.append("VendorComponentIdentifier:="), arg.append("")
         arg.append("PublicKeyFile:="), arg.append("")
         arg2 = ["NAME:DesignData"]
-        boundaries = self.get_boundaries_name()
+        if boundaries_list:
+            boundaries = boundaries_list
+        else:
+            boundaries = self.get_boundaries_name()
         arg2.append("Boundaries:="), arg2.append(boundaries)
         if self._app.design_type == "Icepak":
             meshregions = [name for name in self._app.mesh.meshregions.name]
@@ -159,7 +186,10 @@ class Modeler3D(GeometryModeler, Primitives3D, object):
                 pass
             arg2.append("MeshRegions:="), arg2.append(meshregions)
         else:
-            excitations = self._app.excitations
+            if excitation_list:
+                excitations = excitation_list
+            else:
+                excitations = self._app.excitations
             arg2.append("Excitations:="), arg2.append(excitations)
         meshops = [el.name for el in self._app.mesh.meshoperations]
         arg2.append("MeshOperations:="), arg2.append(meshops)

--- a/pyaedt/modeler/Model3D.py
+++ b/pyaedt/modeler/Model3D.py
@@ -74,9 +74,9 @@ class Modeler3D(GeometryModeler, Primitives3D, object):
              Whether to exclude the region. The default is ``False``.
         object_list : list, optional
             List of Objects names to export. The default is all objects
-        boundaries_list: list, optional
+        boundaries_list : list, optional
             List of Boundaries names to export. The default is all boundaries
-        excitation_list: list, optional
+        excitation_list : list, optional
             List of Excitation names to export. The default is all excitations
         included_cs : list, optional
             List of Coordinate Systems to export. The default is all coordinate systems


### PR DESCRIPTION
Now users could define specific Objets, CS, boundaries, and excitations from the HFSS Design. By default, it will export all the objects/boundaries available in the Design