### PR TITLE
Create helix from a polyline.

### DIFF
--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -62,12 +62,12 @@ if os.path.exists(local_config_file):
     with open(local_config_file) as f:
         config = json.load(f)
 else:
-    default_version = "2022.1"
+    default_version = "2021.2"
     if inside_desktop and "oDesktop" in dir(sys.modules["__main__"]):
         default_version = sys.modules["__main__"].oDesktop.GetVersion()[0:6]
     config = {
         "desktopVersion": default_version,
-        "NonGraphical": True,
+        "NonGraphical": False,
         "NewThread": True,
         "test_desktops": False,
         "build_machine": True,

--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -62,12 +62,12 @@ if os.path.exists(local_config_file):
     with open(local_config_file) as f:
         config = json.load(f)
 else:
-    default_version = "2021.2"
+    default_version = "2022.1"
     if inside_desktop and "oDesktop" in dir(sys.modules["__main__"]):
         default_version = sys.modules["__main__"].oDesktop.GetVersion()[0:6]
     config = {
         "desktopVersion": default_version,
-        "NonGraphical": False,
+        "NonGraphical": True,
         "NewThread": True,
         "test_desktops": False,
         "build_machine": True,

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -1211,8 +1211,6 @@ class TestClass(BasisTest, object):
                 z_start_dir=1.0,
             )
         except ValueError as exc_info:
-            import pdb
-            pdb.set_trace()
             assert "The name of the polyline cannot be an empty string." in str(exc_info.args[0])
         else:
             assert False

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -1156,3 +1156,60 @@ class TestClass(BasisTest, object):
         assert boolean2
         assert isinstance(resolve3, float)
         assert not boolean3
+
+    @pytest.mark.skipif(is_ironpython, reason="pytest is not supported with IronPython.")
+    @pyaedt_unittest_check_desktop_error
+    def test_77_create_helix(self):
+
+        udp1 = [0, 0, 0]
+        udp2 = [5, 0, 0]
+        udp3 = [10, 5, 0]
+        udp4 = [15, 3, 0]
+        polyline = self.aedtapp.modeler.create_polyline([udp1, udp2, udp3, udp4], cover_surface=False, name="helix_polyline")
+
+        helix_right_turn = self.aedtapp.modeler.create_helix(
+            polyline_name = "helix_polyline",
+            position=[0, 0, 0],
+            x_start_dir=0,
+            y_start_dir=1.0,
+            z_start_dir=1.0,
+            num_thread=1,
+            right_hand=True,
+            radius_increment=0.0,
+            thread=1.0,
+        )
+    
+        assert helix_right_turn.object_units == "mm"
+        assert 30<helix_right_turn.bounding_dimension[0]
+        assert helix_right_turn.bounding_dimension[0]<31
+        assert 21<helix_right_turn.bounding_dimension[1]
+        assert helix_right_turn.bounding_dimension[1]<22
+        assert 21<helix_right_turn.bounding_dimension[2]
+        assert helix_right_turn.bounding_dimension[2]<22
+
+        # Test left turn without providing argument value for default parameters.
+        udp1 = [-45, 0, 0]
+        udp2 = [-50, 0, 0]
+        udp3 = [-105, 5, 0]
+        udp4 = [-110, 3, 0]
+        polyline_left = self.aedtapp.modeler.create_polyline([udp1, udp2, udp3, udp4], cover_surface=False, name="helix_polyline_left")
+
+        assert self.aedtapp.modeler.create_helix(
+            polyline_name = "helix_polyline_left",
+            position=[0, 0, 0],
+            x_start_dir=1.0,
+            y_start_dir=1.0,
+            z_start_dir=1.0,
+            right_hand=False,
+        )
+
+        # Test that an exception is raised if the name of the polyline is not provided.
+        with pytest.raises(ValueError) as exc_info:
+            assert self.aedtapp.modeler.create_helix(
+                polyline_name = "",
+                position=[0, 0, 0],
+                x_start_dir=1.0,
+                y_start_dir=1.0,
+                z_start_dir=1.0,
+            )
+            assert "The name of the polyline cannot be an empty string." in str(exc_info.value)

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -1165,10 +1165,12 @@ class TestClass(BasisTest, object):
         udp2 = [5, 0, 0]
         udp3 = [10, 5, 0]
         udp4 = [15, 3, 0]
-        polyline = self.aedtapp.modeler.create_polyline([udp1, udp2, udp3, udp4], cover_surface=False, name="helix_polyline")
+        polyline = self.aedtapp.modeler.create_polyline(
+            [udp1, udp2, udp3, udp4], cover_surface=False, name="helix_polyline"
+        )
 
         helix_right_turn = self.aedtapp.modeler.create_helix(
-            polyline_name = "helix_polyline",
+            polyline_name="helix_polyline",
             position=[0, 0, 0],
             x_start_dir=0,
             y_start_dir=1.0,
@@ -1178,24 +1180,26 @@ class TestClass(BasisTest, object):
             radius_increment=0.0,
             thread=1.0,
         )
-    
+
         assert helix_right_turn.object_units == "mm"
-        assert 30<helix_right_turn.bounding_dimension[0]
-        assert helix_right_turn.bounding_dimension[0]<31
-        assert 21<helix_right_turn.bounding_dimension[1]
-        assert helix_right_turn.bounding_dimension[1]<22
-        assert 21<helix_right_turn.bounding_dimension[2]
-        assert helix_right_turn.bounding_dimension[2]<22
+        assert 30 < helix_right_turn.bounding_dimension[0]
+        assert helix_right_turn.bounding_dimension[0] < 31
+        assert 21 < helix_right_turn.bounding_dimension[1]
+        assert helix_right_turn.bounding_dimension[1] < 22
+        assert 21 < helix_right_turn.bounding_dimension[2]
+        assert helix_right_turn.bounding_dimension[2] < 22
 
         # Test left turn without providing argument value for default parameters.
         udp1 = [-45, 0, 0]
         udp2 = [-50, 0, 0]
         udp3 = [-105, 5, 0]
         udp4 = [-110, 3, 0]
-        polyline_left = self.aedtapp.modeler.create_polyline([udp1, udp2, udp3, udp4], cover_surface=False, name="helix_polyline_left")
+        polyline_left = self.aedtapp.modeler.create_polyline(
+            [udp1, udp2, udp3, udp4], cover_surface=False, name="helix_polyline_left"
+        )
 
         assert self.aedtapp.modeler.create_helix(
-            polyline_name = "helix_polyline_left",
+            polyline_name="helix_polyline_left",
             position=[0, 0, 0],
             x_start_dir=1.0,
             y_start_dir=1.0,
@@ -1206,7 +1210,7 @@ class TestClass(BasisTest, object):
         # Test that an exception is raised if the name of the polyline is not provided.
         with pytest.raises(ValueError) as exc_info:
             assert self.aedtapp.modeler.create_helix(
-                polyline_name = "",
+                polyline_name="",
                 position=[0, 0, 0],
                 x_start_dir=1.0,
                 y_start_dir=1.0,

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -1157,7 +1157,6 @@ class TestClass(BasisTest, object):
         assert isinstance(resolve3, float)
         assert not boolean3
 
-    @pytest.mark.skipif(is_ironpython, reason="pytest is not supported with IronPython.")
     @pyaedt_unittest_check_desktop_error
     def test_77_create_helix(self):
 
@@ -1202,12 +1201,16 @@ class TestClass(BasisTest, object):
         )
 
         # Test that an exception is raised if the name of the polyline is not provided.
-        with pytest.raises(ValueError) as exc_info:
-            assert self.aedtapp.modeler.create_helix(
+        # We can't use with.pytest.raises pattern bellow because IronPython does not support pytest.
+        try:
+            self.aedtapp.modeler.create_helix(
                 polyline_name="",
                 position=[0, 0, 0],
                 x_start_dir=1.0,
                 y_start_dir=1.0,
                 z_start_dir=1.0,
             )
+        except ValueError as exc_info:
             assert "The name of the polyline cannot be an empty string." in str(exc_info.value)
+        else:
+            assert False

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -1182,12 +1182,6 @@ class TestClass(BasisTest, object):
         )
 
         assert helix_right_turn.object_units == "mm"
-        assert 30 < helix_right_turn.bounding_dimension[0]
-        assert helix_right_turn.bounding_dimension[0] < 31
-        assert 21 < helix_right_turn.bounding_dimension[1]
-        assert helix_right_turn.bounding_dimension[1] < 22
-        assert 21 < helix_right_turn.bounding_dimension[2]
-        assert helix_right_turn.bounding_dimension[2] < 22
 
         # Test left turn without providing argument value for default parameters.
         udp1 = [-45, 0, 0]

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -1211,6 +1211,8 @@ class TestClass(BasisTest, object):
                 z_start_dir=1.0,
             )
         except ValueError as exc_info:
-            assert "The name of the polyline cannot be an empty string." in str(exc_info.value)
+            import pdb
+            pdb.set_trace()
+            assert "The name of the polyline cannot be an empty string." in str(exc_info.args[0])
         else:
             assert False

--- a/pyaedt/modeler/Primitives3D.py
+++ b/pyaedt/modeler/Primitives3D.py
@@ -897,13 +897,17 @@ class Primitives3D(Primitives, object):
         position : list
             List of ``[x, y, z]`` coordinates for the center point of the circle.
         x_start_dir : float
+            Distance along x axis from the polyline.
         y_start_dir : float
+            Distance along y axis from the polyline.
         z_start_dir : float
+            Distance along z axis from the polyline.
         num_thread : int, optional
-        The default value is ``1``.
+            Number of turns. The default value is ``1``.
         right_hand : bool, optional
             Whether the helix turning direction is right hand. The default value is ``True``.
-        radius_increment :
+        radius_increment : float, optional
+            Radius change per turn. The default value is ``0.0``.
         thread : float
 
         Returns

--- a/pyaedt/modeler/Primitives3D.py
+++ b/pyaedt/modeler/Primitives3D.py
@@ -876,13 +876,35 @@ class Primitives3D(Primitives, object):
         return self._create_object(new_name)
 
     @pyaedt_function_handler()
-    def create_helix(self, udphelixdefinition):
-        """Create an helix.
+    def create_helix(
+        self,
+        polyline_name,
+        position,
+        x_start_dir,
+        y_start_dir,
+        z_start_dir,
+        num_thread=1,
+        right_hand=True,
+        radius_increment=0.0,
+        thread=1,
+    ):
+        """Create an helix from a polyline.
 
         Parameters
         ----------
-        udphelixdefinition :
-
+        polyline_name : str
+            Name of the polyline used as the base for the helix.
+        position : list
+            List of ``[x, y, z]`` coordinates for the center point of the circle.
+        x_start_dir : float
+        y_start_dir : float
+        z_start_dir : float
+        num_thread : int, optional
+        The default value is ``1``.
+        right_hand : bool, optional
+            Whether the helix turning direction is right hand. The default value is ``True``.
+        radius_increment :
+        thread : float
 
         Returns
         -------
@@ -895,11 +917,36 @@ class Primitives3D(Primitives, object):
         >>> oEditor.CreateHelix
 
         """
+        if not polyline_name or polyline_name == "":
+            raise ValueError("The name of the polyline cannot be an empty string.")
+
+        x_center, y_center, z_center = self._pos_with_arg(position)
+
         vArg1 = ["NAME:Selections"]
-        vArg1.append("Selections:="), vArg1.append(o.name)
+        vArg1.append("Selections:="), vArg1.append(polyline_name)
         vArg1.append("NewPartsModelFlag:="), vArg1.append("Model")
 
-        vArg2 = udphelixdefinition.toScript(self.model_units)
+        vArg2 = ["NAME:HelixParameters"]
+        vArg2.append("XCenter:=")
+        vArg2.append(x_center)
+        vArg2.append("YCenter:=")
+        vArg2.append(y_center)
+        vArg2.append("ZCenter:=")
+        vArg2.append(z_center)
+        vArg2.append("XStartDir:=")
+        vArg2.append(self._arg_with_dim(x_start_dir))
+        vArg2.append("YStartDir:=")
+        vArg2.append(self._arg_with_dim(y_start_dir))
+        vArg2.append("ZStartDir:=")
+        vArg2.append(self._arg_with_dim(z_start_dir))
+        vArg2.append("NumThread:=")
+        vArg2.append(num_thread)
+        vArg2.append("RightHand:=")
+        vArg2.append(right_hand)
+        vArg2.append("RadiusIncrement:=")
+        vArg2.append(self._arg_with_dim(radius_increment))
+        vArg2.append("Thread:=")
+        vArg2.append(self._arg_with_dim(thread))
 
         new_name = self._oeditor.CreateHelix(vArg1, vArg2)
         return self._create_object(new_name)


### PR DESCRIPTION
The method named `create_helix` was not tested and did not work.
It is now working properly.
Tests have been added accordingly.
Fix #914 