### PR TITLE
Renormalization uncheck for waveport in Driven Modal

### DIFF
--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -96,7 +96,7 @@ class TestClass(BasisTest, object):
         udp = self.aedtapp.modeler.Position(100, 0, 0)
         o6 = self.aedtapp.modeler.create_circle(self.aedtapp.PLANE.YZ, udp, 10, name="sheet1a")
         port = self.aedtapp.create_wave_port_from_sheet(
-            o6, 0, self.aedtapp.AxisDir.XNeg, 40, 2, "sheet1a_Port", renorm=False, terminal_references=["outer"]
+            o6, 0, self.aedtapp.AxisDir.XNeg, 40, 2, "sheet1a_Port", renorm=True, terminal_references=["outer"]
         )
         assert port.name == "sheet1a_Port"
         assert port.name in [i.name for i in self.aedtapp.boundaries]
@@ -113,7 +113,9 @@ class TestClass(BasisTest, object):
         id6 = self.aedtapp.modeler.create_box([20, 20, 20], [10, 10, 2], matname="Copper", name="My_Box")
         id7 = self.aedtapp.modeler.create_box([20, 25, 30], [10, 2, 2], matname="Copper")
         rect = self.aedtapp.modeler.create_rectangle(self.aedtapp.PLANE.YZ, [20, 25, 20], [2, 10])
-        ports = self.aedtapp.create_wave_port_from_sheet(rect, 5, self.aedtapp.AxisDir.ZNeg, 40, 2, "sheet3_Port", True)
+        ports = self.aedtapp.create_wave_port_from_sheet(
+            rect, 5, self.aedtapp.AxisDir.ZNeg, 40, 2, "sheet3_Port", False
+        )
         assert ports.name in [i.name for i in self.aedtapp.boundaries]
 
     def test_06a_create_linear_count_sweep(self):
@@ -442,8 +444,8 @@ class TestClass(BasisTest, object):
         assert port.name == "Lump1xx"
         port.name = "Lump1"
         assert port.update()
-        assert self.aedtapp.create_lumped_port_between_objects(
-            "BoxLumped1", "BoxLumped2", self.aedtapp.AxisDir.XNeg, 50, "Lump2", True, True
+        port = self.aedtapp.create_lumped_port_between_objects(
+            "BoxLumped1", "BoxLumped2", self.aedtapp.AxisDir.XNeg, 50, "Lump2", False, True
         )
 
     def test_11_create_circuit_on_objects(self):
@@ -852,7 +854,7 @@ class TestClass(BasisTest, object):
         )
         assert port2.name + "_T1" in self.aedtapp.excitations
         port3 = self.aedtapp.create_lumped_port_between_objects(
-            box1, box2.name, self.aedtapp.AxisDir.XNeg, 50, "Lump3", True, True
+            box1, box2.name, self.aedtapp.AxisDir.XNeg, 50, "Lump3", False, True
         )
         assert port3.name + "_T1" in self.aedtapp.excitations
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -310,20 +310,35 @@ class Hfss(FieldAnalysis3D, object):
             props["Faces"] = [objectname]
         props["DoDeembed"] = deemb
         props["RenormalizeAllTerminals"] = renorm
-        props["Modes"] = OrderedDict(
-            {
-                "Mode1": OrderedDict(
-                    {
-                        "ModeNum": 1,
-                        "UseIntLine": True,
-                        "IntLine": OrderedDict({"Start": start, "End": stop}),
-                        "AlignmentGroup": 0,
-                        "CharImp": "Zpi",
-                        "RenormImp": str(impedance) + "ohm",
-                    }
-                )
-            }
-        )
+        if renorm:
+            props["Modes"] = OrderedDict(
+                {
+                    "Mode1": OrderedDict(
+                        {
+                            "ModeNum": 1,
+                            "UseIntLine": True,
+                            "IntLine": OrderedDict({"Start": start, "End": stop}),
+                            "AlignmentGroup": 0,
+                            "CharImp": "Zpi",
+                            "RenormImp": str(impedance) + "ohm",
+                        }
+                    )
+                }
+            )
+        else:
+            props["Modes"] = OrderedDict(
+                {
+                    "Mode1": OrderedDict(
+                        {
+                            "ModeNum": 1,
+                            "UseIntLine": True,
+                            "IntLine": OrderedDict({"Start": start, "End": stop}),
+                            "AlignmentGroup": 0,
+                            "CharImp": "Zpi",
+                        }
+                    )
+                }
+            )
         props["ShowReporterFilter"] = False
         props["ReporterFilter"] = [True]
         props["Impedance"] = str(impedance) + "ohm"
@@ -361,6 +376,23 @@ class Hfss(FieldAnalysis3D, object):
                         self.odesign.ChangeProperty(properties)
                     except:  # pragma: no cover
                         self.logger.warning("Failed to change terminal impedance.")
+                if not renorm:
+                    properties = [
+                        "NAME:AllTabs",
+                        [
+                            "NAME:HfssTab",
+                            ["NAME:PropServers", "BoundarySetup:" + boundary.name],
+                            [
+                                "NAME:ChangedProps",
+                                ["NAME:Renorm All Terminals", "Value:=", False],
+                            ],
+                        ],
+                    ]
+                    try:
+                        self.odesign.ChangeProperty(properties)
+                    except:  # pragma: no cover
+                        self.logger.warning("Failed to change normalization.")
+
                 new_name = portname + "_T" + str(count)
                 properties = [
                     "NAME:AllTabs",
@@ -473,7 +505,8 @@ class Hfss(FieldAnalysis3D, object):
                     mode["IntLine"] = OrderedDict({"Start": start, "End": stop})
                 mode["AlignmentGroup"] = 0
                 mode["CharImp"] = "Zpi"
-                mode["RenormImp"] = str(impedance) + "ohm"
+                if renorm:
+                    mode["RenormImp"] = str(impedance) + "ohm"
                 modes["Mode1"] = mode
             else:
                 mode = OrderedDict({})
@@ -482,7 +515,8 @@ class Hfss(FieldAnalysis3D, object):
                 mode["UseIntLine"] = False
                 mode["AlignmentGroup"] = 0
                 mode["CharImp"] = "Zpi"
-                mode["RenormImp"] = str(impedance) + "ohm"
+                if renorm:
+                    mode["RenormImp"] = str(impedance) + "ohm"
                 modes["Mode" + str(i)] = mode
             report_filter.append(True)
             i += 1


### PR DESCRIPTION
This feature was not working because, and Renormalization was always checked which is 'dangerous' for a waveport in DrivenModal:

- If Renorm is false, RenormImp key must be not defined for a Waveport in DrivenModal

- If driven Terminal, renormalize is True by default. It has to be modifed after the creation of the port.