### PR TITLE
Fixing Maxwell 3D and optimetrics exceptions 

### DIFF
--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -81,7 +81,7 @@ class TestClass(BasisTest, object):
     def test_06_eddycurrent(self):
         assert self.aedtapp.eddy_effects_on(["Plate"])
 
-    def test_07_setup(self):
+    def test_07a_setup(self):
         adaptive_frequency = "200Hz"
         Setup = self.aedtapp.create_setup()
         Setup.props["MaximumPasses"] = 12
@@ -102,6 +102,19 @@ class TestClass(BasisTest, object):
         assert Setup.disable()
         assert Setup.enable()
         assert self.aedtapp.setup_ctrlprog(Setup.name)
+
+    def test_07b_create_parametrics(self):
+        self.aedtapp["w1"] = "10mm"
+        self.aedtapp["w2"] = "2mm"
+        setup1 = self.aedtapp.parametrics.add("w1", 0.1, 20, 0.2, "LinearStep")
+        assert setup1
+        expression = "re(FluxLinkage(" + self.aedtapp.excitations[2] + "))"
+        assert setup1.add_calculation(
+            calculation=expression,
+            ranges={"Freq": "200Hz"},
+            report_type="EddyCurrent",
+            solution=self.aedtapp.existing_analysis_sweeps[0],
+        )
 
     def test_08_setup_ctrlprog_with_file(self):
         transient_setup = self.aedtapp.create_setup()

--- a/pyaedt/application/design_solutions.py
+++ b/pyaedt/application/design_solutions.py
@@ -70,7 +70,7 @@ solutions_types = {
             "options": None,
             "report_type": "Magnetostatic",
             "default_setup": 6,
-            "default_adaptive": None,
+            "default_adaptive": "LastAdaptive",
         },
         "EddyCurrent": {
             "name": "EddyCurrent",

--- a/pyaedt/modules/DesignXPloration.py
+++ b/pyaedt/modules/DesignXPloration.py
@@ -284,7 +284,12 @@ class CommonOptimetrics(object):
         if setupname not in self.props["Sim. Setups"]:
             self.props["Sim. Setups"].append(setupname)
         domain = "Time"
-        if "Freq" in ranges or "Phase" in ranges or "Theta" in ranges:
+        if (
+            "Freq" in ranges
+            or "Phase" in ranges
+            or "Theta" in ranges
+            or self._app.solution_type in ["Magnetostatic", "Electrostatic", "EddyCurrent", "DCConduction"]
+        ):
             domain = "Sweep"
         if not report_type:
             report_type = self._app.design_solutions.report_type


### PR DESCRIPTION
- Fixing bug in Maxwell 3D, for adding a calculation in optimetrics. Solution types Magnetostatic", "Electrostatic", "EddyCurrent", "DCConduction" should have Domain 'Sweep'