### PR TITLE
Refactoring RDAT parser to read Smith Chart report

### DIFF
--- a/_unittest/example_models/test_report_smith.rdat
+++ b/_unittest/example_models/test_report_smith.rdat
@@ -1,0 +1,792 @@
+$begin 'ReportsData'
+	$begin 'ProductInfo'
+		ProductName='ElectronicsDesktop'
+		ProductMajorVersion=2022
+		ProductMinorVersion=1
+	$end 'ProductInfo'
+	$begin 'ReportSetup'
+		$begin 'Reports'
+			$begin 'S Parameter Chart 1'
+				ReportID=31
+				$begin 'Report2D'
+					name='S Parameter Chart 1'
+					ReportID=31
+					ReportType=0
+					DisplayType=5
+					Title=''
+					Domain=''
+					$begin 'Migration'
+						MigVersion(0, 0, 'mig(0.0)')
+					$end 'Migration'
+					$begin 'Graph2DsV2'
+						$begin 'Graph2D'
+							TraceDefID=30
+							Type='Continuous'
+							Axis='Y1'
+						$end 'Graph2D'
+					$end 'Graph2DsV2'
+					$begin 'PlotDisplayDataManager'
+						NextUniqueID=18
+						MoveBackwards=false
+						$begin 'PlotHeaderDataSource'
+							CompanyName=''
+							ShowDesignName=true
+							ProjectFileName=''
+						$end 'PlotHeaderDataSource'
+						StockNameIDMap(CircleAxis=4, Header=0, Legend=2, PolarGrid=6)
+						$begin 'SourceList'
+						$end 'SourceList'
+						Version='17.0:20150830'
+						$begin 'DocAttributes'
+							$begin 'PlotAttributeStoreMap'
+								$begin 'MainMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=6
+										$begin 'PolarRhoAxisAttribute'
+											DecimalFieldWidth=3
+											DecimalFieldPrecision=2
+											ManualTitle=''
+											AxisColor(R=0, G=0, B=0)
+											MinScale=0
+											MaxScale=1
+											TickSpacing=0.20000000000000001
+											ManualUnits=false
+											Units=''
+											AxisScale='Linear'
+											NumberFormat='Auto'
+											$begin 'TextFont'
+												$begin 'FontAttribute'
+													$begin 'Font'
+														HeightInPts=9
+														Width=0
+														Escapement=0
+														Orientation=0
+														Weight=400
+														Italic=0
+														Underline=0
+														StrikeOut=0
+														CharSet=0
+														OutPrecision=7
+														ClipPrecision=48
+														Quality=6
+														PitchAndFamily=0
+														FaceName='Arial'
+													$end 'Font'
+													Color(R=0, G=0, B=0)
+												$end 'FontAttribute'
+											$end 'TextFont'
+											InfMapMode=false
+											InfMapValue=1.7976931348623156e+306
+											AutoRangeMin=true
+											AutoRangeMax=true
+											AutoSpacing=true
+											kNumMinorDivisions=5
+											ShowAxisTitle=true
+											ShowAxisUnits=true
+											vwm='FullWnd'
+											viewWndWd=#nan
+											ActivateMargins=true
+											MarginPercent=0
+											NeverCollapse=false
+											AxisStripes=true
+										$end 'PolarRhoAxisAttribute'
+									$end 'SubMapItem'
+								$end 'MainMapItem'
+							$end 'PlotAttributeStoreMap'
+						$end 'DocAttributes'
+						$begin 'DisplayTypeAttributes'
+							$begin 'PlotAttributeStoreMap'
+								$begin 'MainMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=10
+										$begin 'CurveCartesianAttribute'
+											YAxis='Y1'
+										$end 'CurveCartesianAttribute'
+									$end 'SubMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=12
+										$begin 'CurveCartesianAttribute'
+											YAxis='Y1'
+										$end 'CurveCartesianAttribute'
+									$end 'SubMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=14
+										$begin 'CurveCartesianAttribute'
+											YAxis='Y1'
+										$end 'CurveCartesianAttribute'
+									$end 'SubMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=16
+										$begin 'CurveCartesianAttribute'
+											YAxis='Y1'
+										$end 'CurveCartesianAttribute'
+									$end 'SubMapItem'
+								$end 'MainMapItem'
+								$begin 'MainMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=10
+										$begin 'CurveRenderAttribute'
+											$begin 'LineRenderAttribute'
+												LineStyle='Solid'
+												LineWidth=3
+												LineColor(R=237, G=28, B=36)
+											$end 'LineRenderAttribute'
+											TraceType='Continuous'
+											SymbolType='HollowHorizontalLeftTriangle'
+											SymbolColor(R=155, G=93, B=112)
+											ShowSymbols=false
+											SymbolFrequency=15
+											ShowArrows=false
+										$end 'CurveRenderAttribute'
+									$end 'SubMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=12
+										$begin 'CurveRenderAttribute'
+											$begin 'LineRenderAttribute'
+												LineStyle='Solid'
+												LineWidth=3
+												LineColor(R=0, G=255, B=0)
+											$end 'LineRenderAttribute'
+											TraceType='Continuous'
+											SymbolType='Circle'
+											SymbolColor(R=128, G=158, B=173)
+											ShowSymbols=false
+											SymbolFrequency=15
+											ShowArrows=false
+										$end 'CurveRenderAttribute'
+									$end 'SubMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=14
+										$begin 'CurveRenderAttribute'
+											$begin 'LineRenderAttribute'
+												LineStyle='Solid'
+												LineWidth=3
+												LineColor(R=0, G=181, B=255)
+											$end 'LineRenderAttribute'
+											TraceType='Continuous'
+											SymbolType='HollowVerticalDownTriangle'
+											SymbolColor(R=79, G=17, B=25)
+											ShowSymbols=false
+											SymbolFrequency=15
+											ShowArrows=false
+										$end 'CurveRenderAttribute'
+									$end 'SubMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=16
+										$begin 'CurveRenderAttribute'
+											$begin 'LineRenderAttribute'
+												LineStyle='Solid'
+												LineWidth=3
+												LineColor(R=247, G=147, B=30)
+											$end 'LineRenderAttribute'
+											TraceType='Continuous'
+											SymbolType='VerticalEllipse'
+											SymbolColor(R=125, G=155, B=61)
+											ShowSymbols=false
+											SymbolFrequency=15
+											ShowArrows=false
+										$end 'CurveRenderAttribute'
+									$end 'SubMapItem'
+								$end 'MainMapItem'
+								$begin 'MainMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=0
+										$begin 'HeaderRenderAttribute'
+											$begin 'TitleFont'
+												$begin 'FontAttribute'
+													$begin 'Font'
+														HeightInPts=14
+														Width=0
+														Escapement=0
+														Orientation=0
+														Weight=400
+														Italic=0
+														Underline=0
+														StrikeOut=0
+														CharSet=0
+														OutPrecision=7
+														ClipPrecision=48
+														Quality=6
+														PitchAndFamily=0
+														FaceName='Arial'
+													$end 'Font'
+													Color(R=0, G=0, B=0)
+												$end 'FontAttribute'
+											$end 'TitleFont'
+											$begin 'SubtitleFont'
+												$begin 'FontAttribute'
+													$begin 'Font'
+														HeightInPts=10
+														Width=0
+														Escapement=0
+														Orientation=0
+														Weight=400
+														Italic=0
+														Underline=0
+														StrikeOut=0
+														CharSet=0
+														OutPrecision=7
+														ClipPrecision=48
+														Quality=6
+														PitchAndFamily=0
+														FaceName='Arial'
+													$end 'Font'
+													Color(R=0, G=0, B=0)
+												$end 'FontAttribute'
+											$end 'SubtitleFont'
+										$end 'HeaderRenderAttribute'
+									$end 'SubMapItem'
+								$end 'MainMapItem'
+								$begin 'MainMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=2
+										$begin 'LegendRenderAttribute'
+											$begin 'LegendTableAttrib'
+												$begin 'TableRenderAttribute'
+													$begin 'TableFontAttrib'
+														$begin 'FontAttribute'
+															$begin 'Font'
+																HeightInPts=8
+																Width=0
+																Escapement=0
+																Orientation=0
+																Weight=400
+																Italic=0
+																Underline=0
+																StrikeOut=0
+																CharSet=0
+																OutPrecision=7
+																ClipPrecision=48
+																Quality=6
+																PitchAndFamily=0
+																FaceName='Arial'
+															$end 'Font'
+															Color(R=0, G=0, B=0)
+														$end 'FontAttribute'
+													$end 'TableFontAttrib'
+													$begin 'TableTitleFontAttrib'
+														$begin 'FontAttribute'
+															$begin 'Font'
+																HeightInPts=8
+																Width=0
+																Escapement=0
+																Orientation=0
+																Weight=400
+																Italic=0
+																Underline=0
+																StrikeOut=0
+																CharSet=0
+																OutPrecision=7
+																ClipPrecision=48
+																Quality=6
+																PitchAndFamily=0
+																FaceName='Arial'
+															$end 'Font'
+															Color(R=0, G=0, B=0)
+														$end 'FontAttribute'
+													$end 'TableTitleFontAttrib'
+													TableBorderLineWidth=1
+													TableBorderLineColor=0
+													TableGridLineWidth=1
+													TableGridLineColor=12632256
+													TableBackgroundColor=16777215
+													TableHeaderBackgroundColor=14408667
+												$end 'TableRenderAttribute'
+											$end 'LegendTableAttrib'
+											ShowTraceName=true
+											ShowSolutionName=true
+											ShowVariationKey=true
+											FileNameDisplayModeInVariationKey=0
+											DockMode='None'
+										$end 'LegendRenderAttribute'
+									$end 'SubMapItem'
+								$end 'MainMapItem'
+								$begin 'MainMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=4
+										$begin 'PolarCircleAxisAttribute'
+											CircDecimalFieldWidth=3
+											CircDecimalFieldPrecision=2
+											CircleAxisMinorDivCount=5
+											CircleAxisMajorDivCount=36
+											$begin 'FontAttribute'
+												$begin 'Font'
+													HeightInPts=9
+													Width=0
+													Escapement=0
+													Orientation=0
+													Weight=400
+													Italic=0
+													Underline=0
+													StrikeOut=0
+													CharSet=0
+													OutPrecision=7
+													ClipPrecision=48
+													Quality=6
+													PitchAndFamily=0
+													FaceName='Arial'
+												$end 'Font'
+												Color(R=0, G=0, B=0)
+											$end 'FontAttribute'
+											$begin 'LineRenderAttribute'
+												LineStyle='Solid'
+												LineWidth=1
+												LineColor(R=0, G=0, B=0)
+											$end 'LineRenderAttribute'
+										$end 'PolarCircleAxisAttribute'
+									$end 'SubMapItem'
+								$end 'MainMapItem'
+								$begin 'MainMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=6
+										$begin 'PolarGridAttribute'
+											ShowGridLabels=true
+											$begin 'CircleGrid'
+												$begin 'FontAttribute'
+													$begin 'Font'
+														HeightInPts=9
+														Width=0
+														Escapement=0
+														Orientation=0
+														Weight=400
+														Italic=0
+														Underline=0
+														StrikeOut=0
+														CharSet=0
+														OutPrecision=7
+														ClipPrecision=48
+														Quality=6
+														PitchAndFamily=0
+														FaceName='Arial'
+													$end 'Font'
+													Color(R=0, G=0, B=0)
+												$end 'FontAttribute'
+												$begin 'LineRenderAttribute'
+													LineStyle='Solid'
+													LineWidth=1
+													LineColor(R=200, G=200, B=200)
+												$end 'LineRenderAttribute'
+											$end 'CircleGrid'
+											$begin 'AngleGrid'
+												$begin 'LineRenderAttribute'
+													LineStyle='Solid'
+													LineWidth=1
+													LineColor(R=220, G=220, B=220)
+												$end 'LineRenderAttribute'
+											$end 'AngleGrid'
+											$begin 'ImpedanceGrid'
+												$begin 'ImpedanceRGrid'
+													$begin 'FontAttribute'
+														$begin 'Font'
+															HeightInPts=9
+															Width=0
+															Escapement=0
+															Orientation=0
+															Weight=400
+															Italic=0
+															Underline=0
+															StrikeOut=0
+															CharSet=0
+															OutPrecision=7
+															ClipPrecision=48
+															Quality=6
+															PitchAndFamily=0
+															FaceName='Arial'
+														$end 'Font'
+														Color(R=0, G=0, B=0)
+													$end 'FontAttribute'
+													$begin 'LineRenderAttribute'
+														LineStyle='Solid'
+														LineWidth=1
+														LineColor(R=200, G=200, B=200)
+													$end 'LineRenderAttribute'
+												$end 'ImpedanceRGrid'
+												$begin 'ImpedanceXGrid'
+													$begin 'FontAttribute'
+														$begin 'Font'
+															HeightInPts=9
+															Width=0
+															Escapement=0
+															Orientation=0
+															Weight=400
+															Italic=0
+															Underline=0
+															StrikeOut=0
+															CharSet=0
+															OutPrecision=7
+															ClipPrecision=48
+															Quality=6
+															PitchAndFamily=0
+															FaceName='Arial'
+														$end 'Font'
+														Color(R=0, G=0, B=0)
+													$end 'FontAttribute'
+													$begin 'LineRenderAttribute'
+														LineStyle='Solid'
+														LineWidth=1
+														LineColor(R=220, G=220, B=220)
+													$end 'LineRenderAttribute'
+												$end 'ImpedanceXGrid'
+											$end 'ImpedanceGrid'
+											$begin 'AdimittanceGrid'
+												$begin 'AdimittanceGGrid'
+													$begin 'FontAttribute'
+														$begin 'Font'
+															HeightInPts=9
+															Width=0
+															Escapement=0
+															Orientation=0
+															Weight=400
+															Italic=0
+															Underline=0
+															StrikeOut=0
+															CharSet=0
+															OutPrecision=7
+															ClipPrecision=48
+															Quality=6
+															PitchAndFamily=0
+															FaceName='Arial'
+														$end 'Font'
+														Color(R=0, G=0, B=0)
+													$end 'FontAttribute'
+													$begin 'LineRenderAttribute'
+														LineStyle='Solid'
+														LineWidth=1
+														LineColor(R=200, G=200, B=200)
+													$end 'LineRenderAttribute'
+												$end 'AdimittanceGGrid'
+												$begin 'AdimittanceBGrid'
+													$begin 'FontAttribute'
+														$begin 'Font'
+															HeightInPts=9
+															Width=0
+															Escapement=0
+															Orientation=0
+															Weight=400
+															Italic=0
+															Underline=0
+															StrikeOut=0
+															CharSet=0
+															OutPrecision=7
+															ClipPrecision=48
+															Quality=6
+															PitchAndFamily=0
+															FaceName='Arial'
+														$end 'Font'
+														Color(R=0, G=0, B=0)
+													$end 'FontAttribute'
+													$begin 'LineRenderAttribute'
+														LineStyle='Solid'
+														LineWidth=1
+														LineColor(R=220, G=220, B=220)
+													$end 'LineRenderAttribute'
+												$end 'AdimittanceBGrid'
+											$end 'AdimittanceGrid'
+										$end 'PolarGridAttribute'
+									$end 'SubMapItem'
+								$end 'MainMapItem'
+								$begin 'MainMapItem'
+									$begin 'SubMapItem'
+										DataSourceID=-1
+										$begin 'PolarPlotRenderAttribute'
+											ShowCircleGrid=false
+											ShowAngleGrid=false
+											ShowImpedanceGrid=true
+											ShowAdmittanceGrid=false
+										$end 'PolarPlotRenderAttribute'
+									$end 'SubMapItem'
+								$end 'MainMapItem'
+							$end 'PlotAttributeStoreMap'
+						$end 'DisplayTypeAttributes'
+						$begin 'DocDefaultAttributes'
+							$begin 'PlotAttributeStoreMap'
+							$end 'PlotAttributeStoreMap'
+						$end 'DocDefaultAttributes'
+						$begin 'PerViewPlotAttributeStoreMap'
+							$begin 'MapItem'
+								ItemID=9
+								$begin 'PlotAttributeStoreMap'
+									$begin 'MainMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=1
+											$begin 'BasicLayoutAttribute'
+												$begin 'LayoutRect'
+													Top=1187
+													Left=8496
+													Bottom=8812
+													Right=871
+												$end 'LayoutRect'
+											$end 'BasicLayoutAttribute'
+										$end 'SubMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=8
+											$begin 'BasicLayoutAttribute'
+												$begin 'LayoutRect'
+													Top=75
+													Left=75
+													Bottom=9925
+													Right=683
+												$end 'LayoutRect'
+											$end 'BasicLayoutAttribute'
+										$end 'SubMapItem'
+									$end 'MainMapItem'
+									$begin 'MainMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=3
+											$begin 'DockableOverlayLayoutAttribute'
+												$begin 'Dock_0'
+													$begin 'OverlayLayoutAttribute'
+														$begin 'BoundingRect'
+															Top=4850
+															Left=783
+															Bottom=9850
+															Right=8283
+														$end 'BoundingRect'
+														ModifySize=false
+														ModifyPosition=false
+													$end 'OverlayLayoutAttribute'
+												$end 'Dock_0'
+											$end 'DockableOverlayLayoutAttribute'
+										$end 'SubMapItem'
+									$end 'MainMapItem'
+									$begin 'MainMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=5
+											$begin 'PolarLayoutAttribute'
+												$begin 'PolarCircleRect'
+													Top=1187
+													Left=8496
+													Bottom=8812
+													Right=871
+												$end 'PolarCircleRect'
+												$begin 'AxisRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisRect'
+												$begin 'AxisLabelRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisLabelRect'
+											$end 'PolarLayoutAttribute'
+										$end 'SubMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=7
+											$begin 'PolarLayoutAttribute'
+												$begin 'PolarCircleRect'
+													Top=1187
+													Left=8496
+													Bottom=8812
+													Right=871
+												$end 'PolarCircleRect'
+												$begin 'AxisRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisRect'
+												$begin 'AxisLabelRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisLabelRect'
+											$end 'PolarLayoutAttribute'
+										$end 'SubMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=11
+											$begin 'PolarLayoutAttribute'
+												$begin 'PolarCircleRect'
+													Top=1187
+													Left=8496
+													Bottom=8812
+													Right=871
+												$end 'PolarCircleRect'
+												$begin 'AxisRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisRect'
+												$begin 'AxisLabelRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisLabelRect'
+											$end 'PolarLayoutAttribute'
+										$end 'SubMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=13
+											$begin 'PolarLayoutAttribute'
+												$begin 'PolarCircleRect'
+													Top=1187
+													Left=8496
+													Bottom=8812
+													Right=871
+												$end 'PolarCircleRect'
+												$begin 'AxisRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisRect'
+												$begin 'AxisLabelRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisLabelRect'
+											$end 'PolarLayoutAttribute'
+										$end 'SubMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=15
+											$begin 'PolarLayoutAttribute'
+												$begin 'PolarCircleRect'
+													Top=1187
+													Left=8496
+													Bottom=8812
+													Right=871
+												$end 'PolarCircleRect'
+												$begin 'AxisRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisRect'
+												$begin 'AxisLabelRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisLabelRect'
+											$end 'PolarLayoutAttribute'
+										$end 'SubMapItem'
+										$begin 'SubMapItem'
+											DataSourceID=17
+											$begin 'PolarLayoutAttribute'
+												$begin 'PolarCircleRect'
+													Top=1187
+													Left=8496
+													Bottom=8812
+													Right=871
+												$end 'PolarCircleRect'
+												$begin 'AxisRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisRect'
+												$begin 'AxisLabelRect'
+													Top=0
+													Left=0
+													Bottom=0
+													Right=0
+												$end 'AxisLabelRect'
+											$end 'PolarLayoutAttribute'
+										$end 'SubMapItem'
+									$end 'MainMapItem'
+								$end 'PlotAttributeStoreMap'
+								PlotType=4
+							$end 'MapItem'
+						$end 'PerViewPlotAttributeStoreMap'
+						IsViewAttribServer=false
+						ViewID=-1
+						$begin 'SourceIDMap'
+							IDMapItem(30, 0, -1, 10)
+							IDMapItem(30, 1, -1, 12)
+							IDMapItem(30, 2, -1, 14)
+							IDMapItem(30, 3, -1, 16)
+						$end 'SourceIDMap'
+						$begin 'TraceCharacteristicsMgr'
+						$end 'TraceCharacteristicsMgr'
+						$begin 'CartesianXMarkerManager'
+							RefMarkerID=-1
+							CurrentMarkerID=-1
+							$begin 'ReferenceCurves'
+							$end 'ReferenceCurves'
+						$end 'CartesianXMarkerManager'
+						$begin 'CartesianYMarkerManager'
+						$end 'CartesianYMarkerManager'
+						XAxisStackID=-1
+						$begin 'AllTransSrcDwg'
+							$begin 'PT'
+								ID=4
+								TransSrcDwg(-1, 0, 8, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17)
+							$end 'PT'
+						$end 'AllTransSrcDwg'
+						$begin 'AllPtSVID'
+							PtID(4, -1, 1)
+						$end 'AllPtSVID'
+					$end 'PlotDisplayDataManager'
+				$end 'Report2D'
+			$end 'S Parameter Chart 1'
+		$end 'Reports'
+	$end 'ReportSetup'
+	$begin 'RepMgrRepsData'
+		$begin 'S Parameter Chart 1'
+			ReportID=31
+			$begin 'Traces'
+				$begin '30'
+					TraceName='S(1,1)'
+					SourceDesc='HFSSDesign1'
+					IsDbAppliedYValue=false
+					$begin 'ExtTraceInfo'
+						NumPoints=0
+						TraceType=0
+						Offset=0
+						XLabel=''
+						SamplingPeriod='0'
+						SamplingPeriodOffset='0'
+						AutoDelay=true
+						DelayValue='0ps'
+						AutoCompCrossAmplitude=true
+						CrossingAmplitude='0mV'
+						YAxis=1
+						AutoCompEyeMeasurementPoint=true
+						EyeMeasurementPoint='0ps'
+						EyePamLow()
+						EyePamVRef()
+						EyePamHigh()
+						EyePamNames()
+						EyePamStrictVRef=false
+					$end 'ExtTraceInfo'
+					TraceCompExprs('S(1,1)')
+					TraceDataName=''
+					IsCompositeData=false
+					$begin 'TraceComponents'
+						$begin 'TraceDataComps'
+							$begin '0'
+								TraceCompExpr='S(1,1)'
+								$begin 'TraceDataCol'
+									ColumnValues(-0.56591345712074204, 0.81730946027046103, -0.56507436133077515, 0.81782101353835657, -0.56423206596047271, 0.81833276955372025, -0.56338653923968829, 0.81884472772106776, -0.56253774895732078, 0.81935688736292034, -0.56168566245389995, 0.81986924771708025, -0.56083024661402814, 0.82038180793382087, -0.5599714678586728, 0.82089456707299124, -0.55910929213730665, 0.82140752410103313, -0.55824368491989496, 0.82192067788790357, -0.55737461118872123, 0.82243402720390657, -0.55650203543005194, 0.8229475707164241, -0.55562592162563695, 0.8234613069865484, -0.55474623324403893, 0.82397523446560861, -0.55386293323178959, 0.82448935149159253, -0.55297598400436887, 0.82500365628545513, -0.55208534743700499, 0.8255181469473134, -0.55119098485528562, 0.8260328214525251, -0.55029285702558295, 0.82654767764764281, -0.54939092414528323, 0.82706271324624336, -0.54848514583282038, 0.82757792582462797, -0.54757548111750398, 0.82809331281738663, -0.54666188842914409, 0.82860887151282603, -0.54574432558746033, 0.8291245990482512, -0.54482274979127754, 0.82964049240510207, -0.54389711760749793, 0.83015654840393627, -0.54296738495984809, 0.83067276369925325, -0.54203350711739207, 0.83118913477415624, -0.54109543868281018, 0.83170565793484585, -0.54015313358043326, 0.83222232930493867, -0.53920654504402921, 0.83273914481960642, -0.53825562560433637, 0.83325610021952867, -0.53730032707633557, 0.83377319104465408, -0.53634060054625932, 0.83429041262776249, -0.5353763963583259, 0.83480776008782143, -0.53440766410119822, 0.83532522832312983, -0.53343435259415561, 0.8358428120042436, -0.53245640987297649, 0.83636050556667252, -0.53147378317552274, 0.836878303203343, -0.53048641892701731, 0.83739619885681849, -0.52949426272501243, 0.83791418621126845, -0.52849725932403713, 0.83843225868417626, -0.52749535261991842, 0.83895040941778132, -0.52648848563376816, 0.83946863127023919, -0.52547660049562706, 0.83998691680649862, -0.524459638427761, 0.84050525828887679, -0.52343753972759555, 0.84102364766733062, -0.52241024375028555, 0.84154207656940416, -0.52137768889091052, 0.84206053628985345, -0.52033981256628281, 0.8425790177799215, -0.51929655119636586, 0.84309751163626812, -0.51824784018528802, 0.84361600808952719, -0.51719361390194363, 0.84413449699248955, -0.51613380566017719, 0.84465296780789167, -0.51506834769852883, 0.8451714095957984, -0.51399717115954524, 0.84568981100056684, -0.5129202060686332, 0.84620816023737111, -0.51183738131245415, 0.84672644507828021, -0.51074862461684278, 0.84724465283786454, -0.50965386252424261, 0.84776277035832137, -0.5085530203706442, 0.84828078399409612, -0.50744602226201674, 0.84879867959598543, -0.50633279105021922, 0.84931644249470195, -0.50521324830837977, 0.84983405748387786, -0.5040873143057315, 0.85035150880249277, -0.50295490798189024, 0.85086878011670097, -0.50181594692056286, 0.85138585450103543, -0.50067034732267224, 0.85190271441896837, -0.49951802397888406, 0.8524193417028032, -0.49835889024152402, 0.85293571753287234, -0.49719285799586982, 0.85345182241601725, -0.49601983763080171, 0.85396763616331972, -0.49483973800880066, 0.85448313786706476, -0.49365246643527566, 0.85499830587689474, -0.49245792862720705, 0.85551311777513572, -0.4912560286810862, 0.8560275503512571, -0.49004666904014249, 0.85654157957543531, -0.48882975046083332, 0.85705518057118679, -0.48760517197858638, 0.85756832758703605, -0.48637283087277339, 0.85808099396717841, -0.48513262263090051, 0.85859315212110454, -0.48388444091199656, 0.85910477349214365, -0.48262817750918124, 0.85961582852488205, -0.48136372231139474, 0.86012628663141921, -0.48009096326427059, 0.86063611615641211, -0.47880978633013371, 0.86114528434086013, -0.47752007544710351, 0.86165375728458837, -0.47622171248728123, 0.86216149990736812, -0.47491457721400554, 0.86266847590863249, -0.47359854723815292, 0.86317464772572217, -0.47227349797346369, 0.86367997649061146, -0.47093930259087463, 0.86418442198505019, -0.46959583197183474, 0.86468794259405934, -0.46824295466058635, 0.86519049525771763, -0.46688053681538777, 0.86569203542116735, -0.4655084421586575, 0.86619251698277266, -0.46412653192602066, 0.86669189224035337, -0.46273466481422959, 0.8671901118354175, -0.46133269692794632, 0.86768712469531439, -0.4599204817253571, 0.86818287797322136, -0.45849786996260278, 0.86867731698587924, -0.45706470963700069, 0.86917038514898337, -0.4556208459290364, 0.86966202391013492, -0.45416612114310823, 0.87015217267925538, -0.45270037464699475, 0.87064076875635799, -0.45122344281003574, 0.87112774725656761, -0.44973515893999516, 0.87161304103227888, -0.44823535321859409, 0.87209658059233064, -0.4467238526356897, 0.87257829401807607, -0.44520048092208114, 0.87305810687621999, -0.44366505848092874, 0.87353594212828611, -0.44211740231775992, 0.87401172003657679, -0.44055732596905561, 0.87448535806647765, -0.43898463942939298, 0.87495677078495293, -0.43739914907713551, 0.87542586975507286, -0.43580065759865366, 0.87589256342640498, -0.43418896391106626, 0.87635675702109461, -0.43256386308349243, 0.87681835241545469, -0.43092514625680678, 0.87727724801686724, -0.42927260056188676, 0.87773333863580516, -0.42760600903635732, 0.87818651535276337, -0.42592515053982311, 0.87863666537987473, -0.42422979966759428, 0.87908367191699599, -0.4225197266629096, 0.87952741400201306, -0.4207946973276645, 0.87996776635512408, -0.41905447293165771, 0.88040459921683833, -0.41729881012036907, 0.88083777817941844, -0.41552746082129238, 0.88126716401148042, -0.41374017214884856, 0.88169261247545794, -0.41193668630790714, 0.88211397413761305, -0.4101167404959572, 0.88253109417027553, -0.40828006680396811, 0.88294381214596529, -0.40642639211599296, 0.88335196182304321, -0.4045554380075701, 0.88375537092252021, -0.40266692064299386, 0.8841538608956333, -0.40076055067152666, 0.88454724668178175, -0.39883603312264204, 0.88493533645639699, -0.39689306730039214, 0.88531793136830605, -0.39493134667701085, 0.88569482526611409, -0.39295055878587631, 0.88606580441312532, -0.39095038511396318, 0.88643064719029341, -0.38893050099394172, 0.88678912378666508, -0.3868905754960873, 0.88714099587676098, -0.3848302713201901, 0.88748601628431512, -0.38274924468766502, 0.88782392863175974, -0.38064714523409227, 0.88815446697481981, -0.37852361590243655, 0.88847735542155648, -0.3763782928372188, 0.88879230773515672, -0.37421080527993972, 0.88909902691974907, -0.37202077546608953, 0.88939720478848505, -0.36980781852409933, 0.88968652151308703, -0.36757154237663725, 0.88996664515404522, -0.36531154764467283, 0.89023723117058839, -0.36302742755479156, 0.8904979219095307, -0.36071876785026968, 0.89074834607205189, -0.35838514670646976, 0.89098811815742263, -0.35602613465117877, 0.89121683788265738, -0.35364129449054726, 0.89143408957701586, -0.35123018124136218, 0.89163944155024311, -0.34879234207044074, 0.8918324454333858, -0.34632731624200713, 0.89201263549097254, -0.34383463507398687, 0.89217952790330113, -0.34131382190422771, 0.89233262001751779, -0.33876439206775849, 0.8924713895661317, -0.33618585288627223, 0.89259529385154257, -0.33357770367113587, 0.89270376889511482, -0.33093943574133039, 0.89279622854927032, -0.32827053245784538, 0.89287206357102067, -0.32557046927618316, 0.89293064065529681, -0.32283871381875301, 0.8929713014263847, -0.32007472596910191, 0.8929933613857135, -0.3172779579900723, 0.89299610881418523, -0.31444785466815683, 0.89297880362719118, -0.31158385348650325, 0.89294067618038242, -0.30868538482922581, 0.89288092602423308, -0.30575187221988526, 0.89279872060537524, -0.30278273259724997, 0.89269319391262492, -0.29977737663166909, 0.89256344506559993, -0.29673520908569356, 0.89240853684376475, -0.29365562922283911, 0.89222749415372637, -0.29053803126871058, 0.89201930243256089, -0.28738180492903576, 0.89178290598494803, -0.2841863359695122, 0.89151720625186937, -0.28095100686276486, 0.8912210600086391, -0.27767519750810027, 0.89089327749004443, -0.27435828603021822, 0.89053262044041415, -0.27099964966348128, 0.89013780008647547, -0.26759866572887653, 0.88970747503093428, -0.2641547127113183, 0.8892402490648097, -0.26066717144555002, 0.8887346688966784, -0.25713542641949133, 0.88818922179712623, -0.25355886720455589, 0.88760233315691228, -0.24993689002316327, 0.88697236395756274, -0.2462688994644108, 0.8862976081533982, -0.24255431035966554, 0.8855762899643248, -0.23879254983069415, 0.8848065610790965, -0.23498305952381671, 0.88398649776921867, -0.23112529804454351, 0.88311409791418538, -0.22721874360811975, 0.88218727793934348, -0.22326289692248877, 0.88120386966839237, -0.21925728432125349, 0.88016161709332708, -0.21520146116539543, 0.8790581730655509, -0.21109501553370594, 0.87789109591294434, -0.20693757222314302, 0.87665784598886909, -0.20272879708163113, 0.87535578216043619, -0.19846840169715774, 0.87398215824491687, -0.19415614846840831, 0.87253411940488401, -0.18979185608358345, 0.87100869851462948, -0.18537540543544537, 0.86940281251259288, -0.18090674600211523, 0.86771325875696315, -0.17638590272449642, 0.86593671140437201, -0.17181298341263937, 0.86406971783462982, -0.16718818671467794, 0.86210869514784572, -0.16251181068320436, 0.86004992676404846, -0.15778426197513568, 0.85788955915957443, -0.15300606572208986, 0.85562359877910188, -0.14817787610909788, 0.85324790916727411, -0.14330048770005241, 0.8507582083694275, -0.13837484754853369, 0.84815006665704717, -0.1334020681325484, 0.84541890464023883, -0.12838344115112613, 0.842559991836765, -0.12332045221964927, 0.83956844577510137, -0.11821479649899262, 0.83643923171746182, -0.11306839529106473, 0.83316716309795313, -0.1078834136299221, 0.82974690278085816, -0.10266227889320872, 0.82617296525454686, -0.097407700453023396, 0.82243971988767461, -0.092122690378301744, 0.81854139538606818, -0.086810585192259773, 0.81447208560102013, -0.081475068678054194, 0.81022575685247022, -0.076120195713468924, 0.80579625694368484, -0.070750417100824817, 0.80117732605739589, -0.065370605341185661, 0.79636260973670681, -0.059986081282061156, 0.79134567416722046, -0.054602641544861004, 0.78612002398946335, -0.049226586612145247, 0.78067912288245289, -0.043864749424906396, 0.77501641716969494, -0.038524524306515158, 0.76912536270754428, -0.033213895992354886, 0.76299945532211766, -0.027941468502378296, 0.75663226506405834, -0.022716493547768606, 0.75001747454974566, -0.017548898112561471, 0.74314892165199409, -0.012449310796595402, 0.73602064679198975, -0.0074290864477595669, 0.72862694506606951, -0.0025003285495845194, 0.72096242341469818, 0.0023240912345040155, 0.71302206300545212, 0.0070305170257081865, 0.70480128695564004, 0.011604496936149169, 0.6962960334619549, 0.016030776316759143, 0.68750283433308912, 0.020293296910987274, 0.67841889883507911, 0.024375202838028201, 0.669042202657401, 0.02825885438141525, 0.65937158168941101, 0.031925850600350712, 0.64940683016117584, 0.035357061808657553, 0.63914880254982398, 0.038532672975670555, 0.62859951848289319, 0.041432239090767958, 0.61776226968441728, 0.044034753493637988, 0.60664172781034598, 0.046318730101686398, 0.59524405180929263, 0.04826230035911, 0.58357699322768819, 0.049843325585264928, 0.57164999765921876, 0.051039525208920133, 0.55947430032451184, 0.051828621137141394, 0.54706301356549158, 0.052188498221072452, 0.53443120385887433, 0.052097380445656614, 0.521595955805497, 0.051534022088303134, 0.50857642044674556, 0.050477912666613514, 0.49539384520907648, 0.04890949403466955, 0.48207158279292395, 0.046810387500413504, 0.46863507641549423, 0.044163628336369172, 0.4551118189974051, 0.040953904557854359, 0.44153128415901377, 0.037167796365466244, 0.42792482726936504, 0.032794012212676617, 0.41432555526975218, 0.027823617087214158, 0.40076816457356218, 0.022250248309367664, 0.38728874701505456, 0.016070313973930054, 0.37392456457052287, 0.0092831691157606606, 0.36071379438614798, 0.0018912647788277568, 0.34769524649374478, -0.006099734571916632, 0.33490805745067131, -0.014680869431962578, 0.32239136396919038, -0.023839842978384793, 0.31018396137038046, -0.03356102093247379, 0.2983239523710457, -0.043825475482253219, 0.28684839225614672, -0.054611074187356626, 0.27579293687264067, -0.065892613713044598, 0.26519150007837883, -0.077641997122661649, 0.25507592727473871, -0.089828452342599591, 0.24547569143470757, -0.10241878834391491, 0.23641761761123842, -0.11537768460516037, 0.2279256412849219, -0.12866800857113636, 0.22002060510745766, -0.14225115513754957, 0.21272009764786703, -0.15608740169814991, 0.20603833669004326, -0.17013627200674286, 0.19998609850526014, -0.18435690203871186, 0.19457069337676863, -0.19870840118170127, 0.18979598653094235, -0.2131502024307029, 0.18566246257244604, -0.22764239578599313, 0.18216733056741466, -0.24214603972533527, 0.17930466609925008, -0.25662344640965662, 0.17706558595899616, -0.27103843714768139, 0.17543845064065805, -0.28535656555214517, 0.17440908949627479, -0.29954530673164398, 0.17396104326345699, -0.31357421174565442, 0.17407581869892713, -0.32741502737635331, 0.17473315021933986, -0.34104178201763258, 0.1759112637444441, -0.35443083913116152, 0.17758713833385092, -0.36756092026113357, 0.17973676168227809, -0.3804131000283355, 0.18233537606417952, -0.39297077583961648, 0.18535771187322325, -0.40521961525657918, 0.18877820646381263, -0.41714748407381147, 0.1925712065517286, -0.42874435817435441, 0.19671115295367669, -0.44000222216965434, 0.20117274692896087, -0.45091495770677981, 0.20593109782175348, -0.46147822415066808, 0.21096185208430365, -0.47168933413590436, 0.21624130408665998, -0.48154712624419754, 0.22174648938739244, -0.49105183680977643, 0.22745526135339764, -0.50020497259615115, 0.23334635217902985, -0.50900918583073396, 0.23939941946927121, -0.51746815283593006, 0.24559507962389918, -0.52558645726097009, 0.25191492929497517, -0.53336947870135143, 0.25834155619376259, -0.54082328729527496, 0.26485854050140573, -0.54795454470930194, 0.2714504480947757, -0.55477041177001229, 0.27810281674031306, -0.5612784628637344, 0.28480213633817775, -0.56748660711202514, 0.2915358242205367, -0.57340301623540924, 0.29829219642477917, -0.57903605894006116, 0.30506043577703806, -0.58439424160060083, 0.31183055753645611, -0.5894861549646877, 0.31859337326733467, -0.5943204265704467, 0.32534045352647728, -0.59890567854387589, 0.33206408987731884, -0.60325049042884704, 0.33875725667165235, -0.60736336669576907, 0.34541357297453468, -0.61125270857468517, 0.35202726494799019, -0.61492678986380789, 0.35859312895517814, -0.61839373637364592, 0.36510649559789116, -0.621661508679488, 0.37156319485718531, -0.624737887869804, 0.37795952246866915, -0.62763046399473632, 0.38429220763062577, -0.63034662693652832, 0.39055838211425598, -0.63289355944195369, 0.39675555082032665, -0.63527823207532508, 0.40288156380546286, -0.63750739986891147, 0.40893458978330816, -0.63958760046560703, 0.41491309109106755, -0.64152515356596229, 0.4208158000995435, -0.64332616150838029, 0.42664169703501947, -0.64499651082701248, 0.43238998917340415, -0.64654187464679125, 0.43806009136094998, -0.64796771578898904, 0.44365160781138147, -0.6492792904736423, 0.44916431512589677, -0.65048165251725321, 0.45459814648049629, -0.65157965793522532, 0.45995317692375443, -0.65257796986871974, 0.46522960972784355, -0.65348106376489956, 0.47042776373576323, -0.65429323274803164, 0.47554806164848618, -0.65501859312662236, 0.48059101919695085, -0.65566108998872419, 0.48555723514523336, -0.65622450284385292, 0.49044738207309752, -0.65671245127560329, 0.49526219788796355, -0.65712840057412847, 0.50000247801849962, -0.65747566732217688, 0.50466906824415536, -0.65775742491243117, 0.50926285811718208, -0.65797670897747718, 0.51378477493596297, -0.65813642271692274, 0.51823577823062283, -0.65823934210899782, 0.52261685472418151, -0.65828812099643874, 0.52692901373456058, -0.65828529603864816, 0.53117328298494504, -0.65823329152401266, 0.5353507047919468, -0.65813442403792821, 0.53946233260298326, -0.65799090698351381, 0.54350922785617017, -0.65780485495325403, 0.54749245713775296, -0.65757828795086271, 0.5514130896138506, -0.65731313546359116, 0.55527219471480849, -0.65701124038597447, 0.55907084005205765, -0.65667436279666691, 0.56281008954873479, -0.65630418359056863, 0.56649100176667211, -0.65590230796889593, 0.57011462841368499, -0.65547026879022752, 0.57368201301616228, -0.65500952978584315, 0.57719418974319558, -0.65452148864292281, 0.58065218236939364, -0.6540074799593375, 0.5840570033646042, -0.65346877807390646, 0.58740965309959248, -0.65290659977608267, 0.59071111915758534, -0.65232210689907044, 0.59396237574239752, -0.65171640880042769, 0.59716438317452558, -0.65109056473416882, 0.60031808746734105, -0.65044558611839609, 0.60342441997605678, -0.64978243870240815, 0.60648429711280283, -0.64910204463720267, 0.60949862012162082, -0.64840528445320744, 0.61246827490770739, -0.6476929989489818, 0.6153941319157199, -0.64696599099456398, 0.61827704605232503, -0.64622502725301612, 0.6211178566486375, -0.64547083982363784, 0.62391738745848657, -0.64470412781019648, 0.62667644668883937, -0.64392555881742752, 0.6293958270589981, -0.64313577037894198, 0.63207630588544927, -0.6423353713195622, 0.63471864518956744, -0.64152494305501395, 0.63732359182554199, -0.64070504083176982, 0.63989187762619515, -0.63987619490975445, 0.64242421956449425, -0.63903891169049576, 0.6449213199288103, -0.63819367479321321, 0.64738386651011348, -0.63734094608123237, 0.64981253279945705, -0.63648116664100207, 0.65220797819428045, -0.63561475771591669, 0.65457084821214995, -0.63474212159702159, 0.65690177471072742, -0.63386364247262428, 0.65920137611282958, -0.6329796872387039, 0.66147025763558553, -0.632090606271975, 0.66370901152275652, -0.63119673416732824, 0.66591821727940403, -0.63029839044133384, 0.66809844190815781, -0.62939588020339543, 0.67025024014639889, -0.62848949479606853, 0.67237415470377493, -0.62757951240600496, 0.67447071649947954, -0.62666619864688955, 0.67654044489883536, -0.6257498071157046, 0.6785838479487305, -0.62483057992356228, 0.68060142261152767, -0.62390874820231113, 0.68259365499711377, -0.62298453258805642, 0.68456102059276547, -0.62205814368267598, 0.68650398449059435, -0.62112978249437401, 0.68842300161231129, -0.6201996408582493, 0.69031851693112933, -0.61926790183782787, 0.69219096569061489, -0.61833474010844336, 0.69404077362034555, -0.61740032232332342, 0.69586835714824946, -0.61646480746319066, 0.69767412360950454, -0.61552834717014893, 0.69945847145193552, -0.61459108606659141, 0.7012217904378073, -0.61365316205982745, 0.70296446184199035, -0.61271470663309879, 0.704686858646426, -0.61177584512361372, 0.70638934573088907, -0.61083669698820486, 0.70807228006001233, -0.60989737605718797, 0.70973601086657101, -0.60895799077696422, 0.71138087983103171, -0.60801864444189058, 0.71300722125736615, -0.60707943541590936, 0.71461536224515909, -0.60614045734441768, 0.71620562285802003, -0.6052017993568144, 0.71777831628833788, -0.60426354626016388, 0.71933374901840885, -0.60332577872437687, 0.72087222097797143, -0.60238857345929953, 0.72239402569820121, -0.60145200338408067, 0.72389945046219806, -0.60051613778916535, 0.72538877645202859, -0.59958104249125799, 0.72686227889235977, -0.59864677998156401, 0.72832022719075062, -0.59771340956762353, 0.72976288507465004, -0.59678098750902164, 0.73119051072515462, -0.59584956714725212, 0.73260335690759459, -0.59491919903000112, 0.7340016710989915, -0.59398993103009479, 0.73538569561246536, -0.59306180845935852, 0.73675566771863232, -0.59213487417760724, 0.73811181976406681, -0.59120916869698725, 0.73945437928688595, -0.59028473028188178, 0.74078356912950538, -0.58936159504456453, 0.74209960754864845, -0.58843979703680571, 0.74340270832264344, -0.58751936833759255, 0.74469308085609254, -0.58660033913715193, 0.74597093028194916, -0.5856827378174263, 0.7472364575610827, -0.58476659102916106, 0.74848985957937353, -0.58385192376575834, 0.74973132924240216, -0.58293875943402795, 0.75096105556779102, -0.58202711992198175, 0.75217922377524526, -0.58111702566378898, 0.75338601537436256, -0.58020849570202571, 0.75458160825024834, -0.57930154774733167, 0.75576617674700408, -0.57839619823558019, 0.7569398917491349, -0.57749246238268459, 0.75810292076092323, -0.57659035423712102, 0.75925542798383061, -0.57568988673028776, 0.76039757439196176, -0.57479107172477506, 0.76152951780565525, -0.57389392006064921, 0.76265141296323335, -0.57299844159982349, 0.76376341159096961, -0.57210464526860749, 0.76486566247130727, -0.571212539098506, 0.76595831150938753, -0.57032213026534107, 0.76704150179791708, -0.56943342512677564, 0.76811537368042393, -0.56854642925829435, 0.7691800648129461, -0.56766114748771845, 0.77023571022418269, -0.56677758392830591, 0.77128244237416277, -0.56589574201050485, 0.77232039121145191, -0.56501562451241061, 0.77334968422895034, -0.56413723358897994, 0.77437044651831144, -0.56326057080006386, 0.77538280082301547, -0.56238563713729162, 0.77638686759013831, -0.56151243304986997, 0.7773827650208428, -0.5606409584693316, 0.77837060911963474, -0.55977121283328124, 0.77935051374240538, -0.55890319510817943, 0.78032259064330156, -0.55803690381120064, 0.78128694952044675, -0.55717233703121249, 0.78224369806054683, -0.55630949244889749, 0.78319294198241041, -0.55544836735607139, 0.78413478507940781, -0.55458895867420943, 0.78506932926090234, -0.55373126297223219, 0.78599667459267319, -0.55287527648356993, 0.78691691933636454, -0.55202099512253411, 0.78783015998798156, -0.55116841450003351, 0.78873649131545442, -0.46287812444749799, 0.87639478645679203, -0.46175682177008232, 0.87689138038570558, -0.46063084482896283, 0.87738760785823233, -0.45950014866980415, 0.87788345908975163, -0.45836468775401717, 0.87837892404060525, -0.45722441594973212, 0.8788739924097615, -0.45607928652261581, 0.87936865362831018, -0.45492925212652424, 0.87986289685278241, -0.4537742647939953, 0.88035671095830148, -0.45261427592657183, 0.88085008453154268, -0.45144923628495531, 0.88134300586351544, -0.4502790959789868, 0.88183546294214588, -0.44910380445745052, 0.88232744344466574, -0.44792331049769868, 0.88281893472979722, -0.44673756219509214, 0.88330992382972673, -0.44554650695225523, 0.88380039744186423, -0.4443500914681402, 0.88429034192038225, -0.44314826172689764, 0.88477974326752307, -0.44194096298655111, 0.8852685871246756, -0.440728139767469, 0.88575685876320509, -0.43950973584063407, 0.88624454307503975, -0.43828569421570274, 0.88673162456299581, -0.43705595712885315, 0.88721808733084251, -0.43582046603041685, 0.88770391507309354, -0.43457916157229148, 0.88818909106451893, -0.43333198359512692, 0.88867359814937008, -0.43207887111528603, 0.88915741873030696, -0.43081976231157143, 0.88964053475701987, -0.42955459451171579, 0.89012292771453749, -0.42828330417863231, 0.89060457861121034, -0.42700582689641808, 0.89108546796636012, -0.42572209735611072, 0.89156557579758522, -0.42443204934118717, 0.89204488160771267, -0.42313561571280678, 0.89252336437138391, -0.42183272839478941, 0.89300100252126546, -0.42052331835832735, 0.89347777393387084, -0.41920731560642172, 0.89395365591498432, -0.41788464915804391, 0.89442862518467192, -0.41655524703201424, 0.89490265786186851, -0.41521903623059164, 0.89537572944852795, -0.41387594272277239, 0.8958478148133211, -0.41252589142729168, 0.89631888817487104, -0.41116880619532237, 0.89678892308450664, -0.40980460979286615, 0.89725789240852438, -0.40843322388283121, 0.89772576830993844, -0.40705456900679488, 0.89819252222970769, -0.40566856456643813, 0.89865812486741903, -0.40427512880465588, 0.89912254616141274, -0.40287417878633103, 0.89958575526833173, -0.40146563037876981, 0.90004772054207449, -0.40004939823179164, 0.9005084095121374, -0.39862539575747041, 0.90096778886132245, -0.39719353510951655, 0.90142582440279162, -0.39575372716230267, 0.90188248105644897, -0.39430588148951728, 0.90233772282462754, -0.39284990634244982, 0.90279151276705771, -0.39138570862789579, 0.90324381297509615, -0.38991319388567941, 0.90369458454519014, -0.38843226626578753, 0.90414378755155345, -0.38694282850510714, 0.90459138101802727, -0.38544478190376658, 0.90503732288910199, -0.38393802630106733, 0.90548157000006946, -0.382422460051008, 0.90592407804627972, -0.38089797999739122, 0.90636480155147314, -0.37936448144850976, 0.9068036938351558, -0.37782185815140518, 0.90724070697898895, -0.37627000226569646, 0.9076757917921594, -0.37470880433697185, 0.9081088977756947, -0.3731381532697382, 0.90853997308569545, -0.37155793629992634, 0.90896896449543885, -0.36996803896694452, 0.90939581735632624, -0.3683683450852791, 0.90982047555762746, -0.36675873671563403, 0.91024288148498922, -0.36513909413560924, 0.91066297597766077, -0.36350929580991348, 0.91108069828439686, -0.36186921836010494, 0.91149598601799398, -0.36021873653386138, 0.91190877510841184, -0.35855772317377393, 0.9123189997544332, -0.35688604918566419, 0.91272659237381459, -0.35520358350642006, 0.91313148355187457, -0.35351019307135162, 0.913533601988467, -0.35180574278106314, 0.91393287444328608, -0.35009009546784564, 0.91432922567944419, -0.34836311186158225, 0.91472257840526394, -0.346624650555175, 0.91511285321422731, -0.34487456796948862, 0.91549996852301085, -0.34311271831781665, 0.91588384050754967, -0.34133895356987126, 0.91626438303705615, -0.33955312341529936, 0.91664150760592766, -0.33775507522673259, 0.91701512326346513, -0.33594465402237322, 0.91738513654133302, -0.33412170242812278, 0.91775145137867586, -0.3322860606392653, 0.91811396904481579, -0.33043756638170674, 0.91847258805944232, -0.32857605487278702, 0.91882720411020924, -0.32670135878167245, 0.91917770996764947, -0.32481330818934251, 0.91952399539730822, -0.32291173054818478, 0.91986594706900615, -0.3209964506412149, 0.92020344846312041, -0.31906729054094018, 0.92053637977379199, -0.31712406956788325, 0.92086461780893691, -0.31516660424879273, 0.9211880358869593, -0.31319470827456136, 0.92150650373004672, -0.31120819245787951, 0.92181988735392195, -0.30920686469065084, 0.92212804895393474, -0.3071905299012086, 0.92243084678735465, -0.30515899001135716, 0.92272813505173612, -0.30311204389328628, 0.92301976375921257, -0.30104948732639297, 0.92330557860657714, -0.29897111295405793, 0.92358542084099704, -0.296876710240427, 0.92385912712120721, -0.29476606542724243, 0.9241265293740234, -0.29263896149079327, 0.92438745464600158, -0.29049517809903436, 0.92464172495007824, -0.28833449156894803, 0.92488915710700359, -0.28615667482421603, 0.92512956258138501, -0.2839614973532808, 0.92536274731215051, -0.28174872516787802, 0.92558851153722332, -0.27951812076213445, 0.92580664961220849, -0.27726944307231643, 0.92601694982287142, -0.27500244743734686, 0.92621919419118603, -0.27271688556019225, 0.92641315827472481, -0.27041250547024104, 0.9265986109591472, -0.26808905148680379, 0.92677531424353854, -0.26574626418387143, 0.92694302301835074, -0.26338388035627958, 0.92710148483566479, -0.26100163298743401, 0.92725043967151743, -0.25859925121877392, 0.92738961967999101, -0.25617646032114499, 0.92751874893878383, -0.25373298166828517, 0.92763754318594926, -0.2512685327126245, 0.92774570954749347, -0.24878282696362522, 0.92784294625550046, -0.24627557396890015, 0.92792894235645262, -0.24374647929835763, 0.92800337740939698, -0.24119524453165395, 0.92806592117359343, -0.23862156724923608, 0.92811623328528026, -0.23602514102729033, 0.92815396292316821, -0.23340565543692121, 0.92817874846226978, -0.23076279604792191, 0.9281902171156533, -0.22809624443751172, 0.92818798456370277, -0.22540567820443641, 0.92817165457044892, -0.22269077098887197, 0.92814081858652309, -0.21995119249858414, 0.92809505533827485, -0.2171866085418343, 0.92803393040258131, -0.21439668106755133, 0.92795699576685764, -0.21158106821333006, 0.92786378937377267, -0.20873942436184495, 0.9277538346501536, -0.20587140020631275, 0.92762664001955242, -0.20297664282567396, 0.92748169839793737, -0.2000547957702187, 0.92731848667195516, -0.19710549915840769, 0.92713646515919612, -0.1941283897857177, 0.92693507704989031, -0.19112310124636045, 0.92671374782944127, -0.18808926406881324, 0.92647188468119734, -0.18502650586613417, 0.9262088758688557, -0.18193445150210236, 0.92592409009786969, -0.1788127232743095, 0.92561687585524022, -0.17566094111536945, 0.92528656072705062, -0.1724787228135144, 0.92493245069310537, -0.16926568425390975, 0.92455382939802677, -0.16602143968210911, 0.92414995739816008, -0.16274560199116866, 0.92372007138364165, -0.15943778303401571, 0.92326338337498293, -0.15609759396278808, 0.92277907989352648, -0.15272464559695462, 0.9222663211051465, -0.14931854882213855, 0.92172423993656172, -0.14587891502169745, 0.92115194116366805, -0.14240535654321773, 0.92054850047128844, -0.13889748720224185, 0.91991296348378948, -0.13535492282565517, 0.91924434476602335, -0.1317772818373385, 0.91854162679410256, -0.12816418588882436, 0.91780375889555132, -0.12451526053787214, 0.91702965615842891, -0.12083013597804826, 0.91621819830907847, -0.11710844782257543, 0.91536822855822486, -0.11334983794590933, 0.91447855241521359, -0.10955395538671198, 0.91354793647029042, -0.10572045731607334, 0.9125751071448962, -0.10184901007509518, 0.91155874941008985, -0.097939290286147396, 0.91049750547332742, -0.093990986042367095, 0.90938997343397954, -0.090003798180218073, 0.90823470590812427, -0.085977441640194177, 0.90703020862334616, -0.081911646921030229, 0.90577493898447148, -0.077806161633045615, 0.90446730461139746, -0.07366075215657937, 0.90310566185043251, -0.069475205411745969, 0.90168831426084495, -0.065249330746078013, 0.9002135110786289, -0.060982961946937191, 0.8986794456598467, -0.056675959385912161, 0.89708425390628921, -0.052328212302762168, 0.89542601267661948, -0.047939641236805157, 0.89370273818662005, -0.043510200614019313, 0.89191238440269904, -0.03903988149845633, 0.89005284143334895, -0.034528714516935254, 0.88812193392387873, -0.029976772966345041, 0.88611741946041656, -0.025384176113212427, 0.88403698698991506, -0.02075109269555437, 0.88187825526369423, -0.016077744637342666, 0.87963877131293988, -0.011364410986239774, 0.87731600896552753, -0.0066114320855370111, 0.87490736741458164, -0.0018192139914966876, 0.87241016985031039, 0.003011766852480096, 0.86982166216786538, 0.007880958673251056, 0.86713901176531538, 0.012787729145161901, 0.8643593064472328, 0.01773135987531212, 0.86147955345093175, 0.022711040585053965, 0.85849667861406409, 0.027725862976026631, 0.85540752570403333, 0.032774814269236702, 0.85220885593160145, 0.037856770405973281, 0.8488973476731011, 0.042970488899839461, 0.84546959642781594, 0.04811460132974224, 0.84192211503941439, 0.053287605464495291, 0.83825133421275444, 0.058487857010660088, 0.83445360335997232, 0.063713560976433825, 0.83052519181247142, 0.068962762645889727, 0.82646229043831787, 0.074233338159596457, 0.82226101370749061, 0.0795229846997106, 0.81791740225058729, 0.084829210280051248, 0.81342742595977113, 0.090149323144485219, 0.80878698768406887, 0.095480420780187356, 0.80399192757450066, 0.10081937855603361, 0.79903802813797242, 0.10616283800066188, 0.79392102006227816, 0.11150719473949067, 0.78863658887800503, 0.11684858611542831, 0.78318038252647149, 0.12218287852405134, 0.77754801990608058, 0.12750565450082932, 0.7717351004724986, 0.13281219960548715, 0.76573721497085168, 0.13809748915693448, 0.75954995738061537, 0.14335617488134345, 0.75316893815581276, 0.14858257154600846, 0.74658979884464283, 0.15377064366255416, 0.73980822817338876, 0.15891399235489756, 0.73281997967944124, 0.16400584250017308, 0.72562089097725424, 0.16903903026450395, 0.71820690473887394, 0.17400599117009949, 0.71057409146725559, 0.17889874884554366, 0.70271867413554145, 0.1837089046273839, 0.69463705475876991, 0.1884276281978943, 0.68632584295577459, 0.19304564946130323, 0.67778188654816895, 0.19755325187843323, 0.66900230422996909, 0.2019402674975144, 0.65998452032542643, 0.20619607393658845, 0.65072630163369749, 0.21030959359006007, 0.64122579633696841, 0.21426929534824068, 0.63148157492315871, 0.21806319913369787, 0.62149267304542966, 0.22167888357134502, 0.6112586362080461, 0.22510349711994351, 0.60077956613169359, 0.22832377300036208, 0.59005616861118315, 0.23132604825991165, 0.57908980263439436, 0.234096287311471, 0.56788253048380999, 0.2366201102803388, 0.55643716849100122, 0.2388828264797288, 0.54475733806059223, 0.24086947331692266, 0.53284751652390505, 0.24256486090532053, 0.52071308732469279, 0.2439536226222935, 0.5083603889803977, 0.24502027180797326, 0.49579676220424046, 0.24574926474543524, 0.48303059451625013, 0.24612506999742362, 0.47007136161789315, 0.2461322440987849, 0.45692966475554675, 0.24575551351673389, 0.44361726325577955, 0.24497986269346456, 0.43014710138135426, 0.24379062787774397, 0.41653332863346421, 0.24217359633501537, 0.40279131261548157, 0.24011511040049424, 0.38893764357766891, 0.23760217570847617, 0.37499012978426804, 0.23462257279586426, 0.36096778288468984, 0.23116497114145634, 0.34689079253206845, 0.22721904456793451, 0.33278048957571144, 0.22277558680426612, 0.31865929726018838, 0.21782662588640356, 0.3045506699933388, 0.21236553596762492, 0.29047901939745674, 0.2063871450212954, 0.27646962753211046, 0.19988783685200215, 0.26254854737026939, 0.19286564579054355, 0.24874249082009842, 0.185320342437683, 0.23507870480851101, 0.17725350884398708, 0.22158483617462529, 0.16866860157157956, 0.20828878635752746, 0.1595710011790184, 0.19521855709553407, 0.14996804680441203, 0.1824020885789808, 0.13986905469257274, 0.1698670917069334, 0.12928531971861248, 0.15764087628491949, 0.11823009919913663, 0.14575017715830113, 0.10671857854855125, 0.13422098039844091, 0.094767818627005562, 0.12307835174172212, 0.08239668493021951, 0.11234626951934486, 0.069625759083625963, 0.10204746430703164, 0.056477233414431872, 0.092203267465629998, 0.04297478967796229, 0.082833470637006731, 0.029143463299571033, 0.073956198105676663, 0.015009494753243277, 0.065587793738972763, 0.00060016992475633033, 0.057742723981818712, -0.014056348505316148, 0.05043349811242686, -0.028931196480037554, 0.043670606670099248, -0.043994988512459164, 0.037462478653269959, -0.059217999840922977, 0.031815457764285002, -0.074570348479972376, 0.026733797655239575, -0.09002217490780122, 0.022219675815646985, -0.10554381723196965, 0.018273225445475366, -0.12110597981810094, 0.014892584383501535, -0.13667989354555299, 0.0120739599174591, -0.15223746606425897, 0.0098117080936005064, -0.16775142065993093, 0.0080984259731588914, -0.18319542258459665, 0.0069250551536393212, -0.19854419196760575, 0.0062809947848414052, -0.2137736026823609, 0.0061542222625023246, -0.2288607667995983, 0.0065314197746290589, -0.24378410450228324, 0.0073981049042788852, -0.25852339956640791, 0.008738763554066482, -0.27305984072041783, 0.010536983547808213, -0.28737604938186723, 0.012775587378700829, -0.30145609443008775, 0.015436762706458811, -0.31528549480709966, 0.018502189352853624, -0.32885121084587982, 0.021953161701450084, -0.34214162530466435, 0.025770705568284383, -0.35514651514085271, 0.029935688772016585, -0.36785701508828028, 0.034428924790590378, -0.38026557411083695, 0.039231269044089676, -0.39236590579456759, 0.044323707487225306, -0.40415293371317146, 0.049687437328116132, -0.41562273276039624, 0.055303939811142469, -0.42677246738955044, 0.061155045109529738, -0.43760032763878859, 0.067222989467944458, -0.44810546375200216, 0.073490464816004325, -0.45828792013266351, 0.079940661141151906, -0.46814856929278048, 0.086557301963804886, -0.47768904638342152, 0.093324673300048885, -0.48691168481879205, 0.10022764652847614, -0.49581945343305123, 0.10725169559860495, -0.50441589553994737, 0.11438290903035545, -0.51270507019975886, 0.12160799715786362, -0.52069149593729203, 0.12891429506803576, -0.52838009709860978, 0.13628976167543197, -0.53577615298322812, 0.14372297536145887, -0.54288524984297415, 0.1512031265886046, -0.5497132357979071, 0.158720007879874, -0.556266178684382, 0.16626400153126386, -0.5625503268193347, 0.17382606540082929, -0.56857207263887011, 0.18139771709319319, -0.57433791914706411, 0.18897101683288967, -0.5798544490928631, 0.1965385492947504, -0.5851282967784468, 0.20409340463480749, -0.59016612239098942, 0.2116291589409881, -0.59497458874139586, 0.21913985429990712, -0.59956034028749594, 0.22661997865389941, -0.60392998431559042, 0.23406444560188019, -0.60809007415225136, 0.24146857427801097, -0.61204709427820014, 0.24882806942428709, -0.61580744721716851, 0.2561390017564309, -0.61937744207497014, 0.26339778870721253, -0.62276328460727115, 0.27060117561752989, -0.62597106869845554, 0.27774621743284295, -0.62900676913859388, 0.28483026095142017, -0.63187623559042161, 0.29185092766053417, -0.63458518764356386, 0.29880609718790796, -0.63713921085867276, 0.30569389138764813, -0.63954375370969319, 0.3125126590729318, -0.64180412533810516, 0.31926096140169435, -0.64392549403845722, 0.32593755791617002, -0.64591288640002098, 0.33254139323276638, -0.6477711870346321, 0.33907158437476131, -0.6495051388259665, 0.34552740873720805, -0.65111934364039559, 0.3519082926706717, -0.6526182634442933, 0.35821380066823283, -0.65400622177715173, 0.3644436251385022, -0.65528740553410059, 0.3705975767459016, -0.65646586701544152, 0.3766755752985626, -0.65754552620455575, 0.38267764116331499, -0.65853017323907947, 0.38860388718688038, -0.65942347104352084, 0.39445451110202534, -0.66022895809455096, 0.40022978839739126, -0.66095005129304996, 0.40593006562982503, -0.66159004891959716, 0.41155575415819667, -0.66215213365254222, 0.41710732427811265, -0.66263937563000552, 0.42258529973724968, -0.663054735539225, 0.42799025261166224, -0.66340106771853602, 0.43332279852388522, -0.66368112325899531, 0.43858359218428533, -0.66389755309423315, 0.44377332323783253, -0.66405291106854081, 0.4488927123989902, -0.66414965697450912, 0.45394250785828683, -0.66419015955270522, 0.45892348194464383, -0.66417669944694602, 0.46383642802839481, -0.66411147210969235, 0.46868215765050947, -0.66399659065294647, 0.47346149786425945, -0.66383408864083304, 0.47817528877627147, -0.66362592282072519, 0.48282438127449279, -0.66337397579041968, 0.48740963493133904, -0.6630800585994141, 0.49193191607079401, -0.66274591328284171, 0.49639209598896489, -0.66237321532705806, 0.50079104931806884, -0.66196357606626888, 0.50512965252443476, -0.66151854500992113, 0.50940878253165822, -0.66103961210090045, 0.51362931546049428, -0.66052820990481653, 0.51779212547765041, -0.65998571573091469, 0.52189808374601854, -0.65941345368532434, 0.52594805746940165, -0.65881269665754416, 0.52994290902518859, -0.65818466824120248, 0.53388349517879152, -0.65753054459024507, 0.53777066637413395, -0.65685145621182395, 0.54160526609472204, -0.65614848969722117, 0.54538813029028976, -0.65542268939223536, 0.54912008686421898, -0.65467505900848677, 0.55280195521733499, -0.65390656317715323, 0.55643454584390184, -0.65311812894668297, 0.56001865997592659, -0.6523106472260275, 0.56355508927216746, -0.65148497417497575, 0.56704461554842212, -0.65064193254315528, 0.57048801054596143, -0.64978231295926936, 0.57388603573512031, -0.6489068751721293, 0.57723944215132605, -0.64801634924502727, 0.58054897026095531, -0.64711143670497495, 0.58381534985465211, -0.64619281164830866, 0.58703929996587079, -0.64526112180414608, 0.59022152881254331, -0.6443169895571349, 0.59336273375997561, -0.64336101293092407, 0.59646360130312703, -0.64239376653373303, 0.59952480706664601, -0.64141580246738661, 0.60254701582106529, -0.64042765120112577, 0.60553088151373535, -0.63942982241148194, 0.60847704731315466, -0.63842280578946764, 0.61138614566542504, -0.63740707181629119, 0.61425879836171227, -0.63638307250877779, 0.61709561661560441, -0.6353512421356311, 0.61989720114940561, -0.63431199790565018, 0.62266414228841815, -0.63326574062896013, 0.62539702006237574, -0.63221285535229699, 0.6280964043132431, -0.63115371196934833, 0.6307628548086297, -0.63008866580710465, 0.63339692136017689, -0.62901805818916789, 0.63599914394626333, -0.62794221697689867, 0.63857005283848622, -0.62686145708928553, 0.64111016873135585, -0.62577608100236093, 0.6436200028747453, -0.6246863792289693, 0.64610005720863173, -0.62359263077966887, 0.64855082449971235, -0.62249510360550708, 0.65097278847953144, -0.62139405502339029, 0.65336642398375222, -0.6202897321247367, 0.65573219709227226, -0.61918237216808192, 0.65807056526987295, -0.6180722029562703, 0.66038197750715144, -0.61695944319884788, 0.66266687446148509, -0.61584430286025105, 0.66492568859779788, -0.61472698349435517, 0.66715884432894668, -0.61360767856592702, 0.66936675815552027, -0.61248657375950588, 0.67154983880490826, -0.61136384727622073, 0.67370848736946776, -0.6102396701190177, 0.67584309744366866, -0.60911420636676572, 0.67795405526009167, -0.60798761343769137, 0.68004173982415961, -0.60686004234255753, 0.68210652304752628, -0.60573163792800877, 0.68414876988000639, -0.60460253911046558, 0.68616883844000676, -0.60347287910095782, 0.68816708014335315, -0.60234278562124643, 0.69014383983048477, -0.60121238111159048, 0.69209945589195332, -0.60008178293049153, 0.69403426039217331, -0.59895110354672987, 0.69594857919140896, -0.59782045072401258, 0.6978427320659456, -0.59668992769850815, 0.69971703282643682, -0.59555963334957285, 0.70157178943439069, -0.59442966236392281, 0.70340730411680041, -0.59330010539351818, 0.70522387347889082, -0.59217104920741293, 0.70702178861497766, -0.59104257683780026, 0.70880133521745081, -0.58991476772049489, 0.71056279368385356, -0.58878769783005791, 0.71230643922209558, -0.58766143980979291, 0.71403254195377064, -0.58653606309680051, 0.71574136701561475, -0.5854116340422918, 0.71743317465910406, -0.58428821602735392, 0.71910822034819832, -0.58316586957433225, 0.72076675485526231, -0.5820446524540156, 0.72240902435515941, -0.58092461978877585, 0.72403527051755923, -0.57980582415183457, 0.72564573059745208, -0.57868831566279166, 0.72724063752391599, -0.57757214207957697, 0.7288202199871332, -0.57645734888695332, 0.73038470252369914, -0.57534397938171056, 0.73193430560023509, -0.57423207475467797, 0.73346924569532423, -0.57312167416967552, 0.73498973537981094, -0.57201281483953048, 0.73649598339546851, -0.57090553209925876, 0.73798819473207899, -0.56979985947653711, 0.73946657070293109, -0.56869582875955671, 0.74093130901877946, -0.56759347006236482, 0.74238260386028165, -0.56649281188779332, 0.74382064594893482, -0.56539388118805811, 0.74524562261655269, -0.56429670342313065, 0.7466577178732875, -0.563201302616952, 0.74805711247424755, -0.56210770141158628, 0.7494439839847119, -0.56101592111938181, 0.75081850684398632, -0.55992598177321706, 0.75218085242791788, -0.55883790217490992, 0.75353118911009043, -0.5577516999418527, 0.75486968232173857, -0.55666739155194467, 0.75619649461038896, -0.55558499238688175, 0.75751178569726829, -0.55450451677387114, 0.75881571253349234, -0.55342597802582549, 0.76010842935506584, -0.55234938848009363, 0.76139008773671768, -0.55127475953578708, 0.76266083664458673, -0.36080306559945502, 0.91963661288229004, -0.35939135739132749, 0.92006918115923553, -0.35797356030073729, 0.92050038661972278, -0.35654961912651623, 0.92093020548942206, -0.35511947801427335, 0.92135861350812165, -0.35368308044757441, 0.92178558591914572, -0.35224036923900082, 0.92221109745851704, -0.35079128652108221, 0.92263512234386447, -0.34933577373710029, 0.92305763426306409, -0.34787377163176841, 0.92347860636260759, -0.346405220241776, 0.9238980112356947, -0.34493005888620604, 0.92431582091003506, -0.34344822615681808, 0.92473200683535983, -0.34195965990819699, 0.925146539870631, -0.34046429724776667, 0.92555939027093859, -0.33896207452566657, 0.92597052767408494, -0.33745292732449078, 0.92637992108683909, -0.33593679044888552, 0.92678753887085774, -0.3344135979150078, 0.92719334872826453, -0.33288328293984054, 0.92759731768687292, -0.33134577793036513, 0.92799941208505077, -0.32980101447258786, 0.92839959755621171, -0.3282489233204216, 0.92879783901292323, -0.32668943438442, 0.92919410063062735, -0.32512247672036343, 0.92958834583095407, -0.32354797851769418, 0.92998053726462437, -0.3219658670878045, 0.93037063679392928, -0.32037606885216907, 0.93075860547477107, -0.31877850933032931, 0.931144403538259, -0.31717311312772106, 0.93152799037184442, -0.31555980392335009, 0.93190932449998354, -0.31393850445731358, 0.93228836356431655, -0.31230913651816339, 0.93266506430334617, -0.31067162093011685, 0.93303938253160745, -0.30902587754010769, 0.93341127311830907, -0.30737182520468442, 0.93378068996543595, -0.30570938177674689, 0.93414758598529646, -0.30403846409212859, 0.93451191307750014, -0.30235898795602262, 0.93487362210534652, -0.30067086812924587, 0.93523266287161533, -0.29897401831435139, 0.93558898409373736, -0.29726835114158012, 0.93594253337832611, -0.29555377815465927, 0.93629325719505974, -0.2938302097964432, 0.93664110084988861, -0.29209755539440013, 0.93698600845755353, -0.29035572314594665, 0.93732792291339395, -0.28860462010362614, 0.93766678586442664, -0.28684415216013981, 0.93800253767967401, -0.28507422403322613, 0.93833511741972098, -0.28329473925039378, 0.93866446280548077, -0.28150560013350739, 0.93899051018614288, -0.27970670778323253, 0.93931319450628659, -0.27789796206333722, 0.93963244927212886, -0.27607926158485968, 0.93994820651688971, -0.27425050369013682, 0.94026039676524398, -0.27241158443670599, 0.94056894899683696, -0.27056239858107811, 0.94087379060883758, -0.26870283956238838, 0.94117484737749835, -0.26683279948592914, 0.94147204341869772, -0.26495216910656888, 0.94176530114743318, -0.26306083781206685, 0.94205454123623744, -0.26115869360628147, 0.94233968257248379, -0.25924562309228827, 0.94262064221455177, -0.25732151145540755, 0.9428973353468183, -0.25538624244615205, 0.94316967523344231, -0.25343969836310226, 0.94343757317090704, -0.25148176003571815, 0.9437009384392846, -0.2495123068070971, 0.94395967825218408, -0.24753121651668489, 0.94421369770535057, -0.24553836548295732, 0.94446289972386943, -0.2435336284860751, 0.94470718500793993, -0.24151687875053329, 0.94494645197717442, -0.2394879879278092, 0.94518059671338295, -0.23744682607903128, 0.94540951290179565, -0.23539326165767935, 0.94563309177068189, -0.23332716149232918, 0.94585122202931471, -0.23124839076946754, 0.94606378980423778, -0.22915681301638516, 0.94627067857377978, -0.22705229008417505, 0.94647176910077091, -0.22493468213085138, 0.94666693936340363, -0.2228038476046128, 0.94685606448418769, -0.22065964322727166, 0.94703901665694123, -0.21850192397787879, 0.94721566507176391, -0.2163305430765588, 0.94738587583792577, -0.21414535196859552, 0.94754951190462244, -0.21194620030878983, 0.94770643297952173, -0.2097329359461213, 0.94785649544504824, -0.20750540490874811, 0.9479995522723299, -0.20526345138937899, 0.94813545293274759, -0.20300691773105453, 0.94826404330700942, -0.20073564441337463, 0.94838516559168229, -0.19844947003921615, 0.9484986582031063, -0.19614823132198198, 0.9486043556786109, -0.19383176307342939, 0.94870208857496185, -0.19149989819212354, 0.94879168336394948, -0.18915246765257104, 0.94887296232504192, -0.18678930049508666, 0.94894574343501381, -0.18441022381644648, 0.949009840254463, -0.18201506276139603, 0.94906506181112515, -0.17960364051507188, 0.94911121247989638, -0.17717577829640396, 0.94914809185945992, -0.17473129535257562, 0.94917549464542705, -0.17227000895460906, 0.94919321049988858, -0.16979173439416478, 0.94920102391727046, -0.16729628498162766, 0.94919871408639167, -0.16478347204558164, 0.94918605474861018, -0.16225310493375514, 0.94916281405195069, -0.15970499101554286, 0.94912875440109123, -0.15713893568620557, 0.94908363230309922, -0.15455474237285616, 0.94902719820879022, -0.15195221254235425, 0.94895919634958525, -0.14933114571121794, 0.94887936456974187, -0.14669133945769949, 0.94878743415382871, -0.14403258943614461, 0.94868312964930679, -0.14135468939378748, 0.94856616868408594, -0.13865743119012922, 0.94843626177891027, -0.1359406048190562, 0.94829311215443535, -0.13320399843387021, 0.94813641553284822, -0.13044739837540498, 0.94796585993388238, -0.12767058920340837, 0.94778112546507098, -0.12487335373139659, 0.94758188410609112, -0.1220554730651781, 0.94736779948702976, -0.1192167266452645, 0.94713852666041953, -0.11635689229340174, 0.94689371186687377, -0.11347574626345305, 0.9466329922941541, -0.11057306329689735, 0.94635599582950114, -0.10764861668319688, 0.94606234080505769, -0.10470217832532498, 0.9457516357362018, -0.10173351881074058, 0.94542347905261959, -0.098742407488125614, 0.94507745882193217, -0.095728612550204026, 0.94471315246569887, -0.092691901122995093, 0.94433012646760772, -0.089632039361852989, 0.94392793607367187, -0.086548792554674597, 0.94350612498424313, -0.083441925232678918, 0.94306422503765619, -0.08031120128917181, 0.94260175588531614, -0.077156384106740902, 0.94211822465803563, -0.073977236693340734, 0.94161312562344168, -0.070773521827760033, 0.94108593983426148, -0.067545002214981165, 0.94053613476729936, -0.064291440651965223, 0.93996316395292379, -0.06101260020443651, 0.93936646659488454, -0.0577082443952543, 0.93874546718028029, -0.05437813740499766, 0.93809957507950537, -0.051022044285416165, 0.93742818413600648, -0.04763973118643601, 0.93673067224568896, -0.044230965597442773, 0.93600640092581688, -0.040795516603599702, 0.93525471487326384, -0.037333155157985985, 0.93447494151197286, -0.033843654370410252, 0.93366639052950984, -0.030326789813744929, 0.93282835340258574, -0.026782339848728191, 0.93196010291146436, -0.023210085968165407, 0.93106089264315917, -0.019609813161561952, 0.9301299564833726, -0.015981310301229443, 0.92916650809711643, -0.012324370550966095, 0.92816974039800915, -0.0086387917984861902, 0.92713882500624656, -0.0049243771127915259, 0.92607291169528272, -0.0011809352277657819, 0.92497112782728197, 0.0025917189466909368, 0.92383257777744088, 0.0063937637845967055, 0.92265634234732108, 0.010225370373437693, 0.92144147816736288, 0.014086701911832469, 0.92018701708880291, 0.017977913073711813, 0.91889196556527508, 0.021899149337376925, 0.91755530402441321, 0.025850546277708431, 0.9161759862298422, 0.02983222881972511, 0.91475293863401752, 0.033844310451633955, 0.91328505972241392, 0.037886892395403778, 0.91177121934969008, 0.041960062732852577, 0.91021025806848033, 0.046063895485121749, 0.90860098645160858, 0.050198449643350497, 0.90694218440858454, 0.054363768148273109, 0.9052326004973581, 0.058559876816370073, 0.9034709512324296, 0.062786783210123515, 0.90165592039053144, 0.067044475449841767, 0.89978615831522724, 0.071332920964408644, 0.89786028122193862, 0.075652065178271791, 0.89587687050503662, 0.080001830131834858, 0.89383447204883792, 0.084382113032377776, 0.89173159554450043, 0.088792784732531424, 0.8895667138150205, 0.093233688133237666, 0.88733826215074518, 0.097704636508061493, 0.88504463765803554, 0.10220541174562887, 0.88268419862395675, 0.10673576250691379, 0.88025526390013087, 0.1112954022940042, 0.87775611230917205, 0.11588400742693475, 0.8751849820774058, 0.12050121492511875, 0.8725400702979067, 0.12514662028986742, 0.86981953242821153, 0.12981977518444912, 0.86702148182743044, 0.1345201850081284, 0.8641439893378684, 0.1392473063606236, 0.86118508291665519, 0.14400054439341858, 0.85814274732333495, 0.14877925004441181, 0.85501492386981237, 0.15358271715244035, 0.85179951023953038, 0.15841017944827046, 0.84849436038328263, 0.16326080741878951, 0.84509728449958244, 0.16813370504122635, 0.841606049108093, 0.17302790638444532, 0.83801837722520878, 0.17794237207451372, 0.83433194865151528, 0.1828759856220433, 0.83054440038149946, 0.18782754960906969, 0.8266533271465718, 0.1927957817335991, 0.82265628210317321, 0.1977793107103471, 0.81855077767848305, 0.20277667202666921, 0.81433428658701057, 0.20778630355322922, 0.81000424303213758, 0.21280654100952412, 0.80555804410751608, 0.21783561328512516, 0.80099305141403976, 0.22287163761824474, 0.79630659290896677, 0.22791261463410806, 0.79149596500465169, 0.23295642324661803, 0.78655843493520206, 0.23800081542784693, 0.78149124341025977, 0.24304341085113512, 0.77629160757599169, 0.24808169141488692, 0.77095672430420825, 0.25311299565563067, 0.76548377383141519, 0.25813451306051582, 0.75986992377036888, 0.26314327829120415, 0.75411233351750506, 0.26813616533301543, 0.74820815908032257, 0.2731098815852902, 0.74215455834943189, 0.27806096191121066, 0.73594869684055841, 0.2829857626677591, 0.72958775393221309, 0.28788045573913829, 0.72306892962511893, 0.29274102259980611, 0.71638945184961145, 0.29756324843632664, 0.7095465843472597, 0.30234271636042565, 0.70253763515278356, 0.30707480174910801, 0.69535996570188496, 0.31175466675126901, 0.68801100058997, 0.31637725500408798, 0.68048823800572245, 0.32093728660641174, 0.67278926086224933, 0.32542925340055262, 0.66491174864679004, 0.32984741461818801, 0.65685349000794369, 0.33418579295048217, 0.64861239609684318, 0.33843817110708679, 0.64018651467567933, 0.3425980889332545, 0.63157404500345182, 0.34665884115893542, 0.62277335350467877, 0.35061347585829522, 0.6137829902220916, 0.35445479370262756, 0.60460170604889485, 0.35817534809400436, 0.59522847073010288, 0.36176744627115065, 0.58566249161559114, 0.36522315148291318, 0.57590323313991665, 0.36853428632813556, 0.56595043699551972, 0.371692437363766, 0.5558041429567302, 0.37468896108537059, 0.54546471030189869, 0.37751499138591293, 0.53493283977016381, 0.38016144859944845, 0.52420959597762196, 0.38261905023621717, 0.51329643020523241, 0.3848783235142903, 0.50219520345759805, 0.38692961979036644, 0.49090820967784327, 0.38876313098824378, 0.47943819898946122, 0.39036890811793096, 0.46778840082094447, 0.39173688197096701, 0.45596254675390901, 0.39285688606830588, 0.44396489291989888, 0.39371868192587212, 0.43180024175571119, 0.39431198668946843, 0.41947396291188838, 0.39462650317507653, 0.40699201309449651, 0.39465195233262157, 0.39436095460621817, 0.39437810813090074, 0.38158797234032471, 0.39379483483862315, 0.36868088896939322, 0.39289212665140827, 0.355648178061437, 0.39166014958717116, 0.34249897484843667, 0.3900892855427785, 0.32924308436760219, 0.38817017837331524, 0.3158909866938322, 0.38589378182207856, 0.30245383898317529, 0.38325140909479494, 0.28894347405256499, 0.38023478383588466, 0.27537239523015294, 0.37683609222852366, 0.26175376722460186, 0.37304803590401608, 0.24810140277991838, 0.36886388531047432, 0.23442974490594534, 0.36427753315653444, 0.22075384450310753, 0.35928354751347358, 0.20708933323343123, 0.35387722412958689, 0.19345239152881727, 0.34805463748452353, 0.17985971167081491, 0.34181269008968873, 0.16632845592481418, 0.33514915952399654, 0.15287620976372684, 0.32806274268359009, 0.139520930272683, 0.32055309671992199, 0.12628088988559499, 0.31262087614341028, 0.11317461566569026, 0.30426776558079394, 0.10022082440539208, 0.29549650769284863, 0.087438353883567035, 0.28631092578658279, 0.074846090680962152, 0.27671594069144623, 0.062462895014452388, 0.26671758151328107, 0.050307523108044636, 0.2563229899318481, 0.038398547670909146, 0.24554041776736948, 0.026754277099303343, 0.23437921760841579, 0.015392674059237528, 0.2228498263658259, 0.0043312741381433453, 0.21096374169524676, -0.006412894723262369, 0.19873349131194384, -0.016823391295051119, 0.18617259530537941, -0.026884437891648384, 0.17329552164531717, -0.036580994257019654, 0.16011763515507868, -0.045898827802943319, 0.14665514030894858, -0.054824579532241506, 0.13292501828808917, -0.063345825019959445, 0.11894495880158396, -0.07145112987629984, 0.10473328724411915, -0.079130099175616711, 0.090308887819088496, -0.086373420403935336, 0.075691123303376295, -0.09317289955297782, 0.060899752167786939, -0.099521490069395369, 0.045954843793711168, -0.10541331445277959, 0.030876692541951422, -0.11084367838323304, 0.015685731433785901, -0.115809077347201, 0.0004024461967106373, -0.1203071958172858, -0.014952709590702318, -0.12433689912627775, -0.03035939754944118, -0.12789821825617032, -0.045797475078881905, -0.13099232783806558, -0.061247072843366508, -0.13362151772744396, -0.076688668600632726, -0.13578915858036725, -0.09210315686625313, -0.13749966190869553, -0.10747191397393516, -0.13875843513617345, -0.12277685815987077, -0.13957183221151728, -0.1380005043703024, -0.13994710035953656, -0.15312601356282077, -0.13989232356677031, -0.16813723634264385, -0.13941636340450209, -0.18301875084448965, -0.13852879778962995, -0.1977558948364177, -0.13723985827346069, -0.21233479208495945, -0.13556036643064348, -0.2267423730782018, -0.13350166989613363, -0.24096639025659369, -0.13107557856795893, -0.25499542794789987, -0.12829430145883888, -0.26881890724381829, -0.12517038464108185, -0.28242708609071682, -0.12171665068771774, -0.29581105489523224, -0.11794613996949666, -0.30896272796835, -0.11387205412278781, -0.32187483114774917, -0.1095077019587252, -0.33454088594943771, -0.10486644803952347, -0.34695519060520819, -0.09996166410460712, -0.35911279834317639, -0.094806683487605348, -0.37100949326538307, -0.089414758625578655, -0.38264176416866302, -0.083799021724857356, -0.39400677664447725, -0.077972448613434123, -0.40510234377951287, -0.071947825778553756, -0.41592689576304592, -0.06573772055978376, -0.42647944868906429, -0.059354454442745903, -0.43675957282183048, -0.052810079376782476, -0.4467673605734826, -0.046116357020817261, -0.45650339442112536, -0.039284740806010167, -0.46596871497004433, -0.03232636069061199, -0.47516478934833251, -0.025252010472366058, -0.48409348009774467, -0.018072137515849386, -0.49275701470527844, -0.010796834746862364, -0.50115795590058709, -0.0034358347626000448, -0.50929917282590442, 0.0040014940951384869, -0.51718381316751771, 0.011506149856089925, -0.52481527632160863, 0.019069497377831354, -0.53219718765187984, 0.026683267289934837, -0.53933337388255942, 0.034339553569798557, -0.54622783965736621, 0.042030809888870049, -0.552884745283586, 0.049749844862504805, -0.55930838566989582, 0.057489816330423577, -0.56550317045729181, 0.065244224788106986, -0.57147360533439451, 0.073006906082685147, -0.577224274521146, 0.08077202347962735, -0.58275982439891993, 0.088534059199611922, -0.5880849482597007, 0.096287805517589892, -0.59320437214275479, 0.10402835550919898, -0.59812284172355246, 0.11175109352266011, -0.6028451102168555, 0.11945168544759015, -0.60737592725373324, 0.12712606884577882, -0.61172002869054687, 0.13477044300261681, -0.61588212730695824, 0.14238125895213793, -0.61986690434927971, 0.14995520952286301, -0.62367900187533376, 0.15748921944650462, -0.62732301585708805, 0.16498043556655342, -0.63080348999773717, 0.17242621717916445, -0.63412491022068207, 0.17982412653454233, -0.6372916997886614, 0.18717191952293211, -0.6403082150125069, 0.19446753656581955, -0.64317874151012244, 0.20170909372943546, -0.64590749097775957, 0.20889487407475496, -0.64849859843703228, 0.21602331925527979, -0.65095611992267388, 0.22309302137142611, -0.65328403057760709, 0.23010271508808888, -0.65548622312345672, 0.23705127001985279, -0.65756650667627536, 0.24393768338660055, -0.65952860587880968, 0.25076107294052591, -0.66137616032224888, 0.25752067016427582, -0.6631127242319288, 0.26421581373859532, -0.66474176639298532, 0.27084594327675915, -0.66626667029345843, 0.27741059332224349, -0.66769073446373439, 0.28390938760509959, -0.6690171729926484, 0.29034203355200988, -0.67024911620185301, 0.29670831704424139, -0.67138961146136744, 0.30300809741739654, -0.67244162413041442, 0.30924130269638206, -0.67340803860882059, 0.31540792505872139, -0.67429165948536052, 0.3215080165191877, -0.67509521277044804, 0.32754168482843715, -0.67582134720159048, 0.33350908957837166, -0.67647263561092241, 0.33941043850674091, -0.67705157634503155, 0.34524598399363199, -0.67756059472809693, 0.35101601974241686, -0.6780020445601338, 0.35672087763781385, -0.67837820964286066, 0.3623609247738695, -0.67869130532637545, 0.36793656064465963, -0.67894348007045169, 0.37344821449078697, -0.67913681701485606, 0.37889634279476792, -0.67927333555362757, 0.38428142691866934, -0.67935499290876045, 0.38960397087749643, -0.67938368569920482, 0.39486449924197325, -0.67936125150152593, 0.40006355516466607, -0.67928947039896403, 0.405201698523454, -0.67917006651600875, 0.41027950417669568, -0.67900470953593139, 0.4152975603245137, -0.67879501619903881, 0.42025646697093222, -0.67854255177969469, 0.42515683448173974, -0.67824883154041848, 0.42999928223314948, -0.67791532216160899, 0.43478443734660094, -0.67754344314566473, 0.4395129335051281, -0.67713456819446349, 0.44418540984703153, -0.67669002655936028, 0.44880250993267679, -0.67621110436301013, 0.45336488078051201, -0.67569904589249086, 0.45787317196849475, -0.6751550548633225, 0.46232803479736623, -0.67458029565411004, 0.46673012151233634, -0.67397589451164353, 0.47108008457988854, -0.67334294072639056, 0.47537857601664896, -0.67268248777840622, 0.47962624676729815, -0.67199555445375647, 0.48382374612878087, -0.67128312593163708, 0.48797172121808396, -0.67054615484241553, 0.49207081648108503, -0.66978556229688901, 0.4961216732400589, -0.66900223888710053, 0.50012492927752772, -0.66819704565908733, 0.50408121845434151, -0.6673708150579879, 0.50799117035987806, -0.66652435184594594, 0.5118554099924788, -0.66565843399329894, 0.51567455746822244, -0.66477381354353815, 0.51944922775633617, -0.66387121745256272, 0.52318003043958239, -0.66295134840276326, 0.52686756949804248, -0.66201488559246657, 0.530512443114868, -0.66106248550131064, 0.53411524350255479, -0.66009478263209209, 0.53767655674847337, -0.65911239022966561, 0.54119696267836781, -0.65811590097745076, 0.54467703473669005, -0.6571058876721122, 0.54811733988263767, -0.65608290387698798, 0.5515184385008558, -0.65504748455481354, 0.55488088432583182, -0.65400014668031259, 0.5582052243790282, -0.6529413898331955, 0.56149199891791457, -0.65187169677212198, 0.56474174139603617, -0.65079153399015832, 0.56795497843337517, -0.64970135225226555, 0.57113222979625733, -0.64860158711534188, 0.57427400838611309, -0.64749265943132628, 0.57738082023646276, -0.64637497583387715, 0.58045316451749629, -0.64524892920910815, 0.58349153354769923, -0.64411489915088038, 0.58649641281195808, -0.64297325240110792, 0.58946828098566795, -0.64182434327554794, 0.59240760996435415, -0.64066851407553305, 0.59531486489835372, -0.6395060954860684, 0.59819050423216402, -0.63833740696074692, 0.60103497974803255, -0.63716275709387959, 0.60384873661345595, -0.63598244398026782, 0.60663221343220897, -0.6347967555629983, 0.60938584229860615, -0.63360596996965812, 0.61211004885468701, -0.6324103558373444, 0.61480525235002081, -0.63121017262682455, 0.61747186570390522, -0.63000567092621618, 0.62011029556966868, -0.6287970927445149, 0.62272094240088127, -0.62758467179531863, 0.62530420051922386, -0.62636863377106233, 0.62786045818384462, -0.62514919660808099, 0.63039009766199317, -0.62392657074280922, 0.63289349530075711, -0.62270095935940362, 0.63537102159975611, -0.62147255862908746, 0.63782304128461009, -0.62024155794147895, 0.64024991338107462, -0.61900814012818828, 0.64265199128967399, -0.61777248167892873, 0.64502962286074095, -0.61653475295040261, 0.6473831504697376, -0.61529511836820439, 0.64971291109273477, -0.61405373662197138, 0.652019236381988, -0.6128107608540192, 0.65430245274147913, -0.61156633884166944, 0.65656288140237851, -0.61032061317349928, 0.65880083849831261, -0.60907372141970251, 0.66101663514040176, -0.60782579629677624, 0.66321057749197021, -0.60657696582671317, 0.66538296684289511, -0.6053273534908945, 0.66753409968352229, -0.60407707837886182, 0.6696642677780994, -0.60282625533213596, 0.67177375823769336, -0.60157499508326318, 0.67386285359252973, -0.60032340439023502, 0.67593183186373906, -0.59907158616645551, 0.67798096663444918, -0.59781963960639339, 0.68001052712021803, -0.59656766030707209, 0.68202077823876228, -0.59531574038554425, 0.68401198067895841, -0.59406396859247224, 0.68598439096910435, -0.59281243042196397, 0.68793826154440307, -0.59156120821777802, 0.68987384081367598, -0.59031038127603008, 0.69179137322526185, -0.58906002594451201, 0.69369109933211281, -0.58781021571874426, 0.69557325585606555, -0.5865610213348722, 0.69743807575127137, -0.58531251085950464, 0.69928578826679644, -0.58406474977661293, 0.70111661900836386, -0.58281780107157299, 0.70293078999925274, -0.58157172531246437, 0.70472851974033357, -0.58032658072870236, 0.70651002326925239, -0.57908242328710402, 0.70827551221875651, -0.5778393067654739, 0.71002519487415372, -0.256691719541563, 0.95048539982992797, -0.25499693993141798, 0.95079800438173789, -0.25329496173334437, 0.9511078374613352, -0.25158572552397934, 0.95141485809573023, -0.2498691712729047, 0.95171902458397573, -0.24814523833631819, 0.95202029448295811, -0.24641386545066563, 0.95231862459288608, -0.24467499072622675, 0.95261397094246347, -0.24292855164066096, 0.95290628877374872, -0.24117448503251465, 0.95319553252668587, -0.23941272709468367, 0.95348165582330202, -0.23764321336784375, 0.95376461145156566, -0.2358658787338416, 0.95404435134889443, -0.23408065740904946, 0.95432082658530593, -0.23228748293768975, 0.95459398734620393, -0.23048628818512354, 0.95486378291478879, -0.22867700533111332, 0.95513016165408793, -0.22685956586305286, 0.95539307098859194, -0.22503390056917408, 0.95565245738548965, -0.22319993953172901, 0.95590826633549619, -0.22135761212014987, 0.95616044233325659, -0.21950684698418876, 0.95640892885732276, -0.21764757204704249, 0.95665366834968968, -0.21577971449846059, 0.9568946021948791, -0.2139032007878453, 0.95713167069856575, -0.21201795661733952, 0.95736481306572951, -0.21012390693491256, 0.95759396737832336, -0.20822097592744254, 0.95781907057244997, -0.20630908701380196, 0.9580400584150297, -0.20438816283794659, 0.95825686547995015, -0.2024581252620162, 0.95846942512368671, -0.20051889535944861, 0.95867766946037958, -0.19857039340810886, 0.95888152933635284, -0.19661253888344565, 0.95908093430406627, -0.19464525045167097, 0.95927581259548467, -0.19266844596297575, 0.95946609109484704, -0.19068204244478151, 0.95965169531082906, -0.18868595609503505, 0.95983254934807694, -0.18668010227555643, 0.96000857587810173, -0.1846643955054374, 0.96017969610951837, -0.18263874945450612, 0.9603458297576114, -0.18060307693685959, 0.96050689501321651, -0.17855728990447309, 0.96066280851089314, -0.17650129944089313, 0.96081348529638055, -0.17443501575502218, 0.96095883879331478, -0.17235834817500584, 0.96109878076918664, -0.17027120514222424, 0.96123322130053124, -0.16817349420540706, 0.96136206873732011, -0.16606512201487283, 0.96148522966654448, -0.1639459943169076, 0.96160260887496707, -0.16181601594829109, 0.96171410931102341, -0.15967509083098325, 0.9618196320458503, -0.15752312196698023, 0.96191907623342532, -0.15536001143335681, 0.96201233906978945, -0.15318566037749895, 0.96209931575133723, -0.15099996901255108, 0.96217989943214688, -0.14880283661308313, 0.9622539811803319, -0.14659416151099583, 0.96232144993338675, -0.14437384109167944, 0.96238219245250567, -0.14214177179043852, 0.96243609327584789, -0.13989784908920655, 0.96248303467072605, -0.13764196751355726, 0.96252289658469081, -0.13537402063004228, 0.96255555659548353, -0.1330939010438652, 0.96258088985983636, -0.13080150039691696, 0.96259876906108366, -0.12849670936619134, 0.96260906435556448, -0.12617941766260271, 0.9626116433177816, -0.12384951403023055, 0.96260637088429035, -0.12150688624600826, 0.96259310929628739, -0.11915142111989235, 0.96257171804086727, -0.11678300449552459, 0.96254205379091862, -0.1144015212514267, 0.96250397034361912, -0.11200685530274464, 0.96245731855751038, -0.10959888960358238, 0.9624019462881066, -0.10717750614994929, 0.96233769832200977, -0.10474258598335287, 0.96226441630949289, -0.10229400919507742, 0.96218193869551993, -0.099831654931176225, 0.96209010064916045, -0.097355401398218952, 0.96198873399136697, -0.094865125869830105, 0.96187766712107425, -0.092360704694059298, 0.96175672493958242, -0.089842013301624848, 0.96162572877318631, -0.087308926215077923, 0.96148449629400645, -0.08476131705892391, 0.96133284143898867, -0.082199058570759514, 0.96117057432702235, -0.079622022613467791, 0.96099750117413862, -0.077030080188525002, 0.96081342420674842, -0.074423101450474954, 0.96061814157287184, -0.071800955722623613, 0.960411447251314, -0.069163511514018089, 0.96019313095874825, -0.066510636537765469, 0.9599629780546538, -0.063842197730759095, 0.95972076944406393, -0.061158061274880521, 0.959466281478078, -0.058458092619742878, 0.95919928585208813, -0.055742156507050535, 0.95891954950167058, -0.053010116996651313, 0.95862683449609676, -0.050261837494361021, 0.95832089792940767, -0.047497180781637192, 0.95800149180900485, -0.04471600904719833, 0.95766836294170821, -0.041918183920667783, 0.95732125281722291, -0.039103566508342263, 0.95695989748897181, -0.036272017431181726, 0.95658402745223092, -0.033423396865118742, 0.95619336751952244, -0.030557564583799244, 0.9557876366932101, -0.027674380003856271, 0.95536654803523968, -0.024773702232844658, 0.95492980853397436, -0.021855390119941146, 0.95447711896807252, -0.0189193023095502, 0.95400817376734603, -0.015965297297933778, 0.95352266087055504, -0.012993233493006427, 0.95302026158007624, -0.01000296927744081, 0.95250065041339904, -0.0069943630752181815, 0.95196349495138577, -0.0039672734217928076, 0.95140845568325572, -0.00092155903801971473, 0.95083518584822924, 0.0021429210919837278, 0.95024333127378613, 0.0052263076388702383, 0.9496325302104851, 0.0083287408418077948, 0.9490024131632957, 0.011450360417751999, 0.94835260271939326, 0.014591305466042552, 0.94768271337236998, 0.017751714368134115, 0.94699235134281312, 0.020931724682234115, 0.94628111439521434, 0.024131473032637459, 0.94554859165115823, 0.027351094993524727, 0.94479436339875722, 0.030590724966985013, 0.94401800089829491, 0.033850496055018574, 0.94321906618404017, 0.037130539925252712, 0.94239711186220476, 0.040430986670115292, 0.94155168090501629, 0.043751964659173179, 0.94068230644088047, 0.047093600384354881, 0.9397885115406166, 0.050456018297750677, 0.93886980899974981, 0.053839340641678265, 0.93792570111684936, 0.05724368727069009, 0.93695567946791347, 0.060669175465178374, 0.93595922467679782, 0.064115919736235052, 0.9349358061816998, 0.067584031621393509, 0.93388488199771147, 0.071073619470876856, 0.93280589847547202, 0.074584788223960044, 0.9316982900559424, 0.078117639175038431, 0.93056147902135189, 0.081672269728978203, 0.92939487524236264, 0.085248773145305892, 0.92819787592152181, 0.088847238270795104, 0.92696986533306391, 0.092467749259963511, 0.92571021455916302, 0.096110385283002628, 0.92441828122272285, 0.099775220220626182, 0.92309340921682881, 0.10346232234532238, 0.92173492843098426, 0.10717175398846242, 0.92034215447428269, 0.11090357119270282, 0.91891438839567885, 0.11465782334910479, 0.91745091640154086, 0.1184345528183765, 0.91595100957069153, 0.12223379453560355, 0.91441392356716034, 0.12605557559784542, 0.91283889835089993, 0.12989991483392382, 0.9112251578867403, 0.13376682235573473, 0.90957190985188274, 0.1376562990903677, 0.9078783453422663, 0.14156833629232102, 0.90614363857816393, 0.14550291503506302, 0.90436694660940542, 0.14946000568116971, 0.90254740902065467, 0.15343956733025724, 0.90068414763720916, 0.15744154724389178, 0.89877626623182161, 0.16146588024665076, 0.89682285023309793, 0.16551248810248201, 0.8948229664360543, 0.16958127886547925, 0.89277566271548425, 0.17367214620419238, 0.89067996774280844, 0.17778496869854318, 0.88853489070716773, 0.18191960910842123, 0.88633942104153973, 0.1860759136130008, 0.88409252815475659, 0.19025371101980787, 0.88179316117032647, 0.19445281194255307, 0.87944024867306192, 0.19867300794671269, 0.87703269846456577, 0.20291407066186021, 0.87456939732871475, 0.20717575085969214, 0.87204921080834774, 0.21145777749672662, 0.86947098299446024, 0.21575985672061165, 0.8668335363292845, 0.22008167083899124, 0.86413567142473735, 0.22442287724987089, 0.86137616689779994, 0.22878310733242158, 0.8585537792245137, 0.2331619652971576, 0.85566724261437477, 0.23755902699446216, 0.85271526890701288, 0.24197383868039526, 0.84969654749318135, 0.24640591573878196, 0.84660974526218857, 0.25085474135857677, 0.84345350657803619, 0.25531976516553295, 0.84022645328667178, 0.25980040180723812, 0.83692718475689276, 0.26429602949061448, 0.83355427795760129, 0.2688059884710548, 0.83010628757424088, 0.27332957949237269, 0.82658174616742797, 0.2778660621768706, 0.8229791643769454, 0.2824146533648505, 0.81929703117443453, 0.28697452540302881, 0.81553381416830384, 0.29154480438136499, 0.81168795996456089, 0.29612456831796591, 0.80775789458744685, 0.30071284529183356, 0.80374202396396577, 0.30530861152334748, 0.79963873447659251, 0.30991078940256178, 0.79544639358864322, 0.31451824546554291, 0.79116335054700482, 0.31912978831915878, 0.78678793716713991, 0.32374416651496257, 0.78231846870548283, 0.32836006637301574, 0.77775324482457697, 0.33297610975676778, 0.77309055065650889, 0.33759085180036058, 0.76832865797042849, 0.34220277859004844, 0.76346582645015559, 0.34681030480172065, 0.75850030508808741, 0.35141177129689594, 0.7534303337018502, 0.35600544267991102, 0.74825414458032757, 0.36058950481944374, 0.74296996426592743, 0.36516206233797388, 0.73757601548010676, 0.36972113607322671, 0.73207051919939981, 0.37426466051617335, 0.72645169688932998, 0.37879048123071907, 0.72071777290374928, 0.3832963522607698, 0.71486697705729463, 0.38777993353100665, 0.70889754737874955, 0.39223878824835096, 0.70280773305318323, 0.39667038031181451, 0.69659579756080947, 0.40107207173915949, 0.69026002202051384, 0.40544112011958977, 0.68379870874598569, 0.40977467610250878, 0.67721018502234476, 0.41406978093325836, 0.67049280711101344, 0.4183233640476563, 0.6636449644904614, 0.42253224073809759, 0.65666508434018744, 0.42669310990497372, 0.64955163627505486, 0.43080255190819461, 0.64230313733669098, 0.43485702653464103, 0.63491815724827549, 0.43885287109849097, 0.62739532393846331, 0.44278629869245201, 0.61973332933960512, 0.44665339660909931, 0.61193093546469246, 0.45045012495265629, 0.60398698076663293, 0.45417231546274178, 0.59590038678251389, 0.45781567057277567, 0.5876701650644317, 0.46137576272688602, 0.57929542439730175, 0.46484803398035096, 0.57077537830267844, 0.46822779590970209, 0.56210935282617014, 0.47151022985973162, 0.5532967946043712, 0.47469038755567389, 0.54433727920544439, 0.47776319210981766, 0.53523051973554681, 0.48072343945269086, 0.52597637570111222, 0.48356580021975654, 0.51657486211476833, 0.48628482212523444, 0.50702615883013136, 0.4888749328552075, 0.49733062008809586, 0.49133044351253535, 0.487488784254406, 0.49364555264629362, 0.47750138372528755, 0.49581435089845671, 0.46736935497475102, 0.49783082630025616, 0.45709384871387249, 0.4996888702501816, 0.44667624012882468, 0.50138228420475583, 0.43611813916090597, 0.50290478711212205, 0.42542140078799012, 0.50425002361703697, 0.41458813526306371, 0.50541157306400941, 0.40362071826157558, 0.50638295932315125, 0.39252180088536842, 0.50715766146062724, 0.38129431946704978, 0.50772912527254432, 0.36994150511462465, 0.50809077569754701, 0.35846689293244299, 0.50823603011937968, 0.34687433085066244, 0.50815831256612931, 0.33516798799187902, 0.50785106880784203, 0.32335236250010568, 0.50730778234865137, 0.31143228875429885, 0.50652199130348474, 0.2994129438856451, 0.50548730614287274, 0.28729985351568721, 0.5041974282822852, 0.2750988966301457, 0.50264616948494345, 0.26281630950225732, 0.50082747203902234, 0.25045868857836789, 0.49873542966185685, 0.23803299223863725, 0.49636430907502738, 0.22554654134632773, 0.49370857218517111, 0.2130070185005454, 0.4907628987962338, 0.20042246590985627, 0.48752220976943322, 0.18780128180727826, 0.48398169053791407, 0.17515221533173456, 0.48013681487367854, 0.16248435980615811, 0.47598336879528802, 0.1498071443490358, 0.47151747449594628, 0.13713032376369369, 0.46673561416316961, 0.12446396665816781, 0.46163465355340788, 0.11181844175845158, 0.45621186517776252, 0.099204402388470989, 0.45046495094874711, 0.086632769102359619, 0.44439206413260218, 0.074114710467140535, 0.43799183044753542, 0.061661622007880203, 0.43126336814541399, 0.049285103342015503, 0.42420630691272043, 0.036996933544539687, 0.4168208054268368, 0.024809044801995472, 0.40910756740505472, 0.012733494428945702, 0.40106785598730826, 0.00078243533752891199, 0.39270350629849526, -0.011031914933245268, 0.38401693604331538, -0.022697306505249659, 0.37501115399532403, -0.034201490626944976, 0.36568976625238031, -0.04553225416286491, 0.35605698014328985, -0.056677454937909065, 0.34611760568436312, -0.067625057754471821, 0.33587705450061306, -0.078363170888022318, 0.32534133614345295, -0.088880082856436296, 0.31451705175557743, -0.099164299249304574, 0.30341138505338278, -0.10920457939666831, 0.29203209061823315, -0.1189899726515781, 0.28038747950933507, -0.12850985405819601, 0.26848640223290743, -0.13775395917683414, 0.25633822912469545, -0.14671241783911329, 0.24395282822472575, -0.15537578661099385, 0.23134054074517324, -0.16373507974802681, 0.21851215425300613, -0.17178179843649014, 0.2054788737093296, -0.17950795812543935, 0.19225229052611664, -0.18690611376833602, 0.17884434981831862, -0.19396938280865977, 0.165267316045068, -0.20069146576133401, 0.15153373724714347, -0.20706666426100703, 0.13765640809960192, -0.21308989646867965, 0.12364833200747313, -0.21875670974989331, 0.10952268247934516, -0.22406329056009552, 0.095292764018051063, -0.22900647149579625, 0.080971972769200318, -0.233583735493468, 0.06657375716801063, -0.23779321718115232, 0.052111578821263618, -0.24163370141068366, 0.037598873856015236, -0.24510461902047975, 0.023049014958620433, -0.24820603990011167, 0.0084752743177285549, -0.25093866344788635, -0.006109212326861139, -0.25330380653131507, -0.020691480341544454, -0.25530338907736921, -0.035258769389229179, -0.25693991743467637, -0.049798554996298927, -0.25821646566320383, -0.064298578356878008, -0.25913665491829707, -0.078746874253656285, -0.25970463110526704, -0.093131796992963325, -0.25992504098790675, -0.10744204427083191, -0.2598030069394115, -0.12166667890594919, -0.25934410052723733, -0.13579514839376339, -0.25855431512445848, -0.14981730225483131, -0.25744003773931806, -0.16372340716771616, -0.2560080202520017, -0.17750415989398285, -0.25426535024332636, -0.19115069801862009, -0.25221942159415534, -0.20465460854391784, -0.24987790502717563, -0.21800793438880423, -0.24724871875419865, -0.23120317885760855, -0.24433999938276355, -0.24423330815354058, -0.24116007322550928, -0.25709175202160944, -0.23771742814485514, -0.26977240261410157, -0.23402068605406592, -0.28226961167857939, -0.23007857618399452, -0.29457818617376019, -0.22589990921288003, -0.30669338242314731, -0.22149355234449794, -0.31861089891884053, -0.21686840540817323, -0.33032686789015786, -0.21203337804238417, -0.34183784575191301, -0.20699736801246169, -0.35314080254721869, -0.20176924070185137, -0.36423311049809831, -0.19635780980606496, -0.37511253177510961, -0.19077181924859463, -0.38577720559439876, -0.18501992632876438, -0.39622563474679789, -0.17911068610303754, -0.40645667165974786, -0.17305253699328163, -0.4164695040879724, -0.16685378760846575, -0.42626364052411997, -0.16052260475963639, -0.43583889541509985, -0.15406700264242007, -0.44519537426456385, -0.14749483315610426, -0.4543334586962684, -0.14081377732403585, -0.46325379154734403, -0.13403133777637305, -0.47195726205493077, -0.12715483225300578, -0.48044499119377915, -0.12019138808212185, -0.4887183172170807, -0.11314793758775694, -0.49677878144710175, -0.10603121437840701, -0.50462811435715094, -0.098847750467678297, -0.51226822198116306, -0.091603874177528091, -0.51970117268239679, -0.08430570877450097, -0.52692918430816271, -0.076959171789560757, -0.53395461175301528, -0.069569974972761087, -0.54077993494889776, -0.062143624834714473, -0.54740774729676001, -0.054685423728020377, -0.55384074455072729, -0.047200471422981123, -0.56008171416254882, -0.03969366713346846, -0.5661335250910623, -0.032169711950398666, -0.57199911807871218, -0.02463311164192562, -0.57768149639459232, -0.017088179781387013, -0.58318371704134608, -0.0095390411657665774, -0.58850888242115851, -0.0019896354895132451, -0.59366013245442117, 0.0055562787596628374, -0.59864063714300353, 0.013095120214328609, -0.60345358956876094, 0.020623480379611217, -0.608102199316779, 0.028138119251761219, -0.61258968631181143, 0.035635960828556842, -0.6169192750556447, 0.043114088535387972, -0.62109418925236437, 0.050569740588923252, -0.62511764680808268, 0.058000305318691221, -0.62899285519122494, 0.065403316465121333, -0.63272300713920249, 0.072776448471004701, -0.63631127669720444, 0.080117511781921363, -0.63976081557464526, 0.087424448169521177, -0.64307474980494161, 0.09469532609040375, -0.64625617669426738, 0.10192833609181036, -0.64930816204517017, 0.10912178627430627, -0.65223373764107684, 0.11627409782035109, -0.6550358989780094, 0.12338380059659798, -0.65771760323011896, 0.13044952883683067, -0.66028176743596267, 0.13747001691136748, -0.66273126689285533, 0.14444409518806273, -0.66506893374694886, 0.15137068598903938, -0.66729755576717131, 0.15824879964673333, -0.66941987529151437, 0.16507753066199665, -0.67143858833462189, 0.17185605396644232, -0.6733563438460769, 0.17858362129068686, -0.67517574310918271, 0.18525955763949448, -0.67689933927052903, 0.19188325787452989, -0.67852963699102653, 0.19845418340482188, -0.68006909220955625, 0.20497185898479559, -0.68152011201080698, 0.21143586961932748, -0.6828850545892664, 0.21784585757492417, -0.68416622930179372, 0.22420151949599071, -0.68536589680155302, 0.23050260362473601, -0.68648626924651923, 0.23674890712323762, -0.68752951057610834, 0.24294027349582703, -0.68849773684989235, 0.24907659010995933, -0.68939301664268093, 0.25515778581349574, -0.69021737149059592, 0.26118382864622042, -0.69097277638312149, 0.26715472364341741, -0.69166116029638214, 0.27307051072910515, -0.69228440676324032, 0.27893126269662594, -0.69284435447606751, 0.28473708327410918, -0.69334279791832831, 0.29048810527241281, -0.69378148802137563, 0.2961844888130224, -0.69416213284309891, 0.30182641963347373, -0.69448639826531267, 0.30741410746781583, -0.6947559087069809, 0.31294778449962307, -0.69497224785059863, 0.31842770388517005, -0.69513695937924747, 0.32385413834428101, -0.69525154772202313, 0.32922737881654124, -0.69531747880572525, 0.33454773318044678, -0.69533618081085402, 0.33981552503323381, -0.69530904493012713, 0.34503109252911146, -0.69523742612787187, 0.35019478727363818, -0.69512264389878897, 0.35530697327214184, -0.6949659830247199, 0.36036802592999195, -0.69476869432816235, 0.36537833110273049, -0.69453199542140698, 0.37033828419398646, -0.6942570714502605, 0.37524828929927506, -0.69394507583143317, 0.3801087583937619, -0.69359713098275988, 0.38492011056213676, -0.69321432904549807, 0.38968277126886269, -0.69279773259805411, 0.39439717166701693, -0.69234837536053262, 0.39906374794411648, -0.69186726288960054, 0.40368294070325639, -0.69135537326320795, 0.40825519437805519, -0.69081365775476877, 0.4127809566798803, -0.6902430414964722, 0.41726067807590522, -0.68964442413142657, 0.42169481129662328, -0.68901868045440584, 0.42608381087144581, -0.68836666104100053, 0.43042813269113372, -0.6876891928650144, 0.43472823359577289, -0.68698707990399865, 0.43898457098714533, -0.68626110373282656, 0.44319760246432466, -0.68551202410526835, 0.44736778548138822, -0.68474057952353407, 0.45149557702622228, -0.68394748779578896, 0.45558143331936757, -0.68313344658166586, 0.45962580953197607, -0.68229913392582131, 0.46362915952190314, -0.68144520877960102, 0.46759193558708656, -0.68057231151089759, 0.47151458823533943, -0.67968106440230314, 0.47539756596972577, -0.678772072137661, 0.47924131508877754, -0.67784592227715579, 0.48304627950075768, -0.67690318572106423, 0.48681290055130422, -0.67594441716232434, 0.49054161686372427, -0.67497015552807527, 0.49423286419132545, -0.67398092441032442, 0.49788707528114828, -0.67297723248592467, 0.50150467974848156, -0.67195957392602101, 0.505086103961643, -0.67092842879516357, 0.50863177093642475, -0.66988426344024965, 0.51214210023974749, -0.66882753086950741, 0.51561750790196748, -0.6677586711216853, 0.51905840633742373, -0.66667811162565471, 0.5224652042727429, -0.66558626755061656, 0.52583830668247666, -0.66448354214709526, 0.52917811473169096, -0.66337032707892973, 0.53248502572507828, -0.66224700274643766, 0.53575943306227203, -0.66111393860096257, 0.53900172619896414, -0.65997149345098349, 0.54221229061352894, -0.65882001575998428, 0.54539150777882328, -0.65765984393627475, 0.54853975513884201, -0.65649130661494204, 0.55165740608997904, -0.65531472293213389, 0.55474482996657792, -0.65413040279183832, 0.55780239203055482, -0.6529386471253622, 0.56083045346480065, -0.65173974814367097, 0.56382937137017852, -0.65053398958277608, 0.5667994987658409, -0.64932164694234251, 0.56974118459270184, -0.64810298771768293, 0.5726547737198332, -0.64687827162531575, 0.57554060695359854, -0.64564775082224168, 0.57839902104936136, -0.64441167011911327, 0.58123034872556645, -0.64317026718744197, 0.58403491868006785, -0.64192377276101753, 0.58681305560850394, -0.64067241083167348, 0.58956508022462273, -0.63941639883956192, 0.59229130928238038, -0.63815594785808161, 0.59499205559969393, -0.63689126277359764, 0.59766762808373708, -0.63562254246010153, 0.60031833175763349, -0.63434997994893949, 0.602944467788467, -0.63307376259375436, 0.60554633351647613, -0.63179407223076056, 0.60812422248535047, -0.6305110853344883, 0.61067842447353204, -0.62922497316912041, 0.6132092255264201, -0.62793590193553761, 0.61571690798941581, -0.62664403291420412, 0.61820175054170501, -0.62534952260399324, 0.62066402823072575, -0.62405252285708013, 0.62310401250722658, -0.62275318101000454, 0.62552197126087161, -0.62145164001101005, 0.62791816885631524, -0.62014803854377254, 0.63029286616968416)
+									ParameterType='ComplexParam'
+									Units=''
+								$end 'TraceDataCol'
+							$end '0'
+						$end 'TraceDataComps'
+					$end 'TraceComponents'
+					$begin 'CurvesInfo'
+						'0'(501, 'feed_pos=\'9mm\'')
+						'1'(501, 'feed_pos=\'10mm\'')
+						'2'(501, 'feed_pos=\'11mm\'')
+						'3'(501, 'feed_pos=\'12mm\'')
+					$end 'CurvesInfo'
+					SurfsInfo[1: 4]
+					SurfNames[1: '']
+					$begin 'PrimarySweepInfo'
+						PrimarySweepName='Freq'
+						$begin 'PrimarySweepCol'
+							ColumnValues(1500000000, 1501000000, 1502000000, 1503000000, 1504000000, 1505000000, 1506000000, 1507000000, 1508000000, 1509000000, 1510000000, 1511000000, 1512000000, 1513000000, 1514000000, 1515000000, 1516000000, 1517000000, 1518000000, 1519000000, 1520000000, 1521000000, 1522000000, 1523000000, 1524000000, 1525000000, 1526000000, 1527000000, 1528000000, 1529000000, 1530000000, 1531000000, 1532000000, 1533000000, 1534000000, 1535000000, 1536000000, 1537000000, 1538000000, 1539000000, 1540000000, 1541000000, 1542000000, 1543000000, 1544000000, 1545000000, 1546000000, 1547000000, 1548000000, 1549000000, 1550000000, 1551000000, 1552000000, 1553000000, 1554000000, 1555000000, 1556000000, 1557000000, 1558000000, 1559000000, 1560000000, 1561000000, 1562000000, 1563000000, 1564000000, 1565000000, 1566000000, 1567000000, 1568000000, 1569000000, 1570000000, 1571000000, 1572000000, 1573000000, 1574000000, 1575000000, 1576000000, 1577000000, 1578000000, 1579000000, 1580000000, 1581000000, 1582000000, 1583000000, 1584000000, 1585000000, 1586000000, 1587000000, 1588000000, 1589000000, 1590000000, 1591000000, 1592000000, 1593000000, 1594000000, 1595000000, 1596000000, 1597000000, 1598000000, 1599000000, 1600000000, 1601000000, 1602000000, 1603000000, 1604000000, 1605000000, 1606000000, 1607000000, 1608000000, 1609000000, 1610000000, 1611000000, 1612000000, 1613000000, 1614000000, 1615000000, 1616000000, 1617000000, 1618000000, 1619000000, 1620000000, 1621000000, 1622000000, 1623000000, 1624000000, 1625000000, 1626000000, 1627000000, 1628000000, 1629000000, 1630000000, 1631000000, 1632000000, 1633000000, 1634000000, 1635000000, 1636000000, 1637000000, 1638000000, 1639000000, 1640000000, 1641000000, 1642000000, 1643000000, 1644000000, 1645000000, 1646000000, 1647000000, 1648000000, 1649000000, 1650000000, 1651000000, 1652000000, 1653000000, 1654000000, 1655000000, 1656000000, 1657000000, 1658000000, 1659000000, 1660000000, 1661000000, 1662000000, 1663000000, 1664000000, 1665000000, 1666000000, 1667000000, 1668000000, 1669000000, 1670000000, 1671000000, 1672000000, 1673000000, 1674000000, 1675000000, 1676000000, 1677000000, 1678000000, 1679000000, 1680000000, 1681000000, 1682000000, 1683000000, 1684000000, 1685000000, 1686000000, 1687000000, 1688000000, 1689000000, 1690000000, 1691000000, 1692000000, 1693000000, 1694000000, 1695000000, 1696000000, 1697000000, 1698000000, 1699000000, 1700000000, 1701000000, 1702000000, 1703000000, 1704000000, 1705000000, 1706000000, 1707000000, 1708000000, 1709000000, 1710000000, 1711000000, 1712000000, 1713000000, 1714000000, 1715000000, 1716000000, 1717000000, 1718000000, 1719000000, 1720000000, 1721000000, 1722000000, 1723000000, 1724000000, 1725000000, 1726000000, 1727000000, 1728000000, 1729000000, 1730000000, 1731000000, 1732000000, 1733000000, 1734000000, 1735000000, 1736000000, 1737000000, 1738000000, 1739000000, 1740000000, 1741000000, 1742000000, 1743000000, 1744000000, 1745000000, 1746000000, 1747000000, 1748000000, 1749000000, 1750000000, 1751000000, 1752000000, 1753000000, 1754000000, 1755000000, 1756000000, 1757000000, 1758000000, 1759000000, 1760000000, 1761000000, 1762000000, 1763000000, 1764000000, 1765000000, 1766000000, 1767000000, 1768000000, 1769000000, 1770000000, 1771000000, 1772000000, 1773000000, 1774000000, 1775000000, 1776000000, 1777000000, 1778000000, 1779000000, 1780000000, 1781000000, 1782000000, 1783000000, 1784000000, 1785000000, 1786000000, 1787000000, 1788000000, 1789000000, 1790000000, 1791000000, 1792000000, 1793000000, 1794000000, 1795000000, 1796000000, 1797000000, 1798000000, 1799000000, 1800000000, 1801000000, 1802000000, 1803000000, 1804000000, 1805000000, 1806000000, 1807000000, 1808000000, 1809000000, 1810000000, 1811000000, 1812000000, 1813000000, 1814000000, 1815000000, 1816000000, 1817000000, 1818000000, 1819000000, 1820000000, 1821000000, 1822000000, 1823000000, 1824000000, 1825000000, 1826000000, 1827000000, 1828000000, 1829000000, 1830000000, 1831000000, 1832000000, 1833000000, 1834000000, 1835000000, 1836000000, 1837000000, 1838000000, 1839000000, 1840000000, 1841000000, 1842000000, 1843000000, 1844000000, 1845000000, 1846000000, 1847000000, 1848000000, 1849000000, 1850000000, 1851000000, 1852000000, 1853000000, 1854000000, 1855000000, 1856000000, 1857000000, 1858000000, 1859000000, 1860000000, 1861000000, 1862000000, 1863000000, 1864000000, 1865000000, 1866000000, 1867000000, 1868000000, 1869000000, 1870000000, 1871000000, 1872000000, 1873000000, 1874000000, 1875000000, 1876000000, 1877000000, 1878000000, 1879000000, 1880000000, 1881000000, 1882000000, 1883000000, 1884000000, 1885000000, 1886000000, 1887000000, 1888000000, 1889000000, 1890000000, 1891000000, 1892000000, 1893000000, 1894000000, 1895000000, 1896000000, 1897000000, 1898000000, 1899000000, 1900000000, 1901000000, 1902000000, 1903000000, 1904000000, 1905000000, 1906000000, 1907000000, 1908000000, 1909000000, 1910000000, 1911000000, 1912000000, 1913000000, 1914000000, 1915000000, 1916000000, 1917000000, 1918000000, 1919000000, 1920000000, 1921000000, 1922000000, 1923000000, 1924000000, 1925000000, 1926000000, 1927000000, 1928000000, 1929000000, 1930000000, 1931000000, 1932000000, 1933000000, 1934000000, 1935000000, 1936000000, 1937000000, 1938000000, 1939000000, 1940000000, 1941000000, 1942000000, 1943000000, 1944000000, 1945000000, 1946000000, 1947000000, 1948000000, 1949000000, 1950000000, 1951000000, 1952000000, 1953000000, 1954000000, 1955000000, 1956000000, 1957000000, 1958000000, 1959000000, 1960000000, 1961000000, 1962000000, 1963000000, 1964000000, 1965000000, 1966000000, 1967000000, 1968000000, 1969000000, 1970000000, 1971000000, 1972000000, 1973000000, 1974000000, 1975000000, 1976000000, 1977000000, 1978000000, 1979000000, 1980000000, 1981000000, 1982000000, 1983000000, 1984000000, 1985000000, 1986000000, 1987000000, 1988000000, 1989000000, 1990000000, 1991000000, 1992000000, 1993000000, 1994000000, 1995000000, 1996000000, 1997000000, 1998000000, 1999000000, 2000000000, 1500000000, 1501000000, 1502000000, 1503000000, 1504000000, 1505000000, 1506000000, 1507000000, 1508000000, 1509000000, 1510000000, 1511000000, 1512000000, 1513000000, 1514000000, 1515000000, 1516000000, 1517000000, 1518000000, 1519000000, 1520000000, 1521000000, 1522000000, 1523000000, 1524000000, 1525000000, 1526000000, 1527000000, 1528000000, 1529000000, 1530000000, 1531000000, 1532000000, 1533000000, 1534000000, 1535000000, 1536000000, 1537000000, 1538000000, 1539000000, 1540000000, 1541000000, 1542000000, 1543000000, 1544000000, 1545000000, 1546000000, 1547000000, 1548000000, 1549000000, 1550000000, 1551000000, 1552000000, 1553000000, 1554000000, 1555000000, 1556000000, 1557000000, 1558000000, 1559000000, 1560000000, 1561000000, 1562000000, 1563000000, 1564000000, 1565000000, 1566000000, 1567000000, 1568000000, 1569000000, 1570000000, 1571000000, 1572000000, 1573000000, 1574000000, 1575000000, 1576000000, 1577000000, 1578000000, 1579000000, 1580000000, 1581000000, 1582000000, 1583000000, 1584000000, 1585000000, 1586000000, 1587000000, 1588000000, 1589000000, 1590000000, 1591000000, 1592000000, 1593000000, 1594000000, 1595000000, 1596000000, 1597000000, 1598000000, 1599000000, 1600000000, 1601000000, 1602000000, 1603000000, 1604000000, 1605000000, 1606000000, 1607000000, 1608000000, 1609000000, 1610000000, 1611000000, 1612000000, 1613000000, 1614000000, 1615000000, 1616000000, 1617000000, 1618000000, 1619000000, 1620000000, 1621000000, 1622000000, 1623000000, 1624000000, 1625000000, 1626000000, 1627000000, 1628000000, 1629000000, 1630000000, 1631000000, 1632000000, 1633000000, 1634000000, 1635000000, 1636000000, 1637000000, 1638000000, 1639000000, 1640000000, 1641000000, 1642000000, 1643000000, 1644000000, 1645000000, 1646000000, 1647000000, 1648000000, 1649000000, 1650000000, 1651000000, 1652000000, 1653000000, 1654000000, 1655000000, 1656000000, 1657000000, 1658000000, 1659000000, 1660000000, 1661000000, 1662000000, 1663000000, 1664000000, 1665000000, 1666000000, 1667000000, 1668000000, 1669000000, 1670000000, 1671000000, 1672000000, 1673000000, 1674000000, 1675000000, 1676000000, 1677000000, 1678000000, 1679000000, 1680000000, 1681000000, 1682000000, 1683000000, 1684000000, 1685000000, 1686000000, 1687000000, 1688000000, 1689000000, 1690000000, 1691000000, 1692000000, 1693000000, 1694000000, 1695000000, 1696000000, 1697000000, 1698000000, 1699000000, 1700000000, 1701000000, 1702000000, 1703000000, 1704000000, 1705000000, 1706000000, 1707000000, 1708000000, 1709000000, 1710000000, 1711000000, 1712000000, 1713000000, 1714000000, 1715000000, 1716000000, 1717000000, 1718000000, 1719000000, 1720000000, 1721000000, 1722000000, 1723000000, 1724000000, 1725000000, 1726000000, 1727000000, 1728000000, 1729000000, 1730000000, 1731000000, 1732000000, 1733000000, 1734000000, 1735000000, 1736000000, 1737000000, 1738000000, 1739000000, 1740000000, 1741000000, 1742000000, 1743000000, 1744000000, 1745000000, 1746000000, 1747000000, 1748000000, 1749000000, 1750000000, 1751000000, 1752000000, 1753000000, 1754000000, 1755000000, 1756000000, 1757000000, 1758000000, 1759000000, 1760000000, 1761000000, 1762000000, 1763000000, 1764000000, 1765000000, 1766000000, 1767000000, 1768000000, 1769000000, 1770000000, 1771000000, 1772000000, 1773000000, 1774000000, 1775000000, 1776000000, 1777000000, 1778000000, 1779000000, 1780000000, 1781000000, 1782000000, 1783000000, 1784000000, 1785000000, 1786000000, 1787000000, 1788000000, 1789000000, 1790000000, 1791000000, 1792000000, 1793000000, 1794000000, 1795000000, 1796000000, 1797000000, 1798000000, 1799000000, 1800000000, 1801000000, 1802000000, 1803000000, 1804000000, 1805000000, 1806000000, 1807000000, 1808000000, 1809000000, 1810000000, 1811000000, 1812000000, 1813000000, 1814000000, 1815000000, 1816000000, 1817000000, 1818000000, 1819000000, 1820000000, 1821000000, 1822000000, 1823000000, 1824000000, 1825000000, 1826000000, 1827000000, 1828000000, 1829000000, 1830000000, 1831000000, 1832000000, 1833000000, 1834000000, 1835000000, 1836000000, 1837000000, 1838000000, 1839000000, 1840000000, 1841000000, 1842000000, 1843000000, 1844000000, 1845000000, 1846000000, 1847000000, 1848000000, 1849000000, 1850000000, 1851000000, 1852000000, 1853000000, 1854000000, 1855000000, 1856000000, 1857000000, 1858000000, 1859000000, 1860000000, 1861000000, 1862000000, 1863000000, 1864000000, 1865000000, 1866000000, 1867000000, 1868000000, 1869000000, 1870000000, 1871000000, 1872000000, 1873000000, 1874000000, 1875000000, 1876000000, 1877000000, 1878000000, 1879000000, 1880000000, 1881000000, 1882000000, 1883000000, 1884000000, 1885000000, 1886000000, 1887000000, 1888000000, 1889000000, 1890000000, 1891000000, 1892000000, 1893000000, 1894000000, 1895000000, 1896000000, 1897000000, 1898000000, 1899000000, 1900000000, 1901000000, 1902000000, 1903000000, 1904000000, 1905000000, 1906000000, 1907000000, 1908000000, 1909000000, 1910000000, 1911000000, 1912000000, 1913000000, 1914000000, 1915000000, 1916000000, 1917000000, 1918000000, 1919000000, 1920000000, 1921000000, 1922000000, 1923000000, 1924000000, 1925000000, 1926000000, 1927000000, 1928000000, 1929000000, 1930000000, 1931000000, 1932000000, 1933000000, 1934000000, 1935000000, 1936000000, 1937000000, 1938000000, 1939000000, 1940000000, 1941000000, 1942000000, 1943000000, 1944000000, 1945000000, 1946000000, 1947000000, 1948000000, 1949000000, 1950000000, 1951000000, 1952000000, 1953000000, 1954000000, 1955000000, 1956000000, 1957000000, 1958000000, 1959000000, 1960000000, 1961000000, 1962000000, 1963000000, 1964000000, 1965000000, 1966000000, 1967000000, 1968000000, 1969000000, 1970000000, 1971000000, 1972000000, 1973000000, 1974000000, 1975000000, 1976000000, 1977000000, 1978000000, 1979000000, 1980000000, 1981000000, 1982000000, 1983000000, 1984000000, 1985000000, 1986000000, 1987000000, 1988000000, 1989000000, 1990000000, 1991000000, 1992000000, 1993000000, 1994000000, 1995000000, 1996000000, 1997000000, 1998000000, 1999000000, 2000000000, 1500000000, 1501000000, 1502000000, 1503000000, 1504000000, 1505000000, 1506000000, 1507000000, 1508000000, 1509000000, 1510000000, 1511000000, 1512000000, 1513000000, 1514000000, 1515000000, 1516000000, 1517000000, 1518000000, 1519000000, 1520000000, 1521000000, 1522000000, 1523000000, 1524000000, 1525000000, 1526000000, 1527000000, 1528000000, 1529000000, 1530000000, 1531000000, 1532000000, 1533000000, 1534000000, 1535000000, 1536000000, 1537000000, 1538000000, 1539000000, 1540000000, 1541000000, 1542000000, 1543000000, 1544000000, 1545000000, 1546000000, 1547000000, 1548000000, 1549000000, 1550000000, 1551000000, 1552000000, 1553000000, 1554000000, 1555000000, 1556000000, 1557000000, 1558000000, 1559000000, 1560000000, 1561000000, 1562000000, 1563000000, 1564000000, 1565000000, 1566000000, 1567000000, 1568000000, 1569000000, 1570000000, 1571000000, 1572000000, 1573000000, 1574000000, 1575000000, 1576000000, 1577000000, 1578000000, 1579000000, 1580000000, 1581000000, 1582000000, 1583000000, 1584000000, 1585000000, 1586000000, 1587000000, 1588000000, 1589000000, 1590000000, 1591000000, 1592000000, 1593000000, 1594000000, 1595000000, 1596000000, 1597000000, 1598000000, 1599000000, 1600000000, 1601000000, 1602000000, 1603000000, 1604000000, 1605000000, 1606000000, 1607000000, 1608000000, 1609000000, 1610000000, 1611000000, 1612000000, 1613000000, 1614000000, 1615000000, 1616000000, 1617000000, 1618000000, 1619000000, 1620000000, 1621000000, 1622000000, 1623000000, 1624000000, 1625000000, 1626000000, 1627000000, 1628000000, 1629000000, 1630000000, 1631000000, 1632000000, 1633000000, 1634000000, 1635000000, 1636000000, 1637000000, 1638000000, 1639000000, 1640000000, 1641000000, 1642000000, 1643000000, 1644000000, 1645000000, 1646000000, 1647000000, 1648000000, 1649000000, 1650000000, 1651000000, 1652000000, 1653000000, 1654000000, 1655000000, 1656000000, 1657000000, 1658000000, 1659000000, 1660000000, 1661000000, 1662000000, 1663000000, 1664000000, 1665000000, 1666000000, 1667000000, 1668000000, 1669000000, 1670000000, 1671000000, 1672000000, 1673000000, 1674000000, 1675000000, 1676000000, 1677000000, 1678000000, 1679000000, 1680000000, 1681000000, 1682000000, 1683000000, 1684000000, 1685000000, 1686000000, 1687000000, 1688000000, 1689000000, 1690000000, 1691000000, 1692000000, 1693000000, 1694000000, 1695000000, 1696000000, 1697000000, 1698000000, 1699000000, 1700000000, 1701000000, 1702000000, 1703000000, 1704000000, 1705000000, 1706000000, 1707000000, 1708000000, 1709000000, 1710000000, 1711000000, 1712000000, 1713000000, 1714000000, 1715000000, 1716000000, 1717000000, 1718000000, 1719000000, 1720000000, 1721000000, 1722000000, 1723000000, 1724000000, 1725000000, 1726000000, 1727000000, 1728000000, 1729000000, 1730000000, 1731000000, 1732000000, 1733000000, 1734000000, 1735000000, 1736000000, 1737000000, 1738000000, 1739000000, 1740000000, 1741000000, 1742000000, 1743000000, 1744000000, 1745000000, 1746000000, 1747000000, 1748000000, 1749000000, 1750000000, 1751000000, 1752000000, 1753000000, 1754000000, 1755000000, 1756000000, 1757000000, 1758000000, 1759000000, 1760000000, 1761000000, 1762000000, 1763000000, 1764000000, 1765000000, 1766000000, 1767000000, 1768000000, 1769000000, 1770000000, 1771000000, 1772000000, 1773000000, 1774000000, 1775000000, 1776000000, 1777000000, 1778000000, 1779000000, 1780000000, 1781000000, 1782000000, 1783000000, 1784000000, 1785000000, 1786000000, 1787000000, 1788000000, 1789000000, 1790000000, 1791000000, 1792000000, 1793000000, 1794000000, 1795000000, 1796000000, 1797000000, 1798000000, 1799000000, 1800000000, 1801000000, 1802000000, 1803000000, 1804000000, 1805000000, 1806000000, 1807000000, 1808000000, 1809000000, 1810000000, 1811000000, 1812000000, 1813000000, 1814000000, 1815000000, 1816000000, 1817000000, 1818000000, 1819000000, 1820000000, 1821000000, 1822000000, 1823000000, 1824000000, 1825000000, 1826000000, 1827000000, 1828000000, 1829000000, 1830000000, 1831000000, 1832000000, 1833000000, 1834000000, 1835000000, 1836000000, 1837000000, 1838000000, 1839000000, 1840000000, 1841000000, 1842000000, 1843000000, 1844000000, 1845000000, 1846000000, 1847000000, 1848000000, 1849000000, 1850000000, 1851000000, 1852000000, 1853000000, 1854000000, 1855000000, 1856000000, 1857000000, 1858000000, 1859000000, 1860000000, 1861000000, 1862000000, 1863000000, 1864000000, 1865000000, 1866000000, 1867000000, 1868000000, 1869000000, 1870000000, 1871000000, 1872000000, 1873000000, 1874000000, 1875000000, 1876000000, 1877000000, 1878000000, 1879000000, 1880000000, 1881000000, 1882000000, 1883000000, 1884000000, 1885000000, 1886000000, 1887000000, 1888000000, 1889000000, 1890000000, 1891000000, 1892000000, 1893000000, 1894000000, 1895000000, 1896000000, 1897000000, 1898000000, 1899000000, 1900000000, 1901000000, 1902000000, 1903000000, 1904000000, 1905000000, 1906000000, 1907000000, 1908000000, 1909000000, 1910000000, 1911000000, 1912000000, 1913000000, 1914000000, 1915000000, 1916000000, 1917000000, 1918000000, 1919000000, 1920000000, 1921000000, 1922000000, 1923000000, 1924000000, 1925000000, 1926000000, 1927000000, 1928000000, 1929000000, 1930000000, 1931000000, 1932000000, 1933000000, 1934000000, 1935000000, 1936000000, 1937000000, 1938000000, 1939000000, 1940000000, 1941000000, 1942000000, 1943000000, 1944000000, 1945000000, 1946000000, 1947000000, 1948000000, 1949000000, 1950000000, 1951000000, 1952000000, 1953000000, 1954000000, 1955000000, 1956000000, 1957000000, 1958000000, 1959000000, 1960000000, 1961000000, 1962000000, 1963000000, 1964000000, 1965000000, 1966000000, 1967000000, 1968000000, 1969000000, 1970000000, 1971000000, 1972000000, 1973000000, 1974000000, 1975000000, 1976000000, 1977000000, 1978000000, 1979000000, 1980000000, 1981000000, 1982000000, 1983000000, 1984000000, 1985000000, 1986000000, 1987000000, 1988000000, 1989000000, 1990000000, 1991000000, 1992000000, 1993000000, 1994000000, 1995000000, 1996000000, 1997000000, 1998000000, 1999000000, 2000000000, 1500000000, 1501000000, 1502000000, 1503000000, 1504000000, 1505000000, 1506000000, 1507000000, 1508000000, 1509000000, 1510000000, 1511000000, 1512000000, 1513000000, 1514000000, 1515000000, 1516000000, 1517000000, 1518000000, 1519000000, 1520000000, 1521000000, 1522000000, 1523000000, 1524000000, 1525000000, 1526000000, 1527000000, 1528000000, 1529000000, 1530000000, 1531000000, 1532000000, 1533000000, 1534000000, 1535000000, 1536000000, 1537000000, 1538000000, 1539000000, 1540000000, 1541000000, 1542000000, 1543000000, 1544000000, 1545000000, 1546000000, 1547000000, 1548000000, 1549000000, 1550000000, 1551000000, 1552000000, 1553000000, 1554000000, 1555000000, 1556000000, 1557000000, 1558000000, 1559000000, 1560000000, 1561000000, 1562000000, 1563000000, 1564000000, 1565000000, 1566000000, 1567000000, 1568000000, 1569000000, 1570000000, 1571000000, 1572000000, 1573000000, 1574000000, 1575000000, 1576000000, 1577000000, 1578000000, 1579000000, 1580000000, 1581000000, 1582000000, 1583000000, 1584000000, 1585000000, 1586000000, 1587000000, 1588000000, 1589000000, 1590000000, 1591000000, 1592000000, 1593000000, 1594000000, 1595000000, 1596000000, 1597000000, 1598000000, 1599000000, 1600000000, 1601000000, 1602000000, 1603000000, 1604000000, 1605000000, 1606000000, 1607000000, 1608000000, 1609000000, 1610000000, 1611000000, 1612000000, 1613000000, 1614000000, 1615000000, 1616000000, 1617000000, 1618000000, 1619000000, 1620000000, 1621000000, 1622000000, 1623000000, 1624000000, 1625000000, 1626000000, 1627000000, 1628000000, 1629000000, 1630000000, 1631000000, 1632000000, 1633000000, 1634000000, 1635000000, 1636000000, 1637000000, 1638000000, 1639000000, 1640000000, 1641000000, 1642000000, 1643000000, 1644000000, 1645000000, 1646000000, 1647000000, 1648000000, 1649000000, 1650000000, 1651000000, 1652000000, 1653000000, 1654000000, 1655000000, 1656000000, 1657000000, 1658000000, 1659000000, 1660000000, 1661000000, 1662000000, 1663000000, 1664000000, 1665000000, 1666000000, 1667000000, 1668000000, 1669000000, 1670000000, 1671000000, 1672000000, 1673000000, 1674000000, 1675000000, 1676000000, 1677000000, 1678000000, 1679000000, 1680000000, 1681000000, 1682000000, 1683000000, 1684000000, 1685000000, 1686000000, 1687000000, 1688000000, 1689000000, 1690000000, 1691000000, 1692000000, 1693000000, 1694000000, 1695000000, 1696000000, 1697000000, 1698000000, 1699000000, 1700000000, 1701000000, 1702000000, 1703000000, 1704000000, 1705000000, 1706000000, 1707000000, 1708000000, 1709000000, 1710000000, 1711000000, 1712000000, 1713000000, 1714000000, 1715000000, 1716000000, 1717000000, 1718000000, 1719000000, 1720000000, 1721000000, 1722000000, 1723000000, 1724000000, 1725000000, 1726000000, 1727000000, 1728000000, 1729000000, 1730000000, 1731000000, 1732000000, 1733000000, 1734000000, 1735000000, 1736000000, 1737000000, 1738000000, 1739000000, 1740000000, 1741000000, 1742000000, 1743000000, 1744000000, 1745000000, 1746000000, 1747000000, 1748000000, 1749000000, 1750000000, 1751000000, 1752000000, 1753000000, 1754000000, 1755000000, 1756000000, 1757000000, 1758000000, 1759000000, 1760000000, 1761000000, 1762000000, 1763000000, 1764000000, 1765000000, 1766000000, 1767000000, 1768000000, 1769000000, 1770000000, 1771000000, 1772000000, 1773000000, 1774000000, 1775000000, 1776000000, 1777000000, 1778000000, 1779000000, 1780000000, 1781000000, 1782000000, 1783000000, 1784000000, 1785000000, 1786000000, 1787000000, 1788000000, 1789000000, 1790000000, 1791000000, 1792000000, 1793000000, 1794000000, 1795000000, 1796000000, 1797000000, 1798000000, 1799000000, 1800000000, 1801000000, 1802000000, 1803000000, 1804000000, 1805000000, 1806000000, 1807000000, 1808000000, 1809000000, 1810000000, 1811000000, 1812000000, 1813000000, 1814000000, 1815000000, 1816000000, 1817000000, 1818000000, 1819000000, 1820000000, 1821000000, 1822000000, 1823000000, 1824000000, 1825000000, 1826000000, 1827000000, 1828000000, 1829000000, 1830000000, 1831000000, 1832000000, 1833000000, 1834000000, 1835000000, 1836000000, 1837000000, 1838000000, 1839000000, 1840000000, 1841000000, 1842000000, 1843000000, 1844000000, 1845000000, 1846000000, 1847000000, 1848000000, 1849000000, 1850000000, 1851000000, 1852000000, 1853000000, 1854000000, 1855000000, 1856000000, 1857000000, 1858000000, 1859000000, 1860000000, 1861000000, 1862000000, 1863000000, 1864000000, 1865000000, 1866000000, 1867000000, 1868000000, 1869000000, 1870000000, 1871000000, 1872000000, 1873000000, 1874000000, 1875000000, 1876000000, 1877000000, 1878000000, 1879000000, 1880000000, 1881000000, 1882000000, 1883000000, 1884000000, 1885000000, 1886000000, 1887000000, 1888000000, 1889000000, 1890000000, 1891000000, 1892000000, 1893000000, 1894000000, 1895000000, 1896000000, 1897000000, 1898000000, 1899000000, 1900000000, 1901000000, 1902000000, 1903000000, 1904000000, 1905000000, 1906000000, 1907000000, 1908000000, 1909000000, 1910000000, 1911000000, 1912000000, 1913000000, 1914000000, 1915000000, 1916000000, 1917000000, 1918000000, 1919000000, 1920000000, 1921000000, 1922000000, 1923000000, 1924000000, 1925000000, 1926000000, 1927000000, 1928000000, 1929000000, 1930000000, 1931000000, 1932000000, 1933000000, 1934000000, 1935000000, 1936000000, 1937000000, 1938000000, 1939000000, 1940000000, 1941000000, 1942000000, 1943000000, 1944000000, 1945000000, 1946000000, 1947000000, 1948000000, 1949000000, 1950000000, 1951000000, 1952000000, 1953000000, 1954000000, 1955000000, 1956000000, 1957000000, 1958000000, 1959000000, 1960000000, 1961000000, 1962000000, 1963000000, 1964000000, 1965000000, 1966000000, 1967000000, 1968000000, 1969000000, 1970000000, 1971000000, 1972000000, 1973000000, 1974000000, 1975000000, 1976000000, 1977000000, 1978000000, 1979000000, 1980000000, 1981000000, 1982000000, 1983000000, 1984000000, 1985000000, 1986000000, 1987000000, 1988000000, 1989000000, 1990000000, 1991000000, 1992000000, 1993000000, 1994000000, 1995000000, 1996000000, 1997000000, 1998000000, 1999000000, 2000000000)
+							ParameterType='DoubleParam'
+							Units='GHz'
+						$end 'PrimarySweepCol'
+					$end 'PrimarySweepInfo'
+				$end '30'
+			$end 'Traces'
+		$end 'S Parameter Chart 1'
+	$end 'RepMgrRepsData'
+$end 'ReportsData'

--- a/_unittest/test_00_report_file_parser.py
+++ b/_unittest/test_00_report_file_parser.py
@@ -2943,3 +2943,5 @@ def test_report_file_parser():
             },
         }
     }
+    data1 = parse_rdat_file(os.path.join(local_path, "example_models", "test_report_smith.rdat"))
+    assert len(data1["S Parameter Chart 1"]["S(1,1)"]["curves"]) == 8

--- a/pyaedt/generic/report_file_parser.py
+++ b/pyaedt/generic/report_file_parser.py
@@ -17,8 +17,8 @@ def parse_rdat_file(file_path):
     for report_name in report_data:
         report_dict[report_name] = {}
         for trace, trace_data in report_data[report_name]["Traces"].items():
-            if trace_data["TraceComponents"]["TraceDataComps"]["0"]["TraceDataCol"]["ParameterType"] == "ComplexParam":
-                all_data = trace_data["TraceComponents"]["TraceDataComps"]["0"]
+            all_data = trace_data["TraceComponents"]["TraceDataComps"]["0"]
+            if all_data["TraceDataCol"]["ParameterType"] == "ComplexParam":
                 all_data_values = all_data["TraceDataCol"]["ColumnValues"]
                 all_re_values = all_data_values[0::2]
                 all_im_values = all_data_values[1::2]
@@ -45,15 +45,13 @@ def parse_rdat_file(file_path):
                     all_im_values = all_im_values[curve_data[0] :]
 
             else:
-                x_data = trace_data["TraceComponents"]["TraceDataComps"]["0"]
                 y_data = trace_data["TraceComponents"]["TraceDataComps"]["1"]
-                all_x_values = x_data["TraceDataCol"]["ColumnValues"]
+                all_x_values = all_data["TraceDataCol"]["ColumnValues"]
                 all_y_values = y_data["TraceDataCol"]["ColumnValues"]
-
-                si_unit_x = SI_UNITS[unit_system(x_data["TraceDataCol"]["Units"])]
+                si_unit_x = SI_UNITS[unit_system(all_data["TraceDataCol"]["Units"])]
                 si_unit_y = SI_UNITS[unit_system(y_data["TraceDataCol"]["Units"])]
                 report_dict[report_name][trace_data["TraceName"]] = {
-                    "x_name": x_data["TraceCompExpr"],
+                    "x_name": all_data["TraceCompExpr"],
                     "x_unit": si_unit_x,
                     "y_unit": si_unit_y,
                     "curves": {},

--- a/pyaedt/generic/report_file_parser.py
+++ b/pyaedt/generic/report_file_parser.py
@@ -17,25 +17,53 @@ def parse_rdat_file(file_path):
     for report_name in report_data:
         report_dict[report_name] = {}
         for trace, trace_data in report_data[report_name]["Traces"].items():
-            x_data = trace_data["TraceComponents"]["TraceDataComps"]["0"]
-            y_data = trace_data["TraceComponents"]["TraceDataComps"]["1"]
-            all_x_values = x_data["TraceDataCol"]["ColumnValues"]
-            all_y_values = y_data["TraceDataCol"]["ColumnValues"]
-
-            si_unit_x = SI_UNITS[unit_system(x_data["TraceDataCol"]["Units"])]
-            si_unit_y = SI_UNITS[unit_system(y_data["TraceDataCol"]["Units"])]
-            report_dict[report_name][trace_data["TraceName"]] = {
-                "x_name": x_data["TraceCompExpr"],
-                "x_unit": si_unit_x,
-                "y_unit": si_unit_y,
-                "curves": {},
-            }
-            for curve, curve_data in trace_data["CurvesInfo"].items():
-                report_dict[report_name][trace_data["TraceName"]]["curves"][curve_data[1]] = {
-                    "x_data": all_x_values[0 : curve_data[0]],
-                    "y_data": all_y_values[0 : curve_data[0]],
+            if trace_data["TraceComponents"]["TraceDataComps"]["0"]["TraceDataCol"]["ParameterType"] == "ComplexParam":
+                all_data = trace_data["TraceComponents"]["TraceDataComps"]["0"]
+                all_data_values = all_data["TraceDataCol"]["ColumnValues"]
+                all_re_values = all_data_values[0::2]
+                all_im_values = all_data_values[1::2]
+                all_x_values = trace_data["PrimarySweepInfo"]["PrimarySweepCol"]["ColumnValues"]
+                si_unit_x = SI_UNITS[unit_system(trace_data["PrimarySweepInfo"]["PrimarySweepCol"]["Units"])]
+                si_unit_y = SI_UNITS[unit_system(all_data["TraceDataCol"]["Units"])]
+                report_dict[report_name][trace_data["TraceName"]] = {
+                    "x_name": all_data["TraceCompExpr"],
+                    "x_unit": si_unit_x,
+                    "y_unit": si_unit_y,
+                    "curves": {},
                 }
-                all_x_values = all_x_values[curve_data[0] :]
-                all_y_values = all_y_values[curve_data[0] :]
+                for curve, curve_data in trace_data["CurvesInfo"].items():
+                    report_dict[report_name][trace_data["TraceName"]]["curves"][curve_data[1] + "real"] = {
+                        "x_data": all_x_values[0 : curve_data[0]],
+                        "y_data": all_re_values[0 : curve_data[0]],
+                    }
+                    report_dict[report_name][trace_data["TraceName"]]["curves"][curve_data[1] + "imag"] = {
+                        "x_data": all_x_values[0 : curve_data[0]],
+                        "y_data": all_im_values[0 : curve_data[0]],
+                    }
+                    all_x_values = all_x_values[curve_data[0] :]
+                    all_re_values = all_re_values[curve_data[0] :]
+                    all_im_values = all_im_values[curve_data[0] :]
+
+            else:
+                x_data = trace_data["TraceComponents"]["TraceDataComps"]["0"]
+                y_data = trace_data["TraceComponents"]["TraceDataComps"]["1"]
+                all_x_values = x_data["TraceDataCol"]["ColumnValues"]
+                all_y_values = y_data["TraceDataCol"]["ColumnValues"]
+
+                si_unit_x = SI_UNITS[unit_system(x_data["TraceDataCol"]["Units"])]
+                si_unit_y = SI_UNITS[unit_system(y_data["TraceDataCol"]["Units"])]
+                report_dict[report_name][trace_data["TraceName"]] = {
+                    "x_name": x_data["TraceCompExpr"],
+                    "x_unit": si_unit_x,
+                    "y_unit": si_unit_y,
+                    "curves": {},
+                }
+                for curve, curve_data in trace_data["CurvesInfo"].items():
+                    report_dict[report_name][trace_data["TraceName"]]["curves"][curve_data[1]] = {
+                        "x_data": all_x_values[0 : curve_data[0]],
+                        "y_data": all_y_values[0 : curve_data[0]],
+                    }
+                    all_x_values = all_x_values[curve_data[0] :]
+                    all_y_values = all_y_values[curve_data[0] :]
 
     return report_dict


### PR DESCRIPTION
If Smith Chart is detected, the output dictionary will have the info from the real and imag. part like 2 different traces