### PR TITLE
Improve the behavior of the `ChangePageCallback `called when adding a button.

### DIFF
--- a/pyaedt/generic/plot.py
+++ b/pyaedt/generic/plot.py
@@ -1178,6 +1178,7 @@ class ModelPlotter(object):
                 self.max_elements = (self.startpos - self.endpos) // (self.size + (self.size // 10))
                 self.i = self.max_elements
                 self.axes_color = axes_color
+                self.text = []
 
             def __call__(self, state):
                 self.plot.button_widgets = [self.plot.button_widgets[0]]

--- a/pyaedt/generic/plot.py
+++ b/pyaedt/generic/plot.py
@@ -1350,8 +1350,7 @@ class ModelPlotter(object):
                 )
         if self.show_legend:
             self._add_buttons()
-        end = time.time() - start
-        files_list = []
+
         if self.show_axes:
             self.pv.show_axes()
         if self.show_grid and not self.is_notebook:
@@ -1447,8 +1446,7 @@ class ModelPlotter(object):
 
         self.pv.background_color = [i / 255 for i in self.background_color]
         self._read_mesh_files(read_frames=True)
-        end = time.time() - start
-        files_list = []
+
         axes_color = [0 if i >= 128 else 1 for i in self.background_color]
 
         if self.show_axes:

--- a/pyaedt/modeler/PrimitivesCircuit.py
+++ b/pyaedt/modeler/PrimitivesCircuit.py
@@ -223,7 +223,7 @@ class CircuitComponents(object):
            Use :func:`Circuit.modeler.schematic.create_interface_port` instead.
         """
         warnings.warn("`create_iport` is deprecated. Use `create_interface_port` instead.", DeprecationWarning)
-        return self.create_interface_port(name, posx, posy, angle)
+        return self.create_interface_port(name, [posx, posy], angle)
 
     @pyaedt_function_handler()
     def create_interface_port(self, name, location=[], angle=0):


### PR DESCRIPTION
- Improve the behavior of the `ChangePageCallback `called when adding a button.

- Deprecated method create_iport was not working.