### PR TITLE
Add breadcrumbs to documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -207,6 +207,7 @@ if os.name != "posix" and "PYAEDT_CI_NO_EXAMPLES" not in os.environ:
         }
 
 # -- Options for HTML output -------------------------------------------------
+html_short_title = html_title = "PyAEDT"
 html_show_sourcelink = True
 html_theme = "pyansys_sphinx_theme"
 html_logo = pyansys_logo_black

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -212,9 +212,12 @@ html_theme = "pyansys_sphinx_theme"
 html_logo = pyansys_logo_black
 
 html_theme_options = {
-    "github_url": "https://github.com/pyansys/PyAEDT",
+    "github_url": "https://github.com/pyansys/pyaedt",
     "show_prev_next": False,
-    "logo_link": "https://aedtdocs.pyansys.com/",  # navigate to the main page
+    "show_breadcrumbs": True,
+    "additional_breadcrumbs": [
+        ("PyAnsys", "https://docs.pyansys.com/"),
+    ],
 }
 
 html_static_path = ["_static"]


### PR DESCRIPTION
This PR adds breadcrumbs to the documentation and changes the link of the PyAnsys logo to return to docs.pyansys.com. This is to remain consistent with the rest of the pyansys documentation (and industry in general) and provide a better experience when navigating through our documentation.

For an example of the rendered breadcrumb trail, see https://mapdldocs.pyansys.com/api/index.html

Note that the top level is always "PyAnsys" and the next level is the current project ("PyAEDT") followed by the sub-pages.
