### PR TITLE
Clean up related to older class names for Twin Builder

### DIFF
--- a/doc/source/API/Primitives.rst
+++ b/doc/source/API/Primitives.rst
@@ -49,7 +49,7 @@ modeler, including all primitives methods and properties.
 * Modeler2D for ``Maxwell2D`` ``Q2d``
 * Modeler3DLayout for ``Hfss3dLayout``
 * ModelerNexxim for ``Circuit``
-* ModelerSimplorer for ``Simplorer``
+* ModelerTwinBuilder for ``TwinBuilder``
 * ModelerEmit for ``Emit``
 
 
@@ -63,7 +63,7 @@ modeler, including all primitives methods and properties.
    Model3D.Modeler3D
    Model3DLayout.Modeler3DLayout
    Circuit.ModelerNexxim
-   Circuit.ModelerSimplorer
+   Circuit.ModelerTwinBuilder
    Circuit.ModelerEmit
 
 
@@ -76,7 +76,7 @@ The ``Primitives`` module includes these classes:
 * Primitives2D for ``Maxwell2D`` ``Q2d``
 * Primitives3DLayout for ``Hfss3dLayout``
 * NexximComponents for ``Circuit``
-* SimplorerComponents for ``Simplorer``
+* TwinBuilderComponents for ``TwinBuilder``
 * CircuitComponents for ``Emit``
 Primives objects are accessible through ``modeler`` property for
 EM Solver and ``modeler.components`` for circuit solvers.
@@ -105,7 +105,7 @@ EM Solver and ``modeler.components`` for circuit solvers.
    Primitives3D.Primitives3D
    Primitives3DLayout.Primitives3DLayout
    PrimitivesNexxim.NexximComponents
-   PrimitivesSimplorer.SimplorerComponents
+   PrimitivesTwinBuilder.TwinBuilderComponents
    PrimitivesCircuit.CircuitComponents
 
 

--- a/doc/source/API/Setup.rst
+++ b/doc/source/API/Setup.rst
@@ -2,7 +2,7 @@ Setup
 =====
 This section lists setup modules:
 * Setup for ``Hfss``, ``Maxwell2D``, ``Maxwell3d``, ``Q2d`` and ``Q3d``
-* SetupCircuit for ``Circuit`` and ``Simplorer``
+* SetupCircuit for ``Circuit`` and ``Twin Builder``
 * Setup3DLayout for ``Hfss3dLayout``
 Setup object is accessible through the ``create_setup`` method and ``setups`` object list.
 

--- a/pyaedt/application/AnalysisTwinBuilder.py
+++ b/pyaedt/application/AnalysisTwinBuilder.py
@@ -1,5 +1,5 @@
 from pyaedt.generic.general_methods import aedt_exception_handler
-from pyaedt.modeler.Circuit import ModelerSimplorer
+from pyaedt.modeler.Circuit import ModelerTwinBuilder
 from pyaedt.modules.SolveSetup import SetupCircuit
 from pyaedt.application.Analysis import Analysis
 from pyaedt.modules.PostProcessor import CircuitPostProcessor
@@ -68,7 +68,7 @@ class AnalysisTwinBuilder(Analysis):
             student_version,
         )
         self.solution_type = solution_type
-        self._modeler = ModelerSimplorer(self)
+        self._modeler = ModelerTwinBuilder(self)
         self._post = CircuitPostProcessor(self)
 
     @property

--- a/pyaedt/modeler/Circuit.py
+++ b/pyaedt/modeler/Circuit.py
@@ -5,7 +5,7 @@ from pyaedt.modeler.Modeler import Modeler
 from pyaedt.modeler.Primitives3DLayout import Primitives3DLayout
 from pyaedt.modeler.PrimitivesEmit import EmitComponents
 from pyaedt.modeler.PrimitivesNexxim import NexximComponents
-from pyaedt.modeler.PrimitivesSimplorer import SimplorerComponents
+from pyaedt.modeler.PrimitivesTwinBuilder import TwinBuilderComponents
 from pyaedt.modeler.PrimitivesMaxwellCircuit import MaxwellCircuitComponents
 from pyaedt.modeler.Object3d import CircuitComponent
 from pyaedt.modeler.Object3d import _dim_arg
@@ -314,25 +314,25 @@ class ModelerNexxim(ModelerCircuit):
         return True
 
 
-class ModelerSimplorer(ModelerCircuit):
-    """ModelerSimplorer class.
+class ModelerTwinBuilder(ModelerCircuit):
+    """ModelerTwinBuilder class.
 
     Parameters
     ----------
-    app : :class:`pyaedt.application.AnalysisSimplorer.FieldAnalysisSimplorer`
+    app : :class:`pyaedt.application.AnalysisTwinBuilder.AnalysisTwinBuilder`
 
     """
 
     def __init__(self, app):
         self._app = app
         ModelerCircuit.__init__(self, app)
-        self._components = SimplorerComponents(self)
+        self._components = TwinBuilderComponents(self)
 
     @property
     def components(self):
         """
         .. deprecated:: 0.4.13
-           Use :func:`Simplorer.modeler.schematic` instead.
+           Use :func:`TwinBuilder.modeler.schematic` instead.
 
         """
         return self._components
@@ -343,7 +343,7 @@ class ModelerSimplorer(ModelerCircuit):
 
         Returns
         -------
-        :class:`pyaedt.modeler.PrimitivesSimplorer.SimplorerComponents`
+        :class:`pyaedt.modeler.PrimitivesTwinBuilder.TwinBuilderComponents`
 
         """
         return self._components
@@ -354,7 +354,7 @@ class ModelerEmit(ModelerCircuit):
 
     Parameters
     ----------
-    app : :class:`pyaedt.application.AnalysisSimplorer.FieldAnalysisSimplorer`
+    app : :class:`pyaedt.application.AnalysisEmit`
 
     """
 

--- a/pyaedt/modeler/PrimitivesCircuit.py
+++ b/pyaedt/modeler/PrimitivesCircuit.py
@@ -20,7 +20,7 @@ from pyaedt.generic.LoadAEDTFile import load_keyword_in_aedt_file
 class CircuitComponents(object):
     """CircutComponents class.
 
-    Manages all circuit components for Nexxim and Simplorer.
+    Manages all circuit components for Nexxim and Twin Builder.
 
     Examples
     --------

--- a/pyaedt/modeler/PrimitivesTwinBuilder.py
+++ b/pyaedt/modeler/PrimitivesTwinBuilder.py
@@ -2,10 +2,10 @@ from pyaedt.generic.general_methods import aedt_exception_handler
 from pyaedt.modeler.PrimitivesCircuit import CircuitComponents, ComponentCatalog
 
 
-class SimplorerComponents(CircuitComponents):
-    """SimplorerComponents class.
+class TwinBuilderComponents(CircuitComponents):
+    """TwinBuilderComponents class.
 
-    This class is for managing all circuit components for Simplorer.
+    This class is for managing all circuit components for Twin Builder.
 
     Parameters
     ----------
@@ -15,10 +15,10 @@ class SimplorerComponents(CircuitComponents):
 
     Examples
     --------
-    Basic usage demonstrated with a Simplorer design:
+    Basic usage demonstrated with a Twin Builder design:
 
-    >>> from pyaedt import Simplorer
-    >>> aedtapp = Simplorer()
+    >>> from pyaedt import Twin Builder
+    >>> aedtapp = TwinBuilder()
     >>> prim = aedtapp.modeler.schematic
     """
 
@@ -201,7 +201,7 @@ class SimplorerComponents(CircuitComponents):
     def create_voltage_source(
         self, compname=None, type="E", amplitude=326, freq=50, location=[], angle=0, use_instance_id_netlist=False
     ):
-        """Create a voltage source.
+        """Create a voltage source (conservative electrical output).
 
         Parameters
         ----------


### PR DESCRIPTION
Clean up related to older class names for Twin Builder
Renaming earlier classes referring to Simplorer