### PR TITLE
Read IBIS file from circuit class.

### DIFF
--- a/_unittest/test_15_ibs_reader.py
+++ b/_unittest/test_15_ibs_reader.py
@@ -58,3 +58,10 @@ class TestClass(BasisTest, object):
         ibis.buffers["RDQS#_u26a_800_modified"].add()
         buffer = ibis.buffers["RDQS#_u26a_800_modified"].insert(0.1016, 0.05334, 0.0)
         assert buffer.name == "CompInst@RDQS#_u26a_800_modified"
+
+    def test_02_read_ibis_from_circuit(self):
+        ibis_model = self.aedtapp.get_ibis_model_from_file(
+            os.path.join(local_path, "example_models", "u26a_800_modified.ibs")
+        )
+        assert len(ibis_model.components) == 6
+        assert len(ibis_model.models) == 17

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -372,7 +372,7 @@ class Circuit(FieldAnalysisCircuit, object):
         return True
 
     @pyaedt_function_handler()
-    def read_ibis(self, path):
+    def get_ibis_model_from_file(self, path):
         """Create an IBIS model based on the data contained in an IBIS file.
 
         Parameters
@@ -386,8 +386,9 @@ class Circuit(FieldAnalysisCircuit, object):
             IBIS object exposing all data from the IBIS file.
         """
 
-        reader = ibis_reader.IbisReader()
-        return reader.read_project(path, self)
+        reader = ibis_reader.IbisReader(path, self)
+        reader.parse_ibis_file()
+        return reader.ibis_model
 
     @pyaedt_function_handler()
     def create_schematic_from_mentor_netlist(self, file_to_import):


### PR DESCRIPTION
It is now possible to extract all ibis file model info directly from `Circuit` class.

Fix #966 .