### PR TITLE
Updated the download method and the WPF example 

### DIFF
--- a/_unittest/test_00_downloads.py
+++ b/_unittest/test_00_downloads.py
@@ -32,3 +32,4 @@ class TestClass(BasisTest, object):
 
     def test_download_wfp(self):
         assert self.examples.download_edb_merge_utility()
+        assert self.examples.download_edb_merge_utility(True)

--- a/examples/00-EDB/07_WPF_Merge_Utility.py
+++ b/examples/00-EDB/07_WPF_Merge_Utility.py
@@ -14,9 +14,10 @@ This demo will show how to run a merge between two EDBs (eg. package on board).
 # json fil can be customized to change settings.
 
 from pyaedt.examples.downloads import download_edb_merge_utility
+from pyaedt.generic.toolkit import launch
 
-python_file = download_edb_merge_utility()
-
+python_file = download_edb_merge_utility(force_download=True)
+desktop_version = "2022.1"
 
 ######################################################################
 # Python Script execution
@@ -35,3 +36,6 @@ python_file = download_edb_merge_utility()
 #
 # The json file contains default settings that can be used in any other project to automatically
 # load all settings.
+# The following command line can be unchecked and launched from python interpreter.
+
+# launch(python_file, specified_version=desktop_version, new_desktop_session=False, autosave=False)

--- a/examples/00-EDB/07_WPF_Merge_Utility.py
+++ b/examples/00-EDB/07_WPF_Merge_Utility.py
@@ -14,7 +14,6 @@ This demo will show how to run a merge between two EDBs (eg. package on board).
 # json fil can be customized to change settings.
 
 from pyaedt.examples.downloads import download_edb_merge_utility
-from pyaedt.generic.toolkit import launch
 
 python_file = download_edb_merge_utility(force_download=True)
 desktop_version = "2022.1"
@@ -38,4 +37,5 @@ desktop_version = "2022.1"
 # load all settings.
 # The following command line can be unchecked and launched from python interpreter.
 
+# from pyaedt.generic.toolkit import launch
 # launch(python_file, specified_version=desktop_version, new_desktop_session=False, autosave=False)

--- a/pyaedt/examples/downloads.py
+++ b/pyaedt/examples/downloads.py
@@ -122,11 +122,16 @@ def download_aedb():
     return _download_file("edb/Galileo.aedb", "edb.def")
 
 
-def download_edb_merge_utility():
+def download_edb_merge_utility(force_download=False):
     """Download an example of WPF Project which allows to merge 2aedb files.
 
     Examples files are downloaded to a persistent cache to avoid
     re-downloading the same file twice.
+
+    Parameters
+    ----------
+    force_download : bool
+        Force to delete cache and download files again.
 
     Returns
     -------
@@ -137,10 +142,14 @@ def download_edb_merge_utility():
     --------
     Download an example result file and return the path of the file
     >>> from pyaedt import examples
-    >>> path = examples.download_edb_mergge_utility()
+    >>> path = examples.download_edb_merge_utility(force_download=True)
     >>> path
-    'C:/Users/user/AppData/local/temp/Galileo.aedb'
+    'C:/Users/user/AppData/local/temp/wpf_edb_merge/merge_wizard.py'
     """
+    if force_download:
+        local_path = os.path.join(EXAMPLES_PATH, "wpf_edb_merge")
+        if os.path.exists(local_path):
+            shutil.rmtree(local_path, ignore_errors=True)
     _download_file("wpf_edb_merge/board.aedb", "edb.def")
     _download_file("wpf_edb_merge/package.aedb", "edb.def")
     _download_file("wpf_edb_merge", "merge_wizard_settings.json")


### PR DESCRIPTION
It will now force download of wpf file to temp folder. It will also give guidance on how to run example