### PR TITLE
Improve the auto-generated documentation of ParametricSetups in DesignXPloration module.

### DIFF
--- a/doc/source/API/CoreModules.rst
+++ b/doc/source/API/CoreModules.rst
@@ -70,7 +70,7 @@ optimetrics setups.
    :toctree: _autosummary
    :nosignatures:
 
-   ParametericSetups
+   ParametricSetups
    OptimizationSetups
    SetupParam
    SetupOpti


### PR DESCRIPTION
In DesignXPloration module, the name of the class is ParametricSetups.
It will fix the documentation generation warning.
Fix #1036 