### PR TITLE
Remove the mutable from the defaults argument.

### DIFF
--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -1160,7 +1160,7 @@ class Analysis(Design, object):
         return setup_name
 
     @pyaedt_function_handler()
-    def create_setup(self, setupname="MySetupAuto", setuptype=None, props={}):
+    def create_setup(self, setupname="MySetupAuto", setuptype=None, props=None):
         """Create a setup.
 
         Parameters
@@ -1205,6 +1205,9 @@ class Analysis(Design, object):
         ...
         pyaedt info: Sweep was created correctly.
         """
+        if props == None:
+            props = {}
+
         if setuptype is None:
             setuptype = self.design_solutions.default_setup
         name = self.generate_unique_setup_name(setupname)

--- a/pyaedt/application/Analysis3D.py
+++ b/pyaedt/application/Analysis3D.py
@@ -426,7 +426,7 @@ class FieldAnalysis3D(Analysis, object):
         return self.export_3d_model(fileName, filePath, fileFormat, object_list, removed_objects)
 
     @pyaedt_function_handler()
-    def export_3d_model(self, fileName, filePath, fileFormat=".step", object_list=[], removed_objects=[]):
+    def export_3d_model(self, fileName, filePath, fileFormat=".step", object_list=None, removed_objects=None):
         """Export the 3D model.
 
         Parameters
@@ -452,6 +452,12 @@ class FieldAnalysis3D(Analysis, object):
 
         >>> oEditor.Export
         """
+
+        if object_list == None:
+            object_list = []
+        if removed_objects == None:
+            removed_objects = []
+
         if not object_list:
             allObjects = self.modeler.object_names
             if removed_objects:

--- a/pyaedt/application/AnalysisNexxim.py
+++ b/pyaedt/application/AnalysisNexxim.py
@@ -175,7 +175,7 @@ class FieldAnalysisCircuit(Analysis):
         return spar
 
     @pyaedt_function_handler()
-    def get_all_return_loss_list(self, excitation_names=[], excitation_name_prefix=""):
+    def get_all_return_loss_list(self, excitation_names=None, excitation_name_prefix=""):
         """Retrieve a list of all return losses for a list of exctitations.
 
         Parameters
@@ -198,6 +198,9 @@ class FieldAnalysisCircuit(Analysis):
 
         >>> oEditor.GetAllPorts
         """
+        if excitation_names == None:
+            excitation_names = []
+
         if not excitation_names:
             excitation_names = self.excitations
         if excitation_name_prefix:
@@ -208,7 +211,7 @@ class FieldAnalysisCircuit(Analysis):
         return spar
 
     @pyaedt_function_handler()
-    def get_all_insertion_loss_list(self, trlist=[], reclist=[], tx_prefix="", rx_prefix=""):
+    def get_all_insertion_loss_list(self, trlist=None, reclist=None, tx_prefix="", rx_prefix=""):
         """Retrieve a list of all insertion losses from two lists of excitations (driver and receiver).
 
         Parameters
@@ -234,6 +237,11 @@ class FieldAnalysisCircuit(Analysis):
 
         >>> oEditor.GetAllPorts
         """
+        if trlist == None:
+            trlist = []
+        if reclist == None:
+            reclist = []
+
         spar = []
         if not trlist:
             trlist = [i for i in self.excitations if tx_prefix in i]
@@ -280,7 +288,7 @@ class FieldAnalysisCircuit(Analysis):
         return next
 
     @pyaedt_function_handler()
-    def get_fext_xtalk_list(self, trlist=[], reclist=[], tx_prefix="", rx_prefix="", skip_same_index_couples=True):
+    def get_fext_xtalk_list(self, trlist=None, reclist=None, tx_prefix="", rx_prefix="", skip_same_index_couples=True):
         """Retrieve a list of all the far end XTalks from two lists of exctitations (driver and receiver).
 
         Parameters
@@ -312,6 +320,11 @@ class FieldAnalysisCircuit(Analysis):
 
         >>> oEditor.GetAllPorts
         """
+        if trlist == None:
+            trlist = []
+        if reclist == None:
+            reclist = []
+
         fext = []
         if not trlist:
             trlist = [i for i in self.excitations if tx_prefix in i]

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -749,7 +749,7 @@ class Circuit(FieldAnalysisCircuit, object):
         return portnames
 
     @pyaedt_function_handler()
-    def export_touchstone(self, solutionname, sweepname, filename=None, variation=[], variations_value=[]):
+    def export_touchstone(self, solutionname, sweepname, filename=None, variation=None, variations_value=None):
         """Export the Touchstone file to a local folder.
 
         Parameters
@@ -778,6 +778,12 @@ class Circuit(FieldAnalysisCircuit, object):
 
         >>> oDesign.ExportNetworkData
         """
+
+        if variation == None:
+            variation = []
+        if variations_value == None:
+            variations_value = []
+
         # Normalize the save path
         if not filename:
             appendix = ""

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -778,7 +778,6 @@ class Circuit(FieldAnalysisCircuit, object):
 
         >>> oDesign.ExportNetworkData
         """
-
         if variation == None:
             variation = []
         if variations_value == None:

--- a/pyaedt/edb_core/padstack.py
+++ b/pyaedt/edb_core/padstack.py
@@ -325,7 +325,7 @@ class EdbPadstacks(object):
         return geom_type, parameters, offset_x, offset_y, rot
 
     @pyaedt_function_handler()
-    def get_via_instance_from_net(self, net_list=[]):
+    def get_via_instance_from_net(self, net_list=None):
         """Get the list for Edb vias from net name list.
 
         Parameters
@@ -339,6 +339,9 @@ class EdbPadstacks(object):
         list of Edb.Cell.Primitive.PadstackInstance
             list of EDB vias.
         """
+        if net_list == None:
+            net_list = []
+
         if not isinstance(net_list, list):
             net_list = [net_list]
         layout_lobj_collection = self._active_layout.GetLayoutInstance().GetAllLayoutObjInstances()

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -1730,7 +1730,7 @@ class Icepak(FieldAnalysisIcepak):
         geometryType="Volume",
         quantity="Temperature",
         variation="",
-        variationlist=[],
+        variationlist=None,
     ):
         """Export a fields summary of all objects.
 
@@ -1764,6 +1764,9 @@ class Icepak(FieldAnalysisIcepak):
         >>> oModule.EditFieldsSummarySetting
         >>> oModule.ExportFieldsSummary
         """
+        if variationlist == None:
+            variationlist = []
+
         all_objs = list(self.modeler.oeditor.GetObjectsInGroup("Solids"))
         all_objs_NonModeled = list(self.modeler.oeditor.GetObjectsInGroup("Non Model"))
         all_objs_model = [item for item in all_objs if item not in all_objs_NonModeled]

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -1432,10 +1432,10 @@ class Icepak(FieldAnalysisIcepak):
         setupname="Setup1",
         sweepname="LastAdaptive",
         map_frequency=None,
-        surface_objects=[],
+        surface_objects=None,
         source_project_name=None,
-        paramlist=[],
-        object_list=[],
+        paramlist=None,
+        object_list=None,
     ):
         """Map EM losses to an Icepak design.
 
@@ -1470,6 +1470,13 @@ class Icepak(FieldAnalysisIcepak):
 
         >>> oModule.AssignEMLoss
         """
+        if surface_objects == None:
+            surface_objects = []
+        if paramlist == None:
+            paramlist = []
+        if object_list == None:
+            object_list = []
+
         self.logger.info("Mapping HFSS EM losses.")
         oName = self.project_name
         if oName == source_project_name or source_project_name is None:

--- a/pyaedt/modeler/PrimitivesEmit.py
+++ b/pyaedt/modeler/PrimitivesEmit.py
@@ -412,7 +412,7 @@ class EmitComponent(object):
         self.__dict__[property_name] = property_value
         return True
 
-    def get_prop_nodes(self, property_filter={}):
+    def get_prop_nodes(self, property_filter=None):
         """Get all property nodes that match a set of key,value pairs.
 
         Args:
@@ -423,6 +423,9 @@ class EmitComponent(object):
         Returns:
             list: All matching nodes (EmitComponentPropNode).
         """
+        if property_filter == None:
+            property_filter = {}
+
         filtered_nodes = []
         nodes_to_expand = [self.root_prop_node]
         while nodes_to_expand:

--- a/pyaedt/modeler/PrimitivesMaxwellCircuit.py
+++ b/pyaedt/modeler/PrimitivesMaxwellCircuit.py
@@ -97,7 +97,7 @@ class MaxwellCircuitComponents(CircuitComponents):
         return id
 
     @pyaedt_function_handler()
-    def create_inductor(self, compname=None, value=50, location=[], angle=0, use_instance_id_netlist=False):
+    def create_inductor(self, compname=None, value=50, location=None, angle=0, use_instance_id_netlist=False):
         """Create an inductor.
 
         Parameters
@@ -123,6 +123,9 @@ class MaxwellCircuitComponents(CircuitComponents):
 
         >>> oEditor.CreateComponent
         """
+        if location == None:
+            location = []
+
         id = self.create_component(
             compname,
             component_library="Passive Elements",

--- a/pyaedt/modeler/PrimitivesMaxwellCircuit.py
+++ b/pyaedt/modeler/PrimitivesMaxwellCircuit.py
@@ -57,7 +57,7 @@ class MaxwellCircuitComponents(CircuitComponents):
         pass
 
     @pyaedt_function_handler()
-    def create_resistor(self, compname=None, value=50, location=[], angle=0, use_instance_id_netlist=False):
+    def create_resistor(self, compname=None, value=50, location=None, angle=0, use_instance_id_netlist=False):
         """Create a resistor.
 
         Parameters
@@ -83,6 +83,9 @@ class MaxwellCircuitComponents(CircuitComponents):
 
         >>> oEditor.CreateComponent
         """
+        if location == None:
+            location = []
+
         id = self.create_component(
             compname,
             component_library="Passive Elements",
@@ -178,7 +181,7 @@ class MaxwellCircuitComponents(CircuitComponents):
         return id
 
     @pyaedt_function_handler()
-    def create_diode(self, compname=None, location=[], angle=0, use_instance_id_netlist=False):
+    def create_diode(self, compname=None, location=None, angle=0, use_instance_id_netlist=False):
         """Create a diode.
 
         Parameters
@@ -202,6 +205,9 @@ class MaxwellCircuitComponents(CircuitComponents):
 
         >>> oEditor.CreateComponent
         """
+        if location == None:
+            location = []
+
         id = self.create_component(
             compname,
             component_library="Passive Elements",

--- a/pyaedt/modeler/PrimitivesNexxim.py
+++ b/pyaedt/modeler/PrimitivesNexxim.py
@@ -764,7 +764,9 @@ class NexximComponents(CircuitComponents):
         cmpid.set_property("DC", value)
         return cmpid
 
-    def create_coupling_inductors(self, compname, l1, l2, value=1, location=[], angle=0, use_instance_id_netlist=False):
+    def create_coupling_inductors(
+        self, compname, l1, l2, value=1, location=None, angle=0, use_instance_id_netlist=False
+    ):
         """Create a coupling inductor.
 
         Parameters
@@ -795,6 +797,9 @@ class NexximComponents(CircuitComponents):
 
         >>> oEditor.CreateComponent
         """
+        if location == None:
+            location = []
+
         cmpid = self.create_component(
             compname,
             component_library="Inductors",

--- a/pyaedt/modeler/PrimitivesNexxim.py
+++ b/pyaedt/modeler/PrimitivesNexxim.py
@@ -530,7 +530,7 @@ class NexximComponents(CircuitComponents):
         return cmpid
 
     @pyaedt_function_handler()
-    def create_capacitor(self, compname=None, value=50, location=[], angle=0, use_instance_id_netlist=False):
+    def create_capacitor(self, compname=None, value=50, location=None, angle=0, use_instance_id_netlist=False):
         """Create a capacitor.
 
         Parameters
@@ -557,6 +557,10 @@ class NexximComponents(CircuitComponents):
 
         >>> oEditor.CreateComponent
         """
+
+        if location == None:
+            location = []
+
         cmpid = self.create_component(
             compname,
             component_library="Capacitors",
@@ -570,7 +574,7 @@ class NexximComponents(CircuitComponents):
         return cmpid
 
     @pyaedt_function_handler()
-    def create_voltage_dc(self, compname=None, value=1, location=[], angle=0, use_instance_id_netlist=False):
+    def create_voltage_dc(self, compname=None, value=1, location=None, angle=0, use_instance_id_netlist=False):
         """Create a voltage DC source.
 
         Parameters
@@ -597,6 +601,9 @@ class NexximComponents(CircuitComponents):
 
         >>> oEditor.CreateComponent
         """
+        if location == None:
+            location = []
+
         cmpid = self.create_component(
             compname,
             component_library="Independent Sources",

--- a/pyaedt/modeler/PrimitivesTwinBuilder.py
+++ b/pyaedt/modeler/PrimitivesTwinBuilder.py
@@ -120,7 +120,7 @@ class TwinBuilderComponents(CircuitComponents):
         return id
 
     @pyaedt_function_handler()
-    def create_inductor(self, compname=None, value=50, location=[], angle=0, use_instance_id_netlist=False):
+    def create_inductor(self, compname=None, value=50, location=None, angle=0, use_instance_id_netlist=False):
         """Create an inductor.
 
         Parameters
@@ -146,6 +146,9 @@ class TwinBuilderComponents(CircuitComponents):
 
         >>> oEditor.CreateComponent
         """
+        if location == None:
+            location = []
+
         id = self.create_component(
             compname,
             component_library="Basic Elements\\Circuit\\Passive Elements",


### PR DESCRIPTION
Severe side effects can arose when using mutable objects as default argument.
Indeed the default values of the argument will be evaluated the first time the method is called.
In the subsequent method calls, the same value is used.