### PR TITLE
Catch all exceptions raised when exporting ipc.

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -43,9 +43,9 @@ class TestClass(BasisTest, object):
         assert os.path.exists(ipc_path)
 
         with unittest.mock.patch('pyaedt.Edb.edblib', new_callable=unittest.mock.PropertyMock) as edblib_mock:
-            Edb.edblib.IPC8521 = unittest.mock.MagicMock()
-            Edb.edblib.IPC8521.IPCExporter = unittest.mock.MagicMock()
-            Edb.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout = unittest.mock.MagicMock(side_effect=Exception("Exception for testing raised in ExportIPC2581FromLayout."))
+            Edb.edblib.IPC8521 = unittest.mock.Mock()
+            Edb.edblib.IPC8521.IPCExporter = unittest.mock.Mock()
+            Edb.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout = unittest.mock.Mock(side_effect=Exception("Exception for testing raised in ExportIPC2581FromLayout."))
 
             assert not self.edbapp.export_to_ipc2581(os.path.exists(ipc_path))
 

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1,6 +1,7 @@
 import os
 import math
 import time
+import unittest.mock
 
 # Setup paths for module imports
 
@@ -40,6 +41,13 @@ class TestClass(BasisTest, object):
         # Export should be made with units set to default -millimeter-.
         self.edbapp.export_to_ipc2581(ipc_path, "mm")
         assert os.path.exists(ipc_path)
+
+        with unittest.mock.patch('pyaedt.Edb.edblib', new_callable=unittest.mock.PropertyMock) as edblib_mock:
+            Edb.edblib.IPC8521 = unittest.mock.MagicMock()
+            Edb.edblib.IPC8521.IPCExporter = unittest.mock.MagicMock()
+            Edb.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout = unittest.mock.MagicMock(side_effect=Exception("Exception for testing raised in ExportIPC2581FromLayout."))
+
+            assert not self.edbapp.export_to_ipc2581(os.path.exists(ipc_path))
 
     def test_01_find_by_name(self):
         comp = self.edbapp.core_components.get_component_by_name("J1")

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -42,7 +42,7 @@ class TestClass(BasisTest, object):
         self.edbapp.export_to_ipc2581(ipc_path, "mm")
         assert os.path.exists(ipc_path)
 
-        # Test the export method when IPC8521.ExportIPC2581FromLayout raises an exception internally.
+        # Test the export_to_ipc2581 method when IPC8521.ExportIPC2581FromLayout raises an exception internally.
         with unittest.mock.patch("pyaedt.Edb.edblib", new_callable=unittest.mock.PropertyMock) as edblib_mock:
             Edb.edblib.IPC8521 = unittest.mock.Mock()
             Edb.edblib.IPC8521.IPCExporter = unittest.mock.Mock()

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1,7 +1,6 @@
 import os
 import math
 import time
-import unittest.mock
 
 # Setup paths for module imports
 
@@ -16,6 +15,7 @@ from _unittest.conftest import config, desktop_version, local_path, scratch_path
 
 try:
     import pytest
+    import unittest.mock
 except ImportError:
     import _unittest_ironpython.conf_unittest as pytest
 
@@ -42,15 +42,16 @@ class TestClass(BasisTest, object):
         self.edbapp.export_to_ipc2581(ipc_path, "mm")
         assert os.path.exists(ipc_path)
 
-        # Test the export_to_ipc2581 method when IPC8521.ExportIPC2581FromLayout raises an exception internally.
-        with unittest.mock.patch("pyaedt.Edb.edblib", new_callable=unittest.mock.PropertyMock) as edblib_mock:
-            Edb.edblib.IPC8521 = unittest.mock.Mock()
-            Edb.edblib.IPC8521.IPCExporter = unittest.mock.Mock()
-            Edb.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout = unittest.mock.Mock(
-                side_effect=Exception("Exception for testing raised in ExportIPC2581FromLayout.")
-            )
+        if not is_ironpython:
+            # Test the export_to_ipc2581 method when IPC8521.ExportIPC2581FromLayout raises an exception internally.
+            with unittest.mock.patch("pyaedt.Edb.edblib", new_callable=unittest.mock.PropertyMock) as edblib_mock:
+                Edb.edblib.IPC8521 = unittest.mock.Mock()
+                Edb.edblib.IPC8521.IPCExporter = unittest.mock.Mock()
+                Edb.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout = unittest.mock.Mock(
+                    side_effect=Exception("Exception for testing raised in ExportIPC2581FromLayout.")
+                )
 
-            assert not self.edbapp.export_to_ipc2581(os.path.exists(ipc_path))
+                assert not self.edbapp.export_to_ipc2581(os.path.exists(ipc_path))
 
     def test_01_find_by_name(self):
         comp = self.edbapp.core_components.get_component_by_name("J1")

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -42,10 +42,12 @@ class TestClass(BasisTest, object):
         self.edbapp.export_to_ipc2581(ipc_path, "mm")
         assert os.path.exists(ipc_path)
 
-        with unittest.mock.patch('pyaedt.Edb.edblib', new_callable=unittest.mock.PropertyMock) as edblib_mock:
+        with unittest.mock.patch("pyaedt.Edb.edblib", new_callable=unittest.mock.PropertyMock) as edblib_mock:
             Edb.edblib.IPC8521 = unittest.mock.Mock()
             Edb.edblib.IPC8521.IPCExporter = unittest.mock.Mock()
-            Edb.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout = unittest.mock.Mock(side_effect=Exception("Exception for testing raised in ExportIPC2581FromLayout."))
+            Edb.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout = unittest.mock.Mock(
+                side_effect=Exception("Exception for testing raised in ExportIPC2581FromLayout.")
+            )
 
             assert not self.edbapp.export_to_ipc2581(os.path.exists(ipc_path))
 

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -42,6 +42,7 @@ class TestClass(BasisTest, object):
         self.edbapp.export_to_ipc2581(ipc_path, "mm")
         assert os.path.exists(ipc_path)
 
+        # Test the export method when IPC8521.ExportIPC2581FromLayout raises an exception internally.
         with unittest.mock.patch("pyaedt.Edb.edblib", new_callable=unittest.mock.PropertyMock) as edblib_mock:
             Edb.edblib.IPC8521 = unittest.mock.Mock()
             Edb.edblib.IPC8521.IPCExporter = unittest.mock.Mock()

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -16,7 +16,7 @@ from _unittest.conftest import config, desktop_version, local_path, scratch_path
 try:
     import pytest
     import unittest.mock
-except ImportError:
+except ImportError:  # pragma: no cover
     import _unittest_ironpython.conf_unittest as pytest
 
 

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -517,16 +517,19 @@ class Edb(object):
             ipc_path = self.edbpath[:-4] + "xml"
         self.logger.info("Export IPC 2581 is starting. This operation can take a while...")
         start = time.time()
-        result = self.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout(
-            self.active_layout, self.edbversion, ipc_path, units.lower()
-        )
-        end = time.time() - start
-        if result:
-            self.logger.info("Export IPC 2581 completed in %s sec.", end)
-            self.logger.info("File saved as %s", ipc_path)
-            return ipc_path
-        self.logger.info("Error Exporting IPC 2581.")
-        return False
+        try:
+            result = self.edblib.IPC8521.IPCExporter.ExportIPC2581FromLayout(
+                self.active_layout, self.edbversion, ipc_path, units.lower()
+            )
+            end = time.time() - start
+            if result:
+                self.logger.info("Export IPC 2581 completed in %s sec.", end)
+                self.logger.info("File saved as %s", ipc_path)
+                return ipc_path
+        except Exception as e:
+            self.logger.info("Error Exporting IPC 2581.")
+            self.logger.info(str(e))
+            return False
 
     def edb_exception(self, ex_value, tb_data):
         """Write the trace stack to AEDT when a Python error occurs.


### PR DESCRIPTION
Catch all exceptions raised when exporting ipc.
Previously we were not catching raised exception in the edlib assembly.

Fix #871.