### PR TITLE
Support touchstone file with more than 9 ports.

### DIFF
--- a/pyaedt/modeler/PrimitivesCircuit.py
+++ b/pyaedt/modeler/PrimitivesCircuit.py
@@ -335,7 +335,7 @@ class CircuitComponents(object):
             model_name = os.path.splitext(os.path.basename(touchstone_full_path))[0]
         if model_name in list(self.o_model_manager.GetNames()):
             model_name = generate_unique_name(model_name, n=2)
-        num_terminal = int(touchstone_full_path[-2:-1])
+        num_terminal = int(os.path.splitext(touchstone_full_path)[1].strip(".sp"))
         with open(touchstone_full_path, "r") as f:
             port_names = _parse_ports_name(f)
         image_subcircuit_path = os.path.normpath(

--- a/pyaedt/modeler/PrimitivesCircuit.py
+++ b/pyaedt/modeler/PrimitivesCircuit.py
@@ -335,7 +335,7 @@ class CircuitComponents(object):
             model_name = os.path.splitext(os.path.basename(touchstone_full_path))[0]
         if model_name in list(self.o_model_manager.GetNames()):
             model_name = generate_unique_name(model_name, n=2)
-        num_terminal = int(os.path.splitext(touchstone_full_path)[1].strip(".sp"))
+        num_terminal = int(os.path.splitext(touchstone_full_path)[1].lower().strip(".sp"))
         with open(touchstone_full_path, "r") as f:
             port_names = _parse_ports_name(f)
         image_subcircuit_path = os.path.normpath(


### PR DESCRIPTION
Support touchstone file with more than 9 ports.
Previously we were only selecting the last digit to get the number of ports contained in the touchstone file.

Fix #928 