### PR TITLE
Do not enforce global threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
       default:
         # basic
         # target: 50%
-        threshold: 0%
+        # threshold: 0%
         # advanced
         if_not_found: success
         if_ci_failed: error


### PR DESCRIPTION
Recommend only enforcing patch coverage. There will be times when you remove source and come out with more efficient code by "lose" coverage. We should only worry about patch.

BTW, great job getting above 80%!