### PR TITLE
Renamed method create_reactangle_in_pad -> create_rectangle_in_pad

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -691,7 +691,7 @@ class TestClass(BasisTest, object):
         edbapp_without_path = None
         del edbapp_without_path
 
-    def test_80_create_reactangle_in_pad(self):
+    def test_80_create_rectangle_in_pad(self):
         example_model = os.path.join(local_path, "example_models", "padstacks.aedb")
         self.local_scratch.copyfolder(
             example_model,
@@ -704,7 +704,7 @@ class TestClass(BasisTest, object):
         )
         for i in range(7):
             padstack_instance = list(edb_padstacks.core_padstack.padstack_instances.values())[i]
-            result = padstack_instance.create_reactangle_in_pad("s")
+            result = padstack_instance.create_rectangle_in_pad("s")
             assert result
         edb_padstacks.close_edb()
 

--- a/pyaedt/edb_core/EDB_Data.py
+++ b/pyaedt/edb_core/EDB_Data.py
@@ -2118,7 +2118,7 @@ class EDBPadstackInstance(object):
         return int(self._edb_padstackinstance.GetGroup().GetPlacementLayer().GetTopBottomAssociation())
 
     @aedt_exception_handler
-    def create_reactangle_in_pad(self, layer_name):
+    def create_rectangle_in_pad(self, layer_name):
         """Create a rectangle inscribed inside a padstack instance pad. The rectangle is fully inscribed in the
         pad and has the maximum area. It is necessary to specify the layer on which the rectangle will be created.
 
@@ -2139,7 +2139,7 @@ class EDBPadstackInstance(object):
         >>> edb_layout = edbapp.core_primitives
         >>> list_of_padstack_instances = list(edbapp.core_padstack.padstack_instances.values())
         >>> padstack_inst = list_of_padstack_instances[0]
-        >>> padstack_inst.create_reactangle_in_pad("TOP")
+        >>> padstack_inst.create_rectangle_in_pad("TOP")
         """
 
         padstack_center = self.position


### PR DESCRIPTION
Fixed typo in the name of the newly created method create_reactangle_in_pad