### PR TITLE
fix assign_winding and assign_coil + update tests

### DIFF
--- a/_unittest/test_27_Maxwell2D.py
+++ b/_unittest/test_27_Maxwell2D.py
@@ -9,6 +9,7 @@ from _unittest.conftest import pyaedt_unittest_check_desktop_error
 from pyaedt import Maxwell2d
 from pyaedt.application.Design import DesignCache
 from pyaedt.generic.constants import SOLUTIONS
+from pyaedt.generic.general_methods import generate_unique_name
 
 try:
     import pytest  # noqa: F401
@@ -33,12 +34,36 @@ class TestClass(BasisTest, object):
 
     @pyaedt_unittest_check_desktop_error
     def test_04_create_winding(self):
-
         bounds = self.aedtapp.assign_winding(current_value=20e-3, coil_terminals=["Coil"])
         assert bounds
         o = self.aedtapp.modeler.create_rectangle([0, 0, 0], [3, 1], name="Rectangle2", matname="copper")
         bounds = self.aedtapp.assign_winding(current_value=20e-3, coil_terminals=o.id)
         assert bounds
+        bounds = self.aedtapp.assign_winding(current_value="20e-3A", coil_terminals=["Coil"])
+        assert bounds
+        bounds = self.aedtapp.assign_winding(res="1ohm", coil_terminals=["Coil"])
+        assert bounds
+        bounds = self.aedtapp.assign_winding(ind="1H", coil_terminals=["Coil"])
+        assert bounds
+        bounds = self.aedtapp.assign_winding(voltage="10V", coil_terminals=["Coil"])
+        assert bounds
+        bounds_name = generate_unique_name("Coil")
+        bounds = self.aedtapp.assign_winding(coil_terminals=["Coil"], name=bounds_name)
+        assert bounds_name == bounds.name
+
+    @pyaedt_unittest_check_desktop_error
+    def test_04a_assign_coil(self):
+        bound = self.aedtapp.assign_coil(input_object=["Coil"])
+        assert bound
+        polarity = "Positive"
+        bound = self.aedtapp.assign_coil(input_object=["Coil"], polarity=polarity)
+        assert bound.props["PolarityType"] == polarity.lower()
+        polarity = "Negative"
+        bound = self.aedtapp.assign_coil(input_object=["Coil"], polarity=polarity)
+        assert bound.props["PolarityType"] == polarity.lower()
+        bound_name = generate_unique_name("Coil")
+        bound = self.aedtapp.assign_coil(input_object=["Coil"], name=bound_name)
+        assert bound_name == bound.name
 
     @pyaedt_unittest_check_desktop_error
     def test_05_create_vector_potential(self):

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -7,6 +7,7 @@ from _unittest.conftest import desktop_version
 from _unittest.conftest import local_path
 from pyaedt import Maxwell3d
 from pyaedt.generic.constants import SOLUTIONS
+from pyaedt.generic.general_methods import generate_unique_name
 
 try:
     import pytest
@@ -73,7 +74,35 @@ class TestClass(BasisTest, object):
         self.aedtapp.solution_type = "EddyCurrent"
 
     def test_05_winding(self):
-        assert self.aedtapp.assign_winding(self.aedtapp.modeler["Coil_Section1"].faces[0].id)
+        face_id = self.aedtapp.modeler["Coil_Section1"].faces[0].id
+        assert self.aedtapp.assign_winding(face_id)
+        bounds = self.aedtapp.assign_winding(current_value=20e-3, coil_terminals=face_id)
+        assert bounds
+        bounds = self.aedtapp.assign_winding(current_value="20e-3A", coil_terminals=face_id)
+        assert bounds
+        bounds = self.aedtapp.assign_winding(res="1ohm", coil_terminals=face_id)
+        assert bounds
+        bounds = self.aedtapp.assign_winding(ind="1H", coil_terminals=face_id)
+        assert bounds
+        bounds = self.aedtapp.assign_winding(voltage="10V", coil_terminals=face_id)
+        assert bounds
+        bounds_name = generate_unique_name("Winding")
+        bounds = self.aedtapp.assign_winding(coil_terminals=face_id, name=bounds_name)
+        assert bounds_name == bounds.name
+
+    def test_05a_assign_coil(self):
+        face_id = self.aedtapp.modeler["Coil_Section1"].faces[0].id
+        bound = self.aedtapp.assign_coil(input_object=face_id)
+        assert bound
+        polarity = "Positive"
+        bound = self.aedtapp.assign_coil(input_object=face_id, polarity=polarity)
+        assert not bound.props["Point out of terminal"]
+        polarity = "Negative"
+        bound = self.aedtapp.assign_coil(input_object=face_id, polarity=polarity)
+        assert bound.props["Point out of terminal"]
+        bound_name = generate_unique_name("Coil")
+        bound = self.aedtapp.assign_coil(input_object=face_id, name=bound_name)
+        assert bound_name == bound.name
 
     def test_05_draw_region(self):
         assert self.aedtapp.modeler.create_air_region(*[300] * 6)

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -709,16 +709,18 @@ class Maxwell(object):
             {
                 "Type": winding_type,
                 "IsSolid": is_solid,
-                "Current": str(current_value) + "A",
-                "Resistance": str(res) + "ohm",
-                "Inductance": str(ind) + "H",
-                "Voltage": str(voltage) + "V",
+                "Current": self.modeler._arg_with_dim(current_value, "A"),
+                "Resistance": self.modeler._arg_with_dim(res, "ohm"),
+                "Inductance": self.modeler._arg_with_dim(ind, "H"),
+                "Voltage": self.modeler._arg_with_dim(voltage, "V"),
                 "ParallelBranchesNum": str(parallel_branches),
             }
         )
         bound = BoundaryObject(self, name, props, "Winding")
         if bound.create():
             self.boundaries.append(bound)
+            if coil_terminals is None:
+                coil_terminals = []
             if type(coil_terminals) is not list:
                 coil_terminals = [coil_terminals]
             coil_names = []
@@ -727,7 +729,8 @@ class Maxwell(object):
                 if c:
                     coil_names.append(c.name)
 
-            self.add_winding_coils(bound.name, coil_names)
+            if coil_names:
+                self.add_winding_coils(bound.name, coil_names)
             return bound
         return False
 
@@ -784,7 +787,7 @@ class Maxwell(object):
 
         >>> oModule.AssignCoil
         """
-        if polarity == "Positive":
+        if polarity.lower() == "positive":
             point = False
         else:
             point = True
@@ -802,7 +805,11 @@ class Maxwell(object):
                 bound = BoundaryObject(self, name, props2, "CoilTerminal")
             else:
                 props2 = OrderedDict(
-                    {"Objects": input_object, "Conductor number": str(conductor_number), "PolarityType": polarity}
+                    {
+                        "Objects": input_object,
+                        "Conductor number": str(conductor_number),
+                        "PolarityType": polarity.lower(),
+                    }
                 )
                 bound = BoundaryObject(self, name, props2, "Coil")
         else:


### PR DESCRIPTION
In this PR:
- Fix in assign_coil() -> polarity is now case insensitive.
- Fix in assign_winding() -> fix in coil_terminals if its None and voltage, current, res, ind fixes
- new 2D/3D tests implementation 