### PR TITLE
posx and posy variable name replacement to standardization xpos and ypos

### DIFF
--- a/pyaedt/modeler/Model3D.py
+++ b/pyaedt/modeler/Model3D.py
@@ -445,9 +445,9 @@ class Modeler3D(GeometryModeler, Primitives3D, object):
                     origin[2] -= wg_thickness
                     origin[1] -= wg_thickness
             centers = [f.center for f in airbox.faces]
-            posx = [i[wg_direction_axis] for i in centers]
-            mini = posx.index(min(posx))
-            maxi = posx.index(max(posx))
+            xpos = [i[wg_direction_axis] for i in centers]
+            mini = xpos.index(min(xpos))
+            maxi = xpos.index(max(xpos))
             if create_sheets_on_openings:
                 p1 = self.create_object_from_face(airbox.faces[mini].id)
                 p2 = self.create_object_from_face(airbox.faces[maxi].id)

--- a/pyaedt/modeler/Model3DLayout.py
+++ b/pyaedt/modeler/Model3DLayout.py
@@ -185,17 +185,17 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
         return val
 
     def _pos_with_arg(self, pos, units=None):
-        posx = self._arg_with_dim(pos[0], units)
+        xpos = self._arg_with_dim(pos[0], units)
         if len(pos) < 2:
-            posy = self._arg_with_dim(0, units)
+            ypos = self._arg_with_dim(0, units)
         else:
-            posy = self._arg_with_dim(pos[1], units)
+            ypos = self._arg_with_dim(pos[1], units)
         if len(pos) < 3:
-            posz = self._arg_with_dim(0, units)
+            zpos = self._arg_with_dim(0, units)
         else:
-            posz = self._arg_with_dim(pos[2], units)
+            zpos = self._arg_with_dim(pos[2], units)
 
-        return posx, posy, posz
+        return xpos, ypos, zpos
 
     @pyaedt_function_handler()
     def change_property(self, property_object, property_name, property_value, property_tab="BaseElementTab"):
@@ -249,14 +249,14 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
                 ]
             )
         elif isinstance(property_value, (str, float, int)):
-            posx = self._arg_with_dim(property_value, self.model_units)
+            xpos = self._arg_with_dim(property_value, self.model_units)
             self.oeditor.ChangeProperty(
                 [
                     "NAME:AllTabs",
                     [
                         "NAME:" + property_tab,
                         ["NAME:PropServers", property_object],
-                        ["NAME:ChangedProps", ["NAME:" + property_name, "Value:=", posx]],
+                        ["NAME:ChangedProps", ["NAME:" + property_name, "Value:=", xpos]],
                     ],
                 ]
             )

--- a/pyaedt/modeler/Primitives.py
+++ b/pyaedt/modeler/Primitives.py
@@ -3466,17 +3466,17 @@ class Primitives(object):
 
     @pyaedt_function_handler()
     def _pos_with_arg(self, pos, units=None):
-        posx = self._arg_with_dim(pos[0], units)
+        xpos = self._arg_with_dim(pos[0], units)
         if len(pos) < 2:
-            posy = self._arg_with_dim(0, units)
+            ypos = self._arg_with_dim(0, units)
         else:
-            posy = self._arg_with_dim(pos[1], units)
+            ypos = self._arg_with_dim(pos[1], units)
         if len(pos) < 3:
-            posz = self._arg_with_dim(0, units)
+            zpos = self._arg_with_dim(0, units)
         else:
-            posz = self._arg_with_dim(pos[2], units)
+            zpos = self._arg_with_dim(pos[2], units)
 
-        return posx, posy, posz
+        return xpos, ypos, zpos
 
     @pyaedt_function_handler()
     def _str_list(self, theList):

--- a/pyaedt/modeler/PrimitivesCircuit.py
+++ b/pyaedt/modeler/PrimitivesCircuit.py
@@ -249,12 +249,12 @@ class CircuitComponents(object):
         >>> oEditor.CreateIPort
         """
         if location:
-            posx, posy = location[0], location[1]
+            xpos, ypos = location[0], location[1]
         else:
-            posx, posy = self._get_location(location)
+            xpos, ypos = self._get_location(location)
         id = self.create_unique_id()
         arg1 = ["NAME:IPortProps", "Name:=", name, "Id:=", id]
-        arg2 = ["NAME:Attributes", "Page:=", 1, "X:=", posx, "Y:=", posy, "Angle:=", angle, "Flip:=", False]
+        arg2 = ["NAME:Attributes", "Page:=", 1, "X:=", xpos, "Y:=", ypos, "Angle:=", angle, "Flip:=", False]
         id = self._oeditor.CreateIPort(arg1, arg2)
 
         id = int(id.split(";")[1])

--- a/pyaedt/modeler/PrimitivesNexxim.py
+++ b/pyaedt/modeler/PrimitivesNexxim.py
@@ -198,7 +198,7 @@ class NexximComponents(CircuitComponents):
         return False
 
     @pyaedt_function_handler()
-    def create_field_model(self, design_name, solution_name, pin_names, model_type="hfss", posx=0, posy=1):
+    def create_field_model(self, design_name, solution_name, pin_names, model_type="hfss"):
         """Create a field model.
 
         Parameters
@@ -211,10 +211,6 @@ class NexximComponents(CircuitComponents):
             List of the pin names.
         model_type : str, optional
             Type of the model. The default is ``"hfss"``.
-        posx : float, optional
-            Position on the X axis. The default is ``0``.
-        posy : float, optional.
-            Position on the Y axis. The default is ``1``.
 
         Returns
         -------


### PR DESCRIPTION
- Replace posx,posy,posz in all methods less deprecated ones