### PR TITLE
Fixed bounding_box for 2022R2

### DIFF
--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -90,7 +90,7 @@ class BasisTest(object):
             oDesktop = sys.modules["__main__"].oDesktop
         except Exception as e:
             oDesktop = None
-        if oDesktop:
+        if oDesktop and not settings.non_graphical:
             oDesktop.ClearMessages("", "", 3)
         for edbapp in self.edbapps[::-1]:
             try:

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -610,7 +610,8 @@ class Desktop:
         bool
             ``True`` when successful, ``False`` when failed.
         """
-        self._desktop.ClearMessages("", "", 3)
+        if not settings.non_graphical:
+            self._desktop.ClearMessages("", "", 3)
         return True
 
     @pyaedt_function_handler()

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -291,11 +291,11 @@ class Desktop:
             self._main.isoutsideDesktop = True
         self.release_on_exit = True
         self.logfile = None
-        if "oDesktop" in dir():
+        if "oDesktop" in dir():  # pragma: no cover
             self.release_on_exit = False
             self._main.oDesktop = oDesktop
             settings.aedt_version = oDesktop.GetVersion()[0:6]
-        elif "oDesktop" in dir(self._main) and self._main.oDesktop is not None:
+        elif "oDesktop" in dir(self._main) and self._main.oDesktop is not None:  # pragma: no cover
             self.release_on_exit = False
         else:
             if "oDesktop" in dir(self._main):
@@ -610,8 +610,7 @@ class Desktop:
         bool
             ``True`` when successful, ``False`` when failed.
         """
-        if not settings.non_graphical:
-            self._desktop.ClearMessages("", "", 3)
+        self._desktop.ClearMessages("", "", 3)
         return True
 
     @pyaedt_function_handler()

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -284,6 +284,7 @@ class Desktop:
         self._main.pyaedt_version = pyaedtversion
         self._main.interpreter_ver = _pythonver
         self._main.student_version = student_version
+        settings.non_graphical = non_graphical
         if is_ironpython:
             self._main.isoutsideDesktop = False
         else:
@@ -293,12 +294,14 @@ class Desktop:
         if "oDesktop" in dir():
             self.release_on_exit = False
             self._main.oDesktop = oDesktop
+            settings.aedt_version = oDesktop.GetVersion()[0:6]
         elif "oDesktop" in dir(self._main) and self._main.oDesktop is not None:
             self.release_on_exit = False
         else:
             if "oDesktop" in dir(self._main):
                 del self._main.oDesktop
             self._main.student_version, version_key, version = self._set_version(specified_version, student_version)
+            settings.aedt_version = version
             if _com == "ironpython":  # pragma: no cover
                 print("Launching PyAEDT outside AEDT with IronPython.")
                 self._init_ironpython(non_graphical, new_desktop_session, version)

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -641,6 +641,8 @@ class Settings(object):
         self._enable_debug_internal_methods_logger = False
         self._enable_debug_logger = False
         self._enable_error_handler = True
+        self.non_graphical = False
+        self.aedt_version = None
 
     @property
     def enable_error_handler(self):

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -24,6 +24,7 @@ from pyaedt.application.Variables import decompose_variable_value
 from pyaedt.generic.constants import AEDT_UNITS
 from pyaedt.generic.constants import MILS2METER
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt import settings
 from pyaedt.modeler.GeometryOperators import GeometryOperators
 
 clamp = lambda n, minn, maxn: max(min(maxn, n), minn)
@@ -803,9 +804,10 @@ class Object3d(object):
             self._odesign.Undo()
         if not modeled:
             self._odesign.Undo()
-        self._primitives._app.odesktop.ClearMessages(
-            self._primitives._app.project_name, self._primitives._app.design_name, 1
-        )
+        if not settings.non_graphical:
+            self._primitives._app.odesktop.ClearMessages(
+                self._primitives._app.project_name, self._primitives._app.design_name, 1
+            )
         return bounding
 
     @pyaedt_function_handler()


### PR DESCRIPTION
- Fixed _bounding_box_unmodel for 2022R2
- Added non_graphical and aedt_version in settings
- oDesktop.ClearMessages has no effect in non graphical mode