### PR TITLE
Expose the 'Parameter' option when reading the Touchstone file.

### DIFF
--- a/_unittest/test_21_Circuit.py
+++ b/_unittest/test_21_Circuit.py
@@ -177,6 +177,10 @@ class TestClass(BasisTest, object):
         assert data.data_imag()
         assert data.data_db()
 
+        data_with_verbose = read_touchstone(os.path.join(self.local_scratch.path, touchstone), verbose=True)
+        assert max(data_with_verbose.data_magnitude()) > 0.37
+        assert max(data_with_verbose.data_magnitude()) < 0.38
+
     def test_17_create_setup(self):
         setup_name = "Dom_LNA"
         LNA_setup = self.aedtapp.create_setup(setup_name)

--- a/_unittest/test_21_Circuit.py
+++ b/_unittest/test_21_Circuit.py
@@ -83,7 +83,7 @@ class TestClass(BasisTest, object):
     def test_06a_create_setup(self):
         setup_name = "LNA"
         LNA_setup = self.aedtapp.create_setup(setup_name)
-        assert LNA_setup
+        assert LNA_setup.name == "LNA"
 
     def test_06b_add_3dlayout_component(self):
         myedb = self.aedtapp.modeler.schematic.add_subcircuit_3dlayout("Galileo_G87173_204")

--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -1367,7 +1367,6 @@ class Analysis(Design, object):
         """
         assert variable in self.output_variables, "Output variable {} does not exist.".format(variable)
         nominal_variation = self.odesign.GetNominalVariation()
-        sol_type = self.solution_type
         value = self.ooutput_variable.GetOutputVariableValue(
             variable, nominal_variation, self.existing_analysis_sweeps[0], self.solution_type, []
         )

--- a/pyaedt/application/AnalysisTwinBuilder.py
+++ b/pyaedt/application/AnalysisTwinBuilder.py
@@ -21,7 +21,7 @@ class AnalysisTwinBuilder(Analysis):
 
     @property
     def existing_analysis_setups(self):
-        """Existing analysis setups.
+        """Get all analysis solution setups.
 
         References
         ----------

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -385,7 +385,6 @@ class Edb(object):
             )
             if self._active_cell is None:
                 self._active_cell = list(self._db.TopCircuitCells)[0]
-            dllpath = os.path.join(os.path.abspath(os.path.dirname(__file__)), "dlls", "EDBLib")
             if self._db and self._active_cell:
                 if not os.path.exists(self.edbpath):
                     os.makedirs(self.edbpath)

--- a/pyaedt/generic/TouchstoneParser.py
+++ b/pyaedt/generic/TouchstoneParser.py
@@ -687,11 +687,11 @@ def _parse_option_line(file, verbose=False):
 
     if verbose:
         print("  Frequency unit: %g Hz" % frequnit)
-        print("  Parameter:      %s" % type)
+        print("  Parameter:      %s" % parameter)
         print("  Format:         %s" % format)
         print("  Reference R:    %g" % z0)
 
-    return (frequnit, type, format, z0)
+    return (frequnit, parameter, format, z0)
 
 
 def _get_next_line_data(file):

--- a/pyaedt/generic/plot.py
+++ b/pyaedt/generic/plot.py
@@ -393,8 +393,8 @@ class ModelPlotter(object):
     >>> model.add_object(r'D:\Simulation\antenna.obj', (200,20,255), 0.6, "in")
     >>> model.add_object(r'D:\Simulation\helix.obj', (0,255,0), 0.5, "in")
     >>> frames = [r'D:\Simulation\helic_antenna.csv', r'D:\Simulation\helic_antenna_10.fld',
-    >>>           r'D:\Simulation\helic_antenna_20.fld', r'D:\Simulation\helic_antenna_30.fld',
-    >>>           r'D:\Simulation\helic_antenna_40.fld']
+    ...           r'D:\Simulation\helic_antenna_20.fld', r'D:\Simulation\helic_antenna_30.fld',
+    ...           r'D:\Simulation\helic_antenna_40.fld']
     >>> model.gif_file = r"D:\Simulation\animation.gif"
     >>> model.animate()
     """

--- a/pyaedt/generic/process.py
+++ b/pyaedt/generic/process.py
@@ -194,7 +194,7 @@ class SiwaveSolve(object):
             if os.path.exists(exec_file):
                 with open(exec_file, "r+") as f:
                     content = f.readlines()
-                    if not "SetNumCpus" in content:
+                    if "SetNumCpus" not in content:
                         f.writelines(str.format("SetNumCpus {}", str(self.nbcores)) + "\n")
                         f.writelines("SaveSiw")
                     else:

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -2201,11 +2201,6 @@ class Padstack(object):
             else:
                 self._pad = Padstack.PDSHole(holetype="None", sizes=[])
 
-        @property
-        def antipad(self):
-            """Antipad."""
-            return self._antipad
-
         @antipad.setter
         def antipad(self, value=None):
             if value:

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -1733,7 +1733,7 @@ class Primitives(object):
             try:
                 self._oeditor.Delete(arg)
             except:
-                self.logger.warning("Failed to delete {}".format(objects_str))
+                self.logger.warning("Failed to delete {}.".format(objects_str))
             remaining -= slice
             if remaining > 0:
                 objects = objects[slice:]
@@ -1742,7 +1742,7 @@ class Primitives(object):
 
         if len(objects) > 0:
             self.cleanup_objects()
-            self.logger.info("Deleted {} Objects".format(num_objects, objects_str))
+            self.logger.info("Deleted {} Objects: {}.".format(num_objects, objects_str))
         return True
 
     @pyaedt_function_handler()


### PR DESCRIPTION
- Fix several issues. The most important being the 'Parameter' option that was not exposed properly.
- Improve docstring for method `existing_analysis_setups`.
- Remove the `antipad` property that was duplicated in the class `PDSLayer`.
- Docstring example was incorrect in `ModelPlotter()` class in the `plot` module.