### PR TITLE
Delete requirements_style.txt

### DIFF
--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,4 +1,0 @@
-codespell==2.1.0
-flake8==3.9.2
-black==22.1.0
-pre-commit==2.18.1


### PR DESCRIPTION
With the move to `pre-commit` in https://github.com/pyansys/pyaedt/pull/982, we no longer need or use `requirements_style.txt`