### PR TITLE
Add 3D Component placement via EDB

### DIFF
--- a/_unittest/example_models/chip.a3dcomp
+++ b/_unittest/example_models/chip.a3dcomp
@@ -1,0 +1,2730 @@
+$begin 'AnsoftComponentChkSum'
+	ChecksumString='00be9e5ba75f995b5de4567b67619b22'
+	ChecksumHistory()
+	VersionHistory()
+	FormatVersion=6
+	Version(2021, 1)
+	ComponentDefinitionType='DesignDerivedComponentDefinition'
+$end 'AnsoftComponentChkSum'
+$begin 'AnsoftComponentHeader'
+	$begin 'Information'
+		$begin 'ComponentInfo'
+			ComponentName='chip'
+			Company=''
+			'Company URL'=''
+			'Model Number'=''
+			'Help URL'=''
+			Version=''
+			Notes=''
+			IconType=''
+			Owner=''
+			Email=''
+			Date=''
+			HasLabel=false
+			LabelImage=''
+		$end 'ComponentInfo'
+	$end 'Information'
+	$begin 'DesignDataDescriptions'
+		$begin 'DesignSettings'
+			ProductName='HFSS'
+			SolutionType='DrivenTerminal'
+			$begin 'DrivenOptions'
+				AutoOpen=false
+			$end 'DrivenOptions'
+		$end 'DesignSettings'
+		$begin 'Component Meshing'
+			Type='Volume'
+		$end 'Component Meshing'
+	$end 'DesignDataDescriptions'
+	$begin 'Preview'
+		Image=''
+	$end 'Preview'
+	ContainsLightweightGeometry=false
+$end 'AnsoftComponentHeader'
+$begin 'ComponentBody'
+	$begin 'HFSSModel'
+		$begin 'Variables'
+		$end 'Variables'
+		$begin 'Datasets'
+		$end 'Datasets'
+		$begin 'DesignData'
+			$begin 'DesignSettings'
+				'Allow Material Override'=true
+				IncludeTemperatureDependence=false
+				EnableFeedback=false
+				Temperatures(10, '22cel', 37, '22cel', 64, '22cel', 91, '22cel', 118, '22cel', 145, '22cel', 172, '22cel', 223, '22cel', 250, '22cel', 277, '22cel', 304, '22cel', 331, '22cel', 358, '22cel', 385, '22cel', 412, '22cel', 439, '22cel', 466, '22cel', 493, '22cel', 520, '22cel', 547, '22cel')
+				ObjsEnabledForDeformation()
+			$end 'DesignSettings'
+			$begin 'DCThickness'
+				DCThicknessObjects(64, '6.66667e-06', 91, '6.66667e-06', 118, '8.65385e-06', 145, '8.65385e-06', 172, '7.85714e-06', 223, '8.65385e-06', 250, '8.65385e-06', 277, '1.66667e-05', 304, '1.66667e-05', 331, '1.66667e-05', 358, '1.66667e-05', 385, '1.66667e-05', 412, '1.66667e-05', 439, '1e-05', 466, '1e-05', 493, '1.52542e-05', 520, '1.52542e-05')
+			$end 'DCThickness'
+			$begin 'Circuit Elements'
+			$end 'Circuit Elements'
+			$begin 'PMLGroups'
+			$end 'PMLGroups'
+			$begin 'MeshOperations'
+				$begin 'GlobalSurfApproximation'
+					CurvedSurfaceApproxChoice='UseSlider'
+					SliderMeshSettings=5
+				$end 'GlobalSurfApproximation'
+				$begin 'GlobalCurvilinear'
+					Apply=false
+				$end 'GlobalCurvilinear'
+				$begin 'GlobalModelRes'
+					UseAutoLength=true
+				$end 'GlobalModelRes'
+				MeshMethod='AnsoftClassic'
+				UseLegacyFaceterForTauVolumeMesh=false
+				DynamicSurfaceResolution=false
+				UseFlexMeshingForTAUvolumeMesh=false
+				UseAlternativeMeshMethodsAsFallBack=true
+				AllowPhiForLayeredGeometry=true
+			$end 'MeshOperations'
+		$end 'DesignData'
+	$end 'HFSSModel'
+	$begin 'MaterialDefinitions'
+		$begin 'Variables'
+		$end 'Variables'
+		$begin 'Datasets'
+		$end 'Datasets'
+		$begin 'Definitions'
+			$begin 'Materials'
+				$begin 'bakelite'
+					CoordinateSystemType='Cartesian'
+					BulkOrSurfaceType=1
+					$begin 'PhysicsTypes'
+						set('Electromagnetic')
+					$end 'PhysicsTypes'
+					permittivity='4.8'
+					conductivity='1e-09'
+					dielectric_loss_tangent='0.002'
+					ModTime=1620675913
+					Library=''
+					LibLocation='Project'
+					ModSinceLib=false
+				$end 'bakelite'
+				$begin 'copper'
+					CoordinateSystemType='Cartesian'
+					BulkOrSurfaceType=1
+					$begin 'PhysicsTypes'
+						set('Electromagnetic')
+					$end 'PhysicsTypes'
+					permeability='0.999991'
+					conductivity='58000000'
+					ModTime=1620675913
+					Library=''
+					LibLocation='Project'
+					ModSinceLib=false
+				$end 'copper'
+				$begin 'teflon_based'
+					CoordinateSystemType='Cartesian'
+					BulkOrSurfaceType=1
+					$begin 'PhysicsTypes'
+						set('Electromagnetic')
+					$end 'PhysicsTypes'
+					permittivity='2.08'
+					dielectric_loss_tangent='0.001'
+					ModTime=1620675913
+					Library=''
+					LibLocation='Project'
+					ModSinceLib=false
+				$end 'teflon_based'
+				$begin 'vacuum'
+					CoordinateSystemType='Cartesian'
+					BulkOrSurfaceType=1
+					$begin 'PhysicsTypes'
+						set('Electromagnetic')
+					$end 'PhysicsTypes'
+					$begin 'AttachedData'
+						$begin 'MatAppearanceData'
+							property_data='appearance_data'
+							Red=230
+							Green=230
+							Blue=230
+							Transparency=0.94999998807907104
+						$end 'MatAppearanceData'
+					$end 'AttachedData'
+					permittivity='1'
+					ModTime=1620675913
+					Library=''
+					LibLocation='Project'
+					ModSinceLib=false
+				$end 'vacuum'
+			$end 'Materials'
+			$begin 'SurfaceMaterials'
+			$end 'SurfaceMaterials'
+		$end 'Definitions'
+	$end 'MaterialDefinitions'
+	$begin 'GeometryData'
+		$begin 'Variables'
+		$end 'Variables'
+		$begin 'Datasets'
+		$end 'Datasets'
+		$begin 'GeometryCore'
+			BlockVersionID=3
+			DataVersion=1
+			NativeKernel='ACIS'
+			NativeKernelVersionID=13
+			Units='mm'
+			InstanceID=-1
+			$begin 'ValidationOptions'
+				EntityCheckLevel='Strict'
+				IgnoreUnclassifiedObjects=false
+				SkipIntersectionChecks=false
+			$end 'ValidationOptions'
+			$begin 'GeometryOperations'
+				BlockVersionID=2
+				$begin 'AnsoftRangedIDServerManager'
+					$begin 'AnsoftRangedIDServer'
+						IDServerObjectTypeID=0
+						IDServerRangeMin=0
+						IDServerRangeMax=2146483647
+						NextUniqueID=590
+						MoveBackwards=false
+					$end 'AnsoftRangedIDServer'
+					$begin 'AnsoftRangedIDServer'
+						IDServerObjectTypeID=1
+						IDServerRangeMin=2146483648
+						IDServerRangeMax=2146485547
+						NextUniqueID=2146483654
+						MoveBackwards=false
+					$end 'AnsoftRangedIDServer'
+				$end 'AnsoftRangedIDServerManager'
+				StartBackGroundFaceID=2146483648
+				$begin 'CoordinateSystems'
+					$begin 'Operation'
+						OperationType='CreateRelativeCoordinateSystem'
+						ID=574
+						ReferenceCoordSystemID=1
+						$begin 'RelativeCSParameters'
+							KernelVersion=13
+							Mode='Axis/Position'
+							OriginX='0'
+							OriginY='0'
+							OriginZ='5e-05'
+							XAxisXvec='1'
+							XAxisYvec='0'
+							XAxisZvec='0'
+							YAxisXvec='6.12303176911189e-17'
+							YAxisYvec='1'
+							YAxisZvec='0'
+						$end 'RelativeCSParameters'
+						ParentPartID=-1
+						ReferenceUDMID=-1
+						$begin 'Attributes'
+							Name='U1_CS'
+							UDMId=-1
+						$end 'Attributes'
+						$begin 'Operations'
+						$end 'Operations'
+						XYPlaneID=575
+					$end 'Operation'
+				$end 'CoordinateSystems'
+				$begin 'OperandCSs'
+				$end 'OperandCSs'
+				$begin 'UserDefinedModels'
+				$end 'UserDefinedModels'
+				$begin 'OperandUserDefinedModels'
+				$end 'OperandUserDefinedModels'
+				$begin 'ToplevelParts'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='CHIP_DIEL'
+							Flags='Wireframe#'
+							Color='(38 74 51)'
+							Transparency=0.90000000000000002
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"bakelite"'
+							SurfaceMaterialValue='""'
+							SolveInside=true
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=9
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=10
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000010.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='CHIP_MOLD'
+							Flags='Wireframe#'
+							Color='(68 97 76)'
+							Transparency=0.90000000000000002
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"teflon_based"'
+							SurfaceMaterialValue='""'
+							SolveInside=true
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=36
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=37
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000037.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='M1'
+							Flags=''
+							Color='(141 183 202)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=63
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=64
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000064.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='M1_L1'
+							Flags=''
+							Color='(141 183 202)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=90
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=91
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000091.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='M1_L2'
+							Flags=''
+							Color='(141 183 202)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=117
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=118
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000118.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='M1_L3'
+							Flags=''
+							Color='(141 183 202)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=144
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=145
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000145.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='M2'
+							Flags=''
+							Color='(239 161 93)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=171
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=172
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=10
+										NumWires=0
+										NumLoops=10
+										NumCoedges=48
+										NumEdges=24
+										NumVertices=16
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000172.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='M2_L1'
+							Flags=''
+							Color='(239 161 93)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=222
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=223
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000223.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='M2_L2'
+							Flags=''
+							Color='(239 161 93)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=249
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=250
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000250.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='SBALL'
+							Flags=''
+							Color='(242 99 241)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=276
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=277
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000277.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='SBALL_L1'
+							Flags=''
+							Color='(242 99 241)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=303
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=304
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000304.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='SBALL_L2'
+							Flags=''
+							Color='(242 99 241)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=330
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=331
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000331.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='SBALL_L3'
+							Flags=''
+							Color='(242 99 241)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=357
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=358
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000358.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='SBALL_L4'
+							Flags=''
+							Color='(242 99 241)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=384
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=385
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000385.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='SBALL_L5'
+							Flags=''
+							Color='(242 99 241)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=411
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=412
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000412.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='V12'
+							Flags=''
+							Color='(40 152 137)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=438
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=439
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000439.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='V12_L1'
+							Flags=''
+							Color='(40 152 137)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=465
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=466
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000466.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='V12_L2'
+							Flags=''
+							Color='(40 152 137)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=492
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=493
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000493.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='V12_L3'
+							Flags=''
+							Color='(40 152 137)'
+							Transparency=0
+							PartCoordinateSystem=1
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"copper"'
+							SurfaceMaterialValue='""'
+							SolveInside=false
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='NativeBody'
+								ID=519
+								ReferenceCoordSystemID=1
+								$begin 'NativeBodyParameters'
+									KernelVersion=1
+									SourceFile=''
+								$end 'NativeBodyParameters'
+								ParentPartID=520
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=6
+										NumWires=0
+										NumLoops=6
+										NumCoedges=24
+										NumEdges=12
+										NumVertices=8
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=-1
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=0
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+								BodyType='BRepBody'
+								$begin 'BodyBlock'
+									BodyFileNamesVec[1: '0000520.sab']
+								$end 'BodyBlock'
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+					$begin 'GeometryPart'
+						$begin 'Attributes'
+							Name='U1Marker'
+							Flags='NonModel#'
+							Color='(143 175 143)'
+							Transparency=0
+							PartCoordinateSystem=574
+							UDMId=-1
+							GroupId=-1
+							MaterialValue='"vacuum"'
+							SurfaceMaterialValue='""'
+							SolveInside=true
+							ShellElement=false
+							ShellElementThickness='0mm'
+							IsMaterialEditable=true
+							UseMaterialAppearance=false
+							IsLightweight=false
+							IsAlwaysHidden=false
+						$end 'Attributes'
+						$begin 'Operations'
+							$begin 'Operation'
+								OperationType='Rectangle'
+								ID=578
+								ReferenceCoordSystemID=1
+								$begin 'RectangleParameters'
+									KernelVersion=13
+									XStart='0'
+									YStart='0'
+									ZStart='0'
+									Width='0.0001'
+									Height='5e-05'
+									WhichAxis='Z'
+								$end 'RectangleParameters'
+								ParentPartID=579
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=0
+										NumWires=1
+										NumLoops=0
+										NumCoedges=4
+										NumEdges=4
+										NumVertices=4
+									$end 'Topology'
+									BodyID=579
+									StartFaceID=-1
+									StartEdgeID=580
+									StartVertexID=584
+									NumNewFaces=0
+									NumNewEdges=4
+									NumNewVertices=4
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+								$end 'OperationIdentity'
+							$end 'Operation'
+							$begin 'Operation'
+								OperationType='CoverLines'
+								ID=588
+								$begin 'LocalOperationParameters'
+									KernelVersion=13
+									LocalOpPart=579
+								$end 'LocalOperationParameters'
+								ParentPartID=579
+								ReferenceUDMID=-1
+								IsSuppressed=false
+								$begin 'OperationIdentity'
+									$begin 'Topology'
+										NumLumps=1
+										NumShells=1
+										NumFaces=1
+										NumWires=0
+										NumLoops=1
+										NumCoedges=4
+										NumEdges=4
+										NumVertices=4
+									$end 'Topology'
+									BodyID=-1
+									StartFaceID=589
+									StartEdgeID=-1
+									StartVertexID=-1
+									NumNewFaces=1
+									NumNewEdges=0
+									NumNewVertices=0
+									FaceNameAndIDMap()
+									EdgeNameAndIDMap()
+									VertexNameAndIDMap()
+									$begin 'GeomTopolBasedOperationIdentityHelper'
+										$begin 'NewFaces'
+											$begin 'Face'
+												NormalizedSerialNum=0
+												ID=589
+												$begin 'FaceGeomTopol'
+													FaceTopol(1, 4, 4, 4)
+													$begin 'FaceGeometry'
+														Area=0.005000000000000001
+														FcUVMid(0.050000000000000003, 0.025000000000000001, 0)
+														$begin 'FcTolVts'
+															TolVt(0, 0, 0, 0)
+															TolVt(0.10000000000000001, 0, 0, 0)
+															TolVt(0.10000000000000001, 0.050000000000000003, 0, 0)
+															TolVt(0, 0.050000000000000003, 0, 0)
+														$end 'FcTolVts'
+													$end 'FaceGeometry'
+												$end 'FaceGeomTopol'
+											$end 'Face'
+										$end 'NewFaces'
+										$begin 'NewEdges'
+										$end 'NewEdges'
+										$begin 'NewVertices'
+										$end 'NewVertices'
+									$end 'GeomTopolBasedOperationIdentityHelper'
+								$end 'OperationIdentity'
+								ParentOperationID=578
+							$end 'Operation'
+						$end 'Operations'
+					$end 'GeometryPart'
+				$end 'ToplevelParts'
+				$begin 'OperandParts'
+				$end 'OperandParts'
+				$begin 'Planes'
+				$end 'Planes'
+				$begin 'Points'
+				$end 'Points'
+				$begin 'GeometryEntityLists'
+				$end 'GeometryEntityLists'
+				$begin 'CachedNames'
+					$begin 'airbox'
+						airbox(-1)
+					$end 'airbox'
+					$begin 'allobjects'
+						allobjects(-1)
+					$end 'allobjects'
+					$begin 'chip_diel'
+						chip_diel(-1)
+					$end 'chip_diel'
+					$begin 'chip_mold'
+						chip_mold(-1)
+					$end 'chip_mold'
+					$begin 'global'
+						global(-1)
+					$end 'global'
+					$begin 'global:xy'
+						'global:xy'(-1)
+					$end 'global:xy'
+					$begin 'global:xz'
+						'global:xz'(-1)
+					$end 'global:xz'
+					$begin 'global:yz'
+						'global:yz'(-1)
+					$end 'global:yz'
+					$begin 'm'
+						m(1, 2)
+					$end 'm'
+					$begin 'm1_l'
+						m1_l(1, 2, 3)
+					$end 'm1_l'
+					$begin 'm2_l'
+						m2_l(1, 2)
+					$end 'm2_l'
+					$begin 'model'
+						model(-1)
+					$end 'model'
+					$begin 'sball'
+						sball(-1)
+					$end 'sball'
+					$begin 'sball_l'
+						sball_l(1, 2, 3, 4, 5)
+					$end 'sball_l'
+					$begin 'u1_cs'
+						u1_cs(-1)
+					$end 'u1_cs'
+					$begin 'u1marker'
+						u1marker(-1)
+					$end 'u1marker'
+					$begin 'v'
+						v(12)
+					$end 'v'
+					$begin 'v12_l'
+						v12_l(1, 2, 3)
+					$end 'v12_l'
+				$end 'CachedNames'
+			$end 'GeometryOperations'
+			$begin 'GeometryDependencies'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 9)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 36)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 63)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 90)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 117)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 144)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 171)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 222)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 249)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 276)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 303)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 330)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 357)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 384)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 411)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 438)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 465)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 492)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 519)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 578)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('GeometryBodyOperation', 588)
+					DependencyObject('GeometryBodyOperation', 578)
+				$end 'DependencyInformation'
+				$begin 'DependencyInformation'
+					NumParents=1
+					DependencyObject('CoordinateSystem', 574)
+					DependencyObject('CoordinateSystem', 1)
+				$end 'DependencyInformation'
+			$end 'GeometryDependencies'
+		$end 'GeometryCore'
+		$begin 'Settings'
+			IncludedParts[20: 10, 439, 520, 37, 579, 493, 250, 223, 64, 466, 304, 277, 331, 385, 358, 172, 145, 118, 91, 412]
+			HiddenParts[0:]
+			IncludedCS[1: 574]
+			ReferenceCS=1
+			IncludedParameters()
+			IncludedDependentParameters()
+			ParameterDescription()
+		$end 'Settings'
+	$end 'GeometryData'
+$end 'ComponentBody'
+$begin 'AllReferencedFilesForComponent'
+$begin 'NativeGeometryFiles'
+NumFiles= 19
+$begin 'sab'
+NativeGeometryFiles/0000010.sab
+BIN000000008718
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6	CHIP_DIEL	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9bakelite
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ Г?“’’’’’Т?љ™™™™™Й?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ 	CHIP_DIEL
+          3J&Ђid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ    %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя        F]tСEG<
+ЧЈp=
+·?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ    %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя        F]tСEG<™™™™™™©?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ    %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя333333Г?333333Гї™™™™™™©?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   333333Гї-   333333Г?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ    %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя333333Гї333333Гї™™™™™™©?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   333333У?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   333333ГїC   333333Г?%   D   unknown%   E   яяяяяяяяяяяяF   333333Гї,   333333Г?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ    vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя        333333Г?
+ЧЈp=
+·?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ    %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя333333Гї333333Г?™™™™™™©?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   333333У?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   333333У?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ    %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя333333Г?333333Г?™™™™™™©?      рї                %   _   яяяяяяяяяяяяC   333333ГїF   333333Г?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ    %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя333333Гї        
+ЧЈp=
+·?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ    %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя333333Г?        
+ЧЈp=
+·?              р?        %   f   яяяяяяяяяяяя,   |®Gбz”ї<   z®Gбz”?(   g   unknown%   h   яяяяяяяяяяяя-   |®Gбz”ї=   z®Gбz”?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ    
+point%   яяяяяяяяяяяяяяяя333333Г?333333Г?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ    %   яяяяяяяяяяяяяяяя333333Гї333333Г?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ    %   %   яяяяяяяяяяяяяяяя333333Г?333333Г?™™™™™™©?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   |®Gбz”їV   z®Gбz”?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   333333У?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ    %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя333333Г?333333Гї™™™™™™©?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ    %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя333333Гї333333Г?™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ "   %   яяяяяяяяяяяяяяяя333333Г?333333Г?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ !   %   яяяяяяяяяяяяяяяя333333Гї333333Г?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ    %   %   яяяяяяяяяяяяяяяя        333333Гї
+ЧЈp=
+·?      р?                %   r   яяяяяяяяяяяяC   |®Gбz”їY   z®Gбz”?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ    %   яяяяяяяяяяяяяяяя333333Гї333333Гї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ     %   яяяяяяяяяяяяяяяя333333Г?333333Гї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ    %   %   яяяяяяяяяяяяяяяя333333Г?333333Г?лQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ    %   %   яяяяяяяяяяяяяяяя333333Гї333333Г?лQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ    %   %   яяяяяяяяяяяяяяяя333333Г?333333ГїлQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ    %   %   яяяяяяяяяяяяяяяя333333Гї333333Гї™™™™™™©?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ #   %   яяяяяяяяяяяяяяяя333333Г?333333Гї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ $   %   яяяяяяяяяяяяяяяя333333Гї333333Гї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ    %   %   яяяяяяяяяяяяяяяя333333Гї333333ГїлQё…л±?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7893 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000037.sab
+BIN000000008722
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6	CHIP_MOLD	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9teflon_based
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ С?XXXXXXШ?У?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ 	CHIP_MOLD%          LaDЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ &   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя        F]tСEG<(\ЏВх(ј?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ '   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя        F]tСEG<
+ЧЈp=
+·?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ (   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя333333Г?333333Гї
+ЧЈp=
+·?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   333333Гї-   333333Г?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ )   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя333333Гї333333Гї
+ЧЈp=
+·?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   333333У?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   333333ГїC   333333Г?%   D   unknown%   E   яяяяяяяяяяяяF   333333Гї,   333333Г?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ,   vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя        333333Г?(\ЏВх(ј?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ *   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя333333Гї333333Г?
+ЧЈp=
+·?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   333333У?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   333333У?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ 0   %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя333333Г?333333Г?
+ЧЈp=
+·?      рї                %   _   яяяяяяяяяяяяC   333333ГїF   333333Г?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ -   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя333333Гї        (\ЏВх(ј?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ /   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя333333Г?        (\ЏВх(ј?              р?        %   f   яяяяяяяяяяяя,   x®Gбz„ї<   x®Gбz„?(   g   unknown%   h   яяяяяяяяяяяя-   x®Gбz„ї=   x®Gбz„?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ 8   
+point%   яяяяяяяяяяяяяяяя333333Г?333333Г?(\ЏВх(ј?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ 9   %   яяяяяяяяяяяяяяяя333333Гї333333Г?(\ЏВх(ј?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ +   %   %   яяяяяяяяяяяяяяяя333333Г?333333Г?
+ЧЈp=
+·?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   x®Gбz„їV   x®Gбz„?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   333333У?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ 1   %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя333333Г?333333Гї
+ЧЈp=
+·?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ 3   %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя333333Гї333333Г?
+ЧЈp=
+·?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ =   %   яяяяяяяяяяяяяяяя333333Г?333333Г?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ <   %   яяяяяяяяяяяяяяяя333333Гї333333Г?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ .   %   %   яяяяяяяяяяяяяяяя        333333Гї(\ЏВх(ј?      р?                %   r   яяяяяяяяяяяяC   x®Gбz„їY   x®Gбz„?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ :   %   яяяяяяяяяяяяяяяя333333Гї333333Гї(\ЏВх(ј?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ ;   %   яяяяяяяяяяяяяяяя333333Г?333333Гї(\ЏВх(ј?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ 5   %   %   яяяяяяяяяяяяяяяя333333Г?333333Г?™™™™™™№?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ 7   %   %   яяяяяяяяяяяяяяяя333333Гї333333Г?™™™™™™№?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ 4   %   %   яяяяяяяяяяяяяяяя333333Г?333333Гї™™™™™™№?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ 2   %   %   яяяяяяяяяяяяяяяя333333Гї333333Гї
+ЧЈp=
+·?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ >   %   яяяяяяяяяяяяяяяя333333Г?333333Гї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ ?   %   яяяяяяяяяяяяяяяя333333Гї333333Гї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ 6   %   %   яяяяяяяяяяяяяяяя333333Гї333333Гї™™™™™™№?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7897 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000064.sab
+BIN000000008702
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6M1	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ І±±±±±б?чцццццж?YYYYYYй?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ M1@           К·ЌЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ A   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяяљ™™™™™№їљ™™™™™№їё…лQё®?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ B   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяяљ™™™™™№їљ™™™™™№ї™™™™™™©?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ C   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕї™™™™™™©?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   Ђ®Gбz”ї-   |®Gбz”?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ D   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕї™™™™™™©?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   ~®Gбz¤?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   Ђ®Gбz”їC   |®Gбz”?%   D   unknown%   E   яяяяяяяяяяяяF   |®Gбz”ї,   Ђ®Gбz”?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ G   vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№їz®Gбzґїё…лQё®?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ E   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґї™™™™™™©?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ~®Gбz¤?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ~®Gбz¤?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ K   %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґї™™™™™™©?      рї                %   _   яяяяяяяяяяяяC   |®Gбz”їF   Ђ®Gбz”?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ H   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя№…лQёѕїљ™™™™™№їё…лQё®?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ J   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяяz®Gбzґїљ™™™™™№їё…лQё®?              р?        %   f   яяяяяяяяяяяя,   Ђ®Gбztї<   x®Gбzt?(   g   unknown%   h   яяяяяяяяяяяя-   Ђ®Gбztї=   x®Gбzt?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ S   
+point%   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґїё…лQё®?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ T   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґїё…лQё®?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ F   %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґї™™™™™™©?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   Ђ®GбztїV   x®Gбzt?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   ~®Gбz¤?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ L   %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕї™™™™™™©?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ N   %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґї™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ X   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ W   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ I   %   %   яяяяяяяяяяяяяяяяљ™™™™™№ї№…лQёѕїё…лQё®?      р?                %   r   яяяяяяяяяяяяC   Ђ®GбztїY   x®Gбzt?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ U   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїё…лQё®?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ V   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїё…лQё®?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ P   %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґї(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ R   %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґї(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ O   %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕї(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ M   %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕї™™™™™™©?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ Y   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ Z   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ Q   %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕї(\ЏВх(¬?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7877 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000091.sab
+BIN000000008708
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6M1_L1	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ І±±±±±б?чцццццж?YYYYYYй?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ M1_L1[           К·ЌЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ \   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяяљ™™™™™№?™™™™™™№?ё…лQё®?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ ]   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяяљ™™™™™№?™™™™™™№?™™™™™™©?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ^   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?™™™™™™©?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   |®Gбz”ї-   Ђ®Gбz”?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ _   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?™™™™™™©?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   ~®Gбz¤?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   |®Gбz”їC   Ђ®Gбz”?%   D   unknown%   E   яяяяяяяяяяяяF   Ђ®Gбz”ї,   |®Gбz”?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ b   vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№?№…лQёѕ?ё…лQё®?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ `   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?™™™™™™©?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ~®Gбz¤?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ~®Gбz¤?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ f   %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?™™™™™™©?      рї                %   _   яяяяяяяяяяяяC   Ђ®Gбz”їF   |®Gбz”?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ c   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?љ™™™™™№?ё…лQё®?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ e   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?љ™™™™™№?ё…лQё®?              р?        %   f   яяяяяяяяяяяя,   Ђ®Gбztї<   x®Gбzt?(   g   unknown%   h   яяяяяяяяяяяя-   Ђ®Gбztї=   x®Gбzt?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ n   
+point%   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ o   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ a   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?™™™™™™©?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   Ђ®GбztїV   x®Gбzt?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   ~®Gбz¤?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ g   %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?™™™™™™©?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ i   %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ s   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ r   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ d   %   %   яяяяяяяяяяяяяяяяљ™™™™™№?z®Gбzґ?ё…лQё®?      р?                %   r   яяяяяяяяяяяяC   Ђ®GбztїY   x®Gбzt?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ p   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ q   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ k   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ m   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ j   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ h   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?™™™™™™©?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ t   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ u   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ l   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?(\ЏВх(¬?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7883 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000118.sab
+BIN000000008708
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6M1_L2	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ І±±±±±б?чцццццж?YYYYYYй?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ M1_L2v           К·ЌЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ w   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™™©ї	ЧЈp=
+·?ё…лQё®?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ x   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя™™™™™™©ї	ЧЈp=
+·?™™™™™™©?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ y   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?™™™™™™©?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   
+ЧЈp=
+·ї-   
+ЧЈp=
+·?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ z   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?™™™™™™©?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   
+ЧЈp=
+З?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   ™™™™™©їC   љ™™™™™©?%   D   unknown%   E   яяяяяяяяяяяяF   љ™™™™™©ї,   ™™™™™©?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ }   vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя™™™™™™©їлQё…лБ?ё…лQё®?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ {   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?™™™™™™©?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ™™™™™™№?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ™™™™™™№?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ Ѓ   %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?™™™™™™©?      рї                %   _   яяяяяяяяяяяяC   
+ЧЈp=
+·їF   
+ЧЈp=
+·?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ ~   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяялQё…лБї
+ЧЈp=
+·?ё…лQё®?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ Ђ   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?
+ЧЈp=
+·?ё…лQё®?              р?        %   f   яяяяяяяяяяяя,   Ђ®Gбztї<   x®Gбzt?(   g   unknown%   h   яяяяяяяяяяяя-   Ђ®Gбztї=   x®Gбzt?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ ‰   
+point%   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ Љ   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ |   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?™™™™™™©?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   Ђ®GбztїV   x®Gбzt?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   
+ЧЈp=
+З?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ ‚   %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?™™™™™™©?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ „   %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ Ћ   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ Ќ   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ    %   %   яяяяяяяяяяяяяяяя™™™™™™©їz®Gбz¤?ё…лQё®?      р?                %   r   яяяяяяяяяяяяC   Ђ®GбztїY   x®Gбzt?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ ‹   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ Њ   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ †   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ €   %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ …   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ ѓ   %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?™™™™™™©?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ Џ   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ ђ   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ ‡   %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?(\ЏВх(¬?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7883 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000145.sab
+BIN000000008708
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6M1_L3	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ І±±±±±б?чцццццж?YYYYYYй?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ M1_L3‘           К·ЌЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ’   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™©?	ЧЈp=
+·їё…лQё®?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ “   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя™™™™™©?	ЧЈp=
+·ї™™™™™™©?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ”   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБї™™™™™™©?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   
+ЧЈp=
+·ї-   
+ЧЈp=
+·?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ •   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБї™™™™™™©?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   
+ЧЈp=
+З?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   љ™™™™™©їC   ™™™™™©?%   D   unknown%   E   яяяяяяяяяяяяF   ™™™™™©ї,   љ™™™™™©?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ    vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя™™™™™™©?z®Gбz¤їё…лQё®?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ –   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤ї™™™™™™©?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ™™™™™™№?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ™™™™™™№?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ њ   %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤ї™™™™™™©?      рї                %   _   яяяяяяяяяяяяC   
+ЧЈp=
+·їF   
+ЧЈp=
+·?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ ™   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяяz®Gбz¤ї
+ЧЈp=
+·їё…лQё®?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ ›   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяялQё…лБ?
+ЧЈp=
+·їё…лQё®?              р?        %   f   яяяяяяяяяяяя,   Ђ®Gбztї<   x®Gбzt?(   g   unknown%   h   яяяяяяяяяяяя-   Ђ®Gбztї=   x®Gбzt?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ ¤   
+point%   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їё…лQё®?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ Ґ   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їё…лQё®?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ —   %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤ї™™™™™™©?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   Ђ®GбztїV   x®Gбzt?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   
+ЧЈp=
+З?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ ќ   %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБї™™™™™™©?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ џ   %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤ї™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ ©   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤ї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ Ё   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤ї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ љ   %   %   яяяяяяяяяяяяяяяя™™™™™™©?лQё…лБїё…лQё®?      р?                %   r   яяяяяяяяяяяяC   Ђ®GбztїY   x®Gбzt?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ ¦   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїё…лQё®?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ §   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїё…лQё®?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ Ў   %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤ї(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ Ј   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤ї(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ     %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБї(\ЏВх(¬?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ ћ   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБї™™™™™™©?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ Є   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ «   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ ў   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБї(\ЏВх(¬?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7883 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000172.sab
+BIN000000015067
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6M2	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ юэээээн?444444д?WWWWWWЧ?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ M2¬           ]ЎпЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ­   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя              H<
+ЧЈp=
+·?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ ®   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя              H<z®Gбzґ?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ Ї   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбz”їz®Gбzґ?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   '      (      яяяя%   яяяяяяяяяяяяяяяя)   *         
++   яяяя	edge%   ,   яяяяяяяяяяяя-   |®Gбz”ї.   Ђ®Gбz”?   /   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ °   %   0   яяяяяяяяяяяя1   2      яяяя3   %   яяяяяяяяяяяяяяяяяяяя4          %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбz”їz®Gбzґ?              рї                              рї%   яяяяяяяяяяяяяяяя5   6      (   
+   яяяя%   яяяяяяяяяяяяяяяя7      8   9   
+   яяяя%   яяяяяяяяяяяяяяяя   :   ;   <   
+   яяяя%   яяяяяяяяяяяяяяяя*   )      #   +   яяяя%   =   яяяяяяяяяяяя>           ?   ~®Gбz¤?   @   unknown%   яяяяяяяяяяяяяяяяA      B   C      яяяя%   яяяяяяяяяяяяяяяяD   E      &   
+F   яяяя%   G   яяяяяяяяяяяя.   љ™™™™™©їH   ›™™™™™©?%   I   unknown%   яяяяяяяяяяяяяяяя   J   4   K      яяяя%   L   яяяяяяяяяяяяM   мQё…л±ї-   мQё…л±?   N   unknown%   яяяяяяяяяяяяяяяя"      6   O   +   яяяя%   яяяяяяяяяяяяяяяя   "   D   P   
++   яяяя%   яяяяяяяяяяяяяяяяяяяя   Q       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ·   vertex%   R   яяяяяяяяяяяя   S   %   T   яяяяяяяяяяяя   U   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№?№…лQёѕ?
+ЧЈp=
+·?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ±   %   V   яяяяяяяяяяяяW   X      яяяяY   %   яяяяяяяяяяяяяяяяяяяяZ          %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїz®Gбzґ?      р?                                      рї%   яяяяяяяяяяяяяяяя[   \   '   K   
+   яяяя%   яяяяяяяяяяяяяяяя8      \   ]      яяяя%   яяяяяяяяяяяяяяяя   8   )   O   
+   яяяя%   яяяяяяяяяяяяяяяя^       _   `   
+   яяяя%   яяяяяяяяяяяяяяяя6   5       9      яяяя%   a   яяяяяяяяяяяяb           >   мQё…лБ?    c   unknown%   яяяяяяяяяяяяяяяя!   d   e   f   
+   яяяя%   яяяяяяяяяяяяяяяяE   D   !   <   F   яяяя%   g   яяяяяяяяяяяя?           h   љ™™™™™№?!   i   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ ї   %   j   яяяяяяяяяяяя#   k   %   l   яяяяяяяяяяяя#   m   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?z®Gбzґ?      рї                %   яяяяяяяяяяяяяяяяn   $   o   p      яяяя%   яяяяяяяяяяяяяяяяq   r   $   C   
+s   яяяя%   t   яяяяяяяяяяяяH   љ™™™™™№їu   љ™™™™™№?B   v   unknown%   яяяяяяяяяяяяяяяя;   %   *   P   F   яяяя%   яяяяяяяяяяяяяяяя%   ;   q   w   
+F   яяяя%   яяяяяяяяяяяяяяяяяяяя%   x       %   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ ё   %   y   яяяяяяяяяяяя&   z   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?мQё…л±?
+ЧЈp=
+·?              рї        %   яяяяяяяяяяяяяяяя'   n   Z   {      яяяя%   |   яяяяяяяяяяяя}   љ™™™™™№їM   љ™™™™™№?4   ~   unknown%   %   %   яяяяяяяяяяяяяяяя(   ҐоЫ ѕ   %      яяяяяяяяяяяяK   Ђ   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?љ™™™™™©?
+ЧЈp=
+·?              р?        %   Ѓ   яяяяяяяяяяяя-   Ђ®Gбztї>   Ђ®Gбzt?)   ‚   unknown%   ѓ   яяяяяяяяяяяя.   Ђ®Gбztї?   Ђ®Gбzt?*   „   unknown%   …   яяяяяяяяяяяяяяяя+      яяяя†   %   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ П   
+point%   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя.   ҐоЫ Р   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя1   ҐоЫ І   %   ‡   яяяяяяяяяяяя€   ‰      яяяяЉ   %   яяяяяяяяяяяяяяяяяяяя‹   1       %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїz®Gбzґ?              рї                              рї%   яяяяяяяяяяяяяяяяЊ   Ќ   J   {   
+2   яяяя%   яяяяяяяяяяяяяяяя_   4   Ќ   Ћ      яяяя%   яяяяяяяяяяяяяяяя4   _   5   ]   
+   яяяя%   Џ   яяяяяяяяяяяяM   Ђ®Gбztїb   Ђ®Gбzt?\   ђ   unknown%   яяяяяяяяяяяяяяяя‘   7   ’   “   
+   яяяя%   яяяяяяяяяяяяяяяя\   [   7   `      яяяя%   ”   яяяяяяяяяяяя•           b   љ™™™™™Й?7   –   unknown%   %   %   яяяяяяяяяяяяяяяя9   ҐоЫ А   %   —   яяяяяяяяяяяя`      %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбz”їz®Gбzґ?              р?        %   яяяяяяяяяяяяяяяя:   ‘   ™   љ   
+   яяяя%   яяяяяяяяяяяяяяяяr   q   :   f   s   яяяя%   ›   яяяяяяяяяяяяh           њ   љ™™™™™Й?:   ќ   unknown%   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ Ж   %   ћ   яяяяяяяяяяяя<   џ   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?z®Gбzґ?              рї        %   %   %   яяяяяяяяяяяяяяяя>   ҐоЫ Ш   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ Ч   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?z®Gбzґ?%   яяяяяяяяяяяяяяяяJ   A   ‹          яяяя%   яяяяяяяяяяяяяяяяЎ   ў   A   p   
+‰   яяяя%   Ј   яяяяяяяяяяяяu   мQё…л±ї¤   мQё…л±?o   Ґ   unknown%   яяяяяяяяяяяяяяяяe   B   E   w   s   яяяя%   яяяяяяяяяяяяяяяяB   e   Ў   ¦   
+s   яяяя%   яяяяяяяяяяяяяяяяяяяяB   €       %   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ №   %   §   яяяяяяяяяяяяC   Ё   %   %   яяяяяяяяяяяяяяяя~®Gбz”їz®Gбz”?
+ЧЈp=
+·?      рї                %   ©   яяяяяяяяяяяяH   Ђ®Gбztїh   Ђ®Gбzt?E   Є   unknown%   «   яяяяяяяяяяяяQ   F      яяяя¬   %   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ С   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбz”?
+ЧЈp=
+·?%   ­   яяяяяяяяяяяя®   љ™™™™™©ї}   ›™™™™™©?Z   Ї   unknown%   %   %   яяяяяяяяяяяяяяяяK   ҐоЫ Ѕ   %   °   яяяяяяяяяяяя{   ±   %   %   яяяяяяяяяяяяяяяя~®Gбz”?z®Gбz”ї
+ЧЈp=
+·?      р?                %   %   %   яяяяяяяяяяяяяяяяM   ҐоЫ Ц   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбz”ї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяO   ҐоЫ И   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?Вх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяP   ҐоЫ О   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?Вх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяQ   ҐоЫ ¶   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?z®Gбzґ?              р?       Ђ       Ђ              р?%   %   %   яяяяяяяяяяяяяяяяW   ҐоЫ і   %   І   яяяяяяяяяяяяx   s      яяяяі   %   яяяяяяяяяяяяяяяяяяяяo   W       %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбz”?z®Gбzґ?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяґ   µ   n       
+X   яяяя%   яяяяяяяяяяяяяяяя’   Z   µ   ¶   2   яяяя%   яяяяяяяяяяяяяяяяZ   ’   [   Ћ   
+2   яяяя%   ·   яяяяяяяяяяяя}   Ђ®Gбztї•   Ђ®Gбzt?Ќ   ё   unknown%   %   %   яяяяяяяяяяяяяяяя]   ҐоЫ З   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбz”їВх(\ЏВµ?       Ђ       Ђ      рї%   яяяяяяяяяяяяяяяяd   ^   №   є   
+   яяяя%   яяяяяяяяяяяяяяяяЌ   Њ   ^   “   2   яяяя%   »   яяяяяяяяяяяяј           •   љ™™™™™№?^   Ѕ   unknown%   %   %   яяяяяяяяяяяяяяяя`   ҐоЫ Б   %   ѕ   яяяяяяяяяяяя“   ї   %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбz”їz®Gбzґ?      р?                %   %   %   яяяяяяяяяяяяяяяяb   ҐоЫ Щ   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбz”їz®Gбzґ?%   яяяяяяяяяяяяяяяяў   Ў   d   љ   ‰   яяяя%   А   яяяяяяяяяяяяњ           Б   мQё…лБ?d   В   unknown%   %   %   яяяяяяяяяяяяяяяяf   ҐоЫ Е   %   Г   яяяяяяяяяяяяf   Д   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбz”?z®Gбzґ?      рї                %   %   %   яяяяяяяяяяяяяяяяh   ҐоЫ Ю   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбz”?z®Gбzґ?%   Е   яяяяяяяяяяяя¤   |®Gбz”ї®   Ђ®Gбz”?‹   Ж   unknown%   яяяяяяяяяяяяяяяя™   o   r   ¦   ‰   яяяя%   яяяяяяяяяяяяяяяяo   ™   ґ   З   
+‰   яяяя%   %   %   яяяяяяяяяяяяяяяяp   ҐоЫ є   %   И   яяяяяяяяяяяяp   Й   %   %   яяяяяяяяяяяяяяяя№…лQёѕїљ™™™™™©ї
+ЧЈp=
+·?              рї        %   К   яяяяяяяяяяяяu   Ђ®Gбztїњ   Ђ®Gбzt?r   Л   unknown%   %   %   яяяяяяяяяяяяяяяяu   ҐоЫ Т   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбz”?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяw   ҐоЫ Н   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбz”?Вх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяx   ҐоЫ µ   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?z®Gбzґ?      рї                               Ђ      р?%   %   %   яяяяяяяяяяяяяяяя{   ҐоЫ ј   %   М   яяяяяяяяяяяя    Н   %   %   яяяяяяяяяяяяяяяяz®GбzґїмQё…л±ї
+ЧЈp=
+·?              р?        %   %   %   яяяяяяяяяяяяяяяя}   ҐоЫ Х   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбz”ї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя€   ҐоЫ ґ   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбz”?z®Gбzґ?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяя№   ‹   ў   З   X   яяяя%   яяяяяяяяяяяяяяяя‹   №   Њ   ¶   
+X   яяяя%   О   яяяяяяяяяяяя®   Ђ®Gбztїј   Ђ®Gбzt?µ   П   unknown%   %   %   яяяяяяяяяяяяяяяяЋ   ҐоЫ Й   %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбz”їВх(\ЏВµ?       Ђ       Ђ      рї%   яяяяяяяяяяяяяяяяµ   ґ   ‘   є   X   яяяя%   Р   яяяяяяяяяяяяБ           ј   ~®Gбz¤?‘   С   unknown%   %   %   яяяяяяяяяяяяяяяя“   ҐоЫ В   %   Т   яяяяяяяяяяяяє   У   %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїz®Gбzґ?              р?        %   %   %   яяяяяяяяяяяяяяяя•   ҐоЫ Ъ   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбz”їz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяљ   ҐоЫ Д   %   Ф   яяяяяяяяяяяяљ   Х   %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбz”?z®Gбzґ?              рї        %   %   %   яяяяяяяяяяяяяяяяњ   ҐоЫ Э   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбz”?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя    ҐоЫ »   %   %   яяяяяяяяяяяяяяяяљ™™™™™№ї№…лQёѕї
+ЧЈp=
+·?      р?                %   Ц   яяяяяяяяяяяя¤   Ђ®GбztїБ   Ђ®Gбzt?ў   Ч   unknown%   %   %   яяяяяяяяяяяяяяяя¤   ҐоЫ У   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя¦   ҐоЫ М   %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбz”?Вх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяя®   ҐоЫ Ф   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя¶   ҐоЫ К   %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїВх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяє   ҐоЫ Г   %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїz®Gбzґ?      р?                %   %   %   яяяяяяяяяяяяяяяяј   ҐоЫ Ы   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяБ   ҐоЫ Ь   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяЗ   ҐоЫ Л   %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїВх(\ЏВµ?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 14241 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000223.sab
+BIN000000008708
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6M2_L1	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ юэээээн?444444д?WWWWWWЧ?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ M2_L1Я           ]ЎпЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ а   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™™©ї	ЧЈp=
+·?
+ЧЈp=
+·?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ б   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя™™™™™™©ї	ЧЈp=
+·?z®Gбzґ?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ в   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?z®Gбzґ?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   
+ЧЈp=
+·ї-   
+ЧЈp=
+·?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ г   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?z®Gбzґ?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   
+ЧЈp=
+З?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   ™™™™™©їC   љ™™™™™©?%   D   unknown%   E   яяяяяяяяяяяяF   љ™™™™™©ї,   ™™™™™©?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ж   vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя™™™™™™©їлQё…лБ?
+ЧЈp=
+·?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ д   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?z®Gбzґ?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ™™™™™™№?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ™™™™™™№?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ к   %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?z®Gбzґ?      рї                %   _   яяяяяяяяяяяяC   
+ЧЈp=
+·їF   
+ЧЈp=
+·?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ з   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяялQё…лБї
+ЧЈp=
+·?
+ЧЈp=
+·?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ й   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?
+ЧЈp=
+·?
+ЧЈp=
+·?              р?        %   f   яяяяяяяяяяяя,   Ђ®Gбztї<   Ђ®Gбzt?(   g   unknown%   h   яяяяяяяяяяяя-   Ђ®Gбztї=   Ђ®Gбzt?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ т   
+point%   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ у   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ е   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?z®Gбzґ?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   Ђ®GбztїV   Ђ®Gбzt?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   
+ЧЈp=
+З?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ л   %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?z®Gбzґ?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ н   %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?z®Gбzґ?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ ч   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ ц   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ и   %   %   яяяяяяяяяяяяяяяя™™™™™™©їz®Gбz¤?
+ЧЈp=
+·?      р?                %   r   яяяяяяяяяяяяC   Ђ®GбztїY   Ђ®Gбzt?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ ф   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ х   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ п   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?Вх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ с   %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?Вх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ о   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?Вх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ м   %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?z®Gбzґ?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ ш   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ щ   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ р   %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?Вх(\ЏВµ?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7883 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000250.sab
+BIN000000008708
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6M2_L2	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ юэээээн?444444д?WWWWWWЧ?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ M2_L2ъ           ]ЎпЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ы   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™©?	ЧЈp=
+·ї
+ЧЈp=
+·?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ ь   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя™™™™™©?	ЧЈp=
+·їz®Gбzґ?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ э   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїz®Gбzґ?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   
+ЧЈp=
+·ї-   
+ЧЈp=
+·?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ю   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїz®Gбzґ?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   
+ЧЈp=
+З?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   љ™™™™™©їC   ™™™™™©?%   D   unknown%   E   яяяяяяяяяяяяF   ™™™™™©ї,   љ™™™™™©?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя™™™™™™©?z®Gбz¤ї
+ЧЈp=
+·?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їz®Gбzґ?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ™™™™™™№?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ™™™™™™№?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ   %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їz®Gбzґ?      рї                %   _   яяяяяяяяяяяяC   
+ЧЈp=
+·їF   
+ЧЈp=
+·?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяяz®Gбz¤ї
+ЧЈp=
+·ї
+ЧЈp=
+·?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяялQё…лБ?
+ЧЈp=
+·ї
+ЧЈp=
+·?              р?        %   f   яяяяяяяяяяяя,   Ђ®Gбztї<   Ђ®Gбzt?(   g   unknown%   h   яяяяяяяяяяяя-   Ђ®Gбztї=   Ђ®Gбzt?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ   
+point%   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤ї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤ї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ    %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їz®Gбzґ?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   Ђ®GбztїV   Ђ®Gбzt?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   
+ЧЈp=
+З?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ   %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїz®Gбzґ?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ   %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їz®Gбzґ?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ   %   %   яяяяяяяяяяяяяяяя™™™™™™©?лQё…лБї
+ЧЈp=
+·?      р?                %   r   яяяяяяяяяяяяC   Ђ®GбztїY   Ђ®Gбzt?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБї
+ЧЈp=
+·?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ 
+  %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їВх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їВх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ 	  %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїВх(\ЏВµ?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїz®Gбzґ?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїВх(\ЏВµ?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7883 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000277.sab
+BIN000000008958
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6SBALL	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ ^^^^^^о?ЩШШШШШШ?>>>>>>о?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ SBALL          сcтЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™№ї™™™™™№?™™™™™™©?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+   
+      Аї333333і?        333333ії      А?            %   %   яяяяяяяяяяяяяяяя™™™™™№ї™™™™™№?                              р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя333333ії333333і?              р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   њ™™™™™™ї-   ™™™™™™?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя      Аї333333і?                      рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   љ™™™™™©?   >   unknown
+      Аї      А?        333333ії      А?        %   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   ™™™™™™їC   њ™™™™™™?%   D   unknown%   E   яяяяяяяяяяяяF   њ™™™™™™ї,   ™™™™™™?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№ї      А?™™™™™™©?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя      Аї      А?              рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   љ™™™™™©?    W   unknown
+333333ії333333і?        333333ії      А?        %   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   љ™™™™™©?!   Z   unknown
+      Аї333333і?              Аї      А?        %   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ    %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя333333ії      А?              рї                %   _   яяяяяяяяяяяяC   ™™™™™™їF   њ™™™™™™?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя      Аїљ™™™™™№?™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя333333іїљ™™™™™№?™™™™™™©?              р?        %   f   яяяяяяяяяяяя,   ™™™™™™™ї<   ™™™™™™™?(   g   unknown%   h   яяяяяяяяяяяя-   ™™™™™™™ї=   ™™™™™™™?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ (  
+point%   яяяяяяяяяяяяяяяя333333ії      А?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ )  %   яяяяяяяяяяяяяяяя      Аї      А?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ   %   %   яяяяяяяяяяяяяяяя333333ії      А?                      р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   ™™™™™™™їV   ™™™™™™™?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   љ™™™™™©?6   m   unknown
+      Аї333333і?        333333ії333333і?        %   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ !  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя333333ії333333і?                      р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ #  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя      Аї      А?                      рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ -  %   яяяяяяяяяяяяяяяя333333ії      А?        %   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ ,  %   яяяяяяяяяяяяяяяя      Аї      А?        %   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ   %   %   яяяяяяяяяяяяяяяяљ™™™™™№ї333333і?™™™™™™©?      р?                %   r   яяяяяяяяяяяяC   ™™™™™™™їY   ™™™™™™™?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ *  %   яяяяяяяяяяяяяяяя      Аї333333і?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ +  %   яяяяяяяяяяяяяяяя333333ії333333і?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ %  %   %   яяяяяяяяяяяяяяяя333333ії      А?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ '  %   %   яяяяяяяяяяяяяяяя      Аї      А?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ $  %   %   яяяяяяяяяяяяяяяя333333ії333333і?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ "  %   %   яяяяяяяяяяяяяяяя      Аї333333і?              р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ .  %   яяяяяяяяяяяяяяяя333333ії333333і?        %   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ /  %   яяяяяяяяяяяяяяяя      Аї333333і?        %   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ &  %   %   яяяяяяяяяяяяяяяя      Аї333333і?™™™™™™™?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 8133 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000304.sab
+BIN000000008964
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6SBALL_L1	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ ^^^^^^о?ЩШШШШШШ?>>>>>>о?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ SBALL_L10          сcтЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ 1  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™™№?™™™™™№?™™™™™™©?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ 2  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+   
+333333і?333333і?              А?      А?            %   %   яяяяяяяяяяяяяяяя™™™™™™№?™™™™™№?                              р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ 3  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя      А?333333і?              р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   ™™™™™™ї-   њ™™™™™™?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ 4  %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя333333і?333333і?                      рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   љ™™™™™©?   >   unknown
+333333і?      А?              А?      А?        %   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   ™™™™™™їC   њ™™™™™™?%   D   unknown%   E   яяяяяяяяяяяяF   њ™™™™™™ї,   ™™™™™™?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ 7  vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№?      А?™™™™™™©?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ 5  %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя333333і?      А?              рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   љ™™™™™©?    W   unknown
+      А?333333і?              А?      А?        %   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   љ™™™™™©?!   Z   unknown
+333333і?333333і?        333333і?      А?        %   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ ;  %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя      А?      А?              рї                %   _   яяяяяяяяяяяяC   њ™™™™™™їF   ™™™™™™?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ 8  %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя333333і?љ™™™™™№?™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ :  %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя      А?љ™™™™™№?™™™™™™©?              р?        %   f   яяяяяяяяяяяя,   ™™™™™™™ї<   ™™™™™™™?(   g   unknown%   h   яяяяяяяяяяяя-   ™™™™™™™ї=   ™™™™™™™?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ C  
+point%   яяяяяяяяяяяяяяяя      А?      А?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ D  %   яяяяяяяяяяяяяяяя333333і?      А?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ 6  %   %   яяяяяяяяяяяяяяяя      А?      А?                      р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   ™™™™™™™їV   ™™™™™™™?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   љ™™™™™©?6   m   unknown
+333333і?333333і?              А?333333і?        %   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ <  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя      А?333333і?                      р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ >  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя333333і?      А?                      рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ H  %   яяяяяяяяяяяяяяяя      А?      А?        %   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ G  %   яяяяяяяяяяяяяяяя333333і?      А?        %   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ 9  %   %   яяяяяяяяяяяяяяяяљ™™™™™№?333333і?™™™™™™©?      р?                %   r   яяяяяяяяяяяяC   ™™™™™™™їY   ™™™™™™™?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ E  %   яяяяяяяяяяяяяяяя333333і?333333і?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ F  %   яяяяяяяяяяяяяяяя      А?333333і?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ @  %   %   яяяяяяяяяяяяяяяя      А?      А?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ B  %   %   яяяяяяяяяяяяяяяя333333і?      А?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ ?  %   %   яяяяяяяяяяяяяяяя      А?333333і?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ =  %   %   яяяяяяяяяяяяяяяя333333і?333333і?              р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ I  %   яяяяяяяяяяяяяяяя      А?333333і?        %   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ J  %   яяяяяяяяяяяяяяяя333333і?333333і?        %   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ A  %   %   яяяяяяяяяяяяяяяя333333і?333333і?™™™™™™™?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 8139 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000331.sab
+BIN000000008964
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6SBALL_L2	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ ^^^^^^о?ЩШШШШШШ?>>>>>>о?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ SBALL_L2K          сcтЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ L  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™™№?™™™™™™№ї™™™™™™©?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ M  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+   
+333333і?      Аї              А?333333ії            %   %   яяяяяяяяяяяяяяяя™™™™™™№?™™™™™™№ї                              р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ N  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя      А?      Аї              р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   ™™™™™™ї-   њ™™™™™™?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ O  %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя333333і?      Аї                      рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   љ™™™™™©?   >   unknown
+333333і?333333ії              А?333333ії        %   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   њ™™™™™™їC   ™™™™™™?%   D   unknown%   E   яяяяяяяяяяяяF   ™™™™™™ї,   њ™™™™™™?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ R  vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№?333333ії™™™™™™©?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ P  %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя333333і?333333ії              рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   љ™™™™™©?    W   unknown
+      А?      Аї              А?333333ії        %   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   љ™™™™™©?!   Z   unknown
+333333і?      Аї        333333і?333333ії        %   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ V  %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя      А?333333ії              рї                %   _   яяяяяяяяяяяяC   њ™™™™™™їF   ™™™™™™?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ S  %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя333333і?љ™™™™™№ї™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ U  %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя      А?љ™™™™™№ї™™™™™™©?              р?        %   f   яяяяяяяяяяяя,   ™™™™™™™ї<   ™™™™™™™?(   g   unknown%   h   яяяяяяяяяяяя-   ™™™™™™™ї=   ™™™™™™™?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ ^  
+point%   яяяяяяяяяяяяяяяя      А?333333ії™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ _  %   яяяяяяяяяяяяяяяя333333і?333333ії™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ Q  %   %   яяяяяяяяяяяяяяяя      А?333333ії                      р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   ™™™™™™™їV   ™™™™™™™?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   љ™™™™™©?6   m   unknown
+333333і?      Аї              А?      Аї        %   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ W  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя      А?      Аї                      р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ Y  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя333333і?333333ії                      рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ c  %   яяяяяяяяяяяяяяяя      А?333333ії        %   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ b  %   яяяяяяяяяяяяяяяя333333і?333333ії        %   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ T  %   %   яяяяяяяяяяяяяяяяљ™™™™™№?      Аї™™™™™™©?      р?                %   r   яяяяяяяяяяяяC   ™™™™™™™їY   ™™™™™™™?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ `  %   яяяяяяяяяяяяяяяя333333і?      Аї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ a  %   яяяяяяяяяяяяяяяя      А?      Аї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ [  %   %   яяяяяяяяяяяяяяяя      А?333333ії™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ ]  %   %   яяяяяяяяяяяяяяяя333333і?333333ії™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ Z  %   %   яяяяяяяяяяяяяяяя      А?      Аї™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ X  %   %   яяяяяяяяяяяяяяяя333333і?      Аї              р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ d  %   яяяяяяяяяяяяяяяя      А?      Аї        %   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ e  %   яяяяяяяяяяяяяяяя333333і?      Аї        %   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ \  %   %   яяяяяяяяяяяяяяяя333333і?      Аї™™™™™™™?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 8139 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000358.sab
+BIN000000008964
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6SBALL_L3	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ ^^^^^^о?ЩШШШШШШ?>>>>>>о?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ SBALL_L3f          сcтЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ g  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя        ™™™™™№ї™™™™™™©?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ h  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+   
+™™™™™™™ї      Аї        ™™™™™™™?333333ії            %   %   яяяяяяяяяяяяяяяя        ™™™™™№ї                              р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ i  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя™™™™™™™?      Аї              р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   ™™™™™™™ї-   ™™™™™™™?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ j  %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя™™™™™™™ї      Аї                      рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   ™™™™™™©?   >   unknown
+™™™™™™™ї333333ії        ™™™™™™™?333333ії        %   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   њ™™™™™™їC   ™™™™™™?%   D   unknown%   E   яяяяяяяяяяяяF   ™™™™™™ї,   њ™™™™™™?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ m  vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя        333333ії™™™™™™©?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ k  %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя™™™™™™™ї333333ії              рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   љ™™™™™©?    W   unknown
+™™™™™™™?      Аї        ™™™™™™™?333333ії        %   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   љ™™™™™©?!   Z   unknown
+™™™™™™™ї      Аї        ™™™™™™™ї333333ії        %   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ q  %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя™™™™™™™?333333ії              рї                %   _   яяяяяяяяяяяяC   ™™™™™™™їF   ™™™™™™™?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ n  %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя™™™™™™™їљ™™™™™№ї™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ p  %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя™™™™™™™?љ™™™™™№ї™™™™™™©?              р?        %   f   яяяяяяяяяяяя,   ™™™™™™™ї<   ™™™™™™™?(   g   unknown%   h   яяяяяяяяяяяя-   ™™™™™™™ї=   ™™™™™™™?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ y  
+point%   яяяяяяяяяяяяяяяя™™™™™™™?333333ії™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ z  %   яяяяяяяяяяяяяяяя™™™™™™™ї333333ії™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ l  %   %   яяяяяяяяяяяяяяяя™™™™™™™?333333ії                      р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   ™™™™™™™їV   ™™™™™™™?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   ™™™™™™©?6   m   unknown
+™™™™™™™ї      Аї        ™™™™™™™?      Аї        %   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ r  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя™™™™™™™?      Аї                      р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ t  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя™™™™™™™ї333333ії                      рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ ~  %   яяяяяяяяяяяяяяяя™™™™™™™?333333ії        %   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ }  %   яяяяяяяяяяяяяяяя™™™™™™™ї333333ії        %   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ o  %   %   яяяяяяяяяяяяяяяя              Аї™™™™™™©?      р?                %   r   яяяяяяяяяяяяC   ™™™™™™™їY   ™™™™™™™?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ {  %   яяяяяяяяяяяяяяяя™™™™™™™ї      Аї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ |  %   яяяяяяяяяяяяяяяя™™™™™™™?      Аї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ v  %   %   яяяяяяяяяяяяяяяя™™™™™™™?333333ії™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ x  %   %   яяяяяяяяяяяяяяяя™™™™™™™ї333333ії™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ u  %   %   яяяяяяяяяяяяяяяя™™™™™™™?      Аї™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ s  %   %   яяяяяяяяяяяяяяяя™™™™™™™ї      Аї              р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ   %   яяяяяяяяяяяяяяяя™™™™™™™?      Аї        %   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ Ђ  %   яяяяяяяяяяяяяяяя™™™™™™™ї      Аї        %   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ w  %   %   яяяяяяяяяяяяяяяя™™™™™™™ї      Аї™™™™™™™?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 8139 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000385.sab
+BIN000000008964
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6SBALL_L4	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ ^^^^^^о?ЩШШШШШШ?>>>>>>о?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ SBALL_L4Ѓ          сcтЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ‚  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя        ™™™™™№?™™™™™™©?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ ѓ  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+   
+™™™™™™™ї333333і?        ™™™™™™™?      А?            %   %   яяяяяяяяяяяяяяяя        ™™™™™№?                              р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ „  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя™™™™™™™?333333і?              р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   ™™™™™™™ї-   ™™™™™™™?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ …  %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя™™™™™™™ї333333і?                      рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   ™™™™™™©?   >   unknown
+™™™™™™™ї      А?        ™™™™™™™?      А?        %   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   ™™™™™™їC   њ™™™™™™?%   D   unknown%   E   яяяяяяяяяяяяF   њ™™™™™™ї,   ™™™™™™?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ €  vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя              А?™™™™™™©?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ †  %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя™™™™™™™ї      А?              рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   љ™™™™™©?    W   unknown
+™™™™™™™?333333і?        ™™™™™™™?      А?        %   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   љ™™™™™©?!   Z   unknown
+™™™™™™™ї333333і?        ™™™™™™™ї      А?        %   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ Њ  %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя™™™™™™™?      А?              рї                %   _   яяяяяяяяяяяяC   ™™™™™™™їF   ™™™™™™™?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ ‰  %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя™™™™™™™їљ™™™™™№?™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ ‹  %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя™™™™™™™?љ™™™™™№?™™™™™™©?              р?        %   f   яяяяяяяяяяяя,   ™™™™™™™ї<   ™™™™™™™?(   g   unknown%   h   яяяяяяяяяяяя-   ™™™™™™™ї=   ™™™™™™™?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ ”  
+point%   яяяяяяяяяяяяяяяя™™™™™™™?      А?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ •  %   яяяяяяяяяяяяяяяя™™™™™™™ї      А?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ ‡  %   %   яяяяяяяяяяяяяяяя™™™™™™™?      А?                      р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   ™™™™™™™їV   ™™™™™™™?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   ™™™™™™©?6   m   unknown
+™™™™™™™ї333333і?        ™™™™™™™?333333і?        %   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ Ќ  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя™™™™™™™?333333і?                      р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ Џ  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя™™™™™™™ї      А?                      рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ ™  %   яяяяяяяяяяяяяяяя™™™™™™™?      А?        %   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ   %   яяяяяяяяяяяяяяяя™™™™™™™ї      А?        %   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ Љ  %   %   яяяяяяяяяяяяяяяя        333333і?™™™™™™©?      р?                %   r   яяяяяяяяяяяяC   ™™™™™™™їY   ™™™™™™™?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ –  %   яяяяяяяяяяяяяяяя™™™™™™™ї333333і?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ —  %   яяяяяяяяяяяяяяяя™™™™™™™?333333і?™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ ‘  %   %   яяяяяяяяяяяяяяяя™™™™™™™?      А?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ “  %   %   яяяяяяяяяяяяяяяя™™™™™™™ї      А?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ ђ  %   %   яяяяяяяяяяяяяяяя™™™™™™™?333333і?™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ Ћ  %   %   яяяяяяяяяяяяяяяя™™™™™™™ї333333і?              р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ љ  %   яяяяяяяяяяяяяяяя™™™™™™™?333333і?        %   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ ›  %   яяяяяяяяяяяяяяяя™™™™™™™ї333333і?        %   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ ’  %   %   яяяяяяяяяяяяяяяя™™™™™™™ї333333і?™™™™™™™?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 8139 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000412.sab
+BIN000000008964
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6SBALL_L5	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ ^^^^^^о?ЩШШШШШШ?>>>>>>о?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ SBALL_L5њ          сcтЂid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ќ  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™№ї™™™™™™№ї™™™™™™©?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ ћ  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+   
+      Аї      Аї        333333ії333333ії            %   %   яяяяяяяяяяяяяяяя™™™™™№ї™™™™™™№ї                              р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ џ  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя333333ії      Аї              р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   њ™™™™™™ї-   ™™™™™™?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ    %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя      Аї      Аї                      рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   љ™™™™™©?   >   unknown
+      Аї333333ії        333333ії333333ії        %   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   њ™™™™™™їC   ™™™™™™?%   D   unknown%   E   яяяяяяяяяяяяF   ™™™™™™ї,   њ™™™™™™?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ Ј  vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№ї333333ії™™™™™™©?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ Ў  %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя      Аї333333ії              рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   љ™™™™™©?    W   unknown
+333333ії      Аї        333333ії333333ії        %   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   љ™™™™™©?!   Z   unknown
+      Аї      Аї              Аї333333ії        %   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ §  %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя333333ії333333ії              рї                %   _   яяяяяяяяяяяяC   ™™™™™™їF   њ™™™™™™?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ ¤  %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя      Аїљ™™™™™№ї™™™™™™©?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ ¦  %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя333333іїљ™™™™™№ї™™™™™™©?              р?        %   f   яяяяяяяяяяяя,   ™™™™™™™ї<   ™™™™™™™?(   g   unknown%   h   яяяяяяяяяяяя-   ™™™™™™™ї=   ™™™™™™™?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ Ї  
+point%   яяяяяяяяяяяяяяяя333333ії333333ії™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ °  %   яяяяяяяяяяяяяяяя      Аї333333ії™™™™™™©?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ ў  %   %   яяяяяяяяяяяяяяяя333333ії333333ії                      р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   ™™™™™™™їV   ™™™™™™™?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   љ™™™™™©?6   m   unknown
+      Аї      Аї        333333ії      Аї        %   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ Ё  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя333333ії      Аї                      р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ Є  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя      Аї333333ії                      рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ ґ  %   яяяяяяяяяяяяяяяя333333ії333333ії        %   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ і  %   яяяяяяяяяяяяяяяя      Аї333333ії        %   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ Ґ  %   %   яяяяяяяяяяяяяяяяљ™™™™™№ї      Аї™™™™™™©?      р?                %   r   яяяяяяяяяяяяC   ™™™™™™™їY   ™™™™™™™?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ ±  %   яяяяяяяяяяяяяяяя      Аї      Аї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ І  %   яяяяяяяяяяяяяяяя333333ії      Аї™™™™™™©?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ ¬  %   %   яяяяяяяяяяяяяяяя333333ії333333ії™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ ®  %   %   яяяяяяяяяяяяяяяя      Аї333333ії™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ «  %   %   яяяяяяяяяяяяяяяя333333ії      Аї™™™™™™™?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ ©  %   %   яяяяяяяяяяяяяяяя      Аї      Аї              р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ µ  %   яяяяяяяяяяяяяяяя333333ії      Аї        %   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ ¶  %   яяяяяяяяяяяяяяяя      Аї      Аї        %   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ ­  %   %   яяяяяяяяяяяяяяяя      Аї      Аї™™™™™™™?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 8139 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000439.sab
+BIN000000008704
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6V12	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ Д?г?111111б?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ V12·          ‰(Ђid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ё  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяяљ™™™™™№їљ™™™™™№їz®Gбzґ?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ №  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяяљ™™™™™№їљ™™™™™№їё…лQё®?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ є  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїё…лQё®?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   Ђ®Gбz”ї-   |®Gбz”?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ »  %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїё…лQё®?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   ~®Gбz¤?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   Ђ®Gбz”їC   |®Gбz”?%   D   unknown%   E   яяяяяяяяяяяяF   |®Gбz”ї,   Ђ®Gбz”?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ѕ  vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№їz®Gбzґїz®Gбzґ?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ј  %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґїё…лQё®?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ~®Gбz¤?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ~®Gбz¤?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ В  %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґїё…лQё®?      рї                %   _   яяяяяяяяяяяяC   |®Gбz”їF   Ђ®Gбz”?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ ї  %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяя№…лQёѕїљ™™™™™№їz®Gбzґ?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ Б  %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяяz®Gбzґїљ™™™™™№їz®Gбzґ?              р?        %   f   яяяяяяяяяяяя,   x®Gбz„ї<   x®Gбz„?(   g   unknown%   h   яяяяяяяяяяяя-   x®Gбz„ї=   x®Gбz„?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ К  
+point%   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ Л  %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ Ѕ  %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґїё…лQё®?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   x®Gбz„їV   x®Gбz„?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   ~®Gбz¤?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ Г  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїё…лQё®?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ Е  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґїё…лQё®?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ П  %   яяяяяяяяяяяяяяяяz®Gбzґїz®Gбzґїё…лQё®?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ О  %   яяяяяяяяяяяяяяяя№…лQёѕїz®Gбzґїё…лQё®?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ А  %   %   яяяяяяяяяяяяяяяяљ™™™™™№ї№…лQёѕїz®Gбzґ?      р?                %   r   яяяяяяяяяяяяC   x®Gбz„їY   x®Gбz„?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ М  %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ Н  %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ З  %   %   яяяяяяяяяяяяяяяяz®Gбzґїz®GбzґїлQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ Й  %   %   яяяяяяяяяяяяяяяя№…лQёѕїz®GбzґїлQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ Ж  %   %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїлQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ Д  %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїё…лQё®?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ Р  %   яяяяяяяяяяяяяяяяz®Gбzґї№…лQёѕїё…лQё®?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ С  %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїё…лQё®?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ И  %   %   яяяяяяяяяяяяяяяя№…лQёѕї№…лQёѕїлQё…л±?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7879 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000466.sab
+BIN000000008710
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6V12_L1	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ Д?г?111111б?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ V12_L1Т          ‰(Ђid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ У  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяяљ™™™™™№?™™™™™™№?z®Gбzґ?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ Ф  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяяљ™™™™™№?™™™™™™№?ё…лQё®?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ Х  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?ё…лQё®?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   |®Gбz”ї-   Ђ®Gбz”?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ Ц  %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?ё…лQё®?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   ~®Gбz¤?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   |®Gбz”їC   Ђ®Gбz”?%   D   unknown%   E   яяяяяяяяяяяяF   Ђ®Gбz”ї,   |®Gбz”?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ Щ  vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяяљ™™™™™№?№…лQёѕ?z®Gбzґ?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ Ч  %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?ё…лQё®?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ~®Gбz¤?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ~®Gбz¤?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ Э  %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?ё…лQё®?      рї                %   _   яяяяяяяяяяяяC   Ђ®Gбz”їF   |®Gбz”?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ Ъ  %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?љ™™™™™№?z®Gбzґ?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ Ь  %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?љ™™™™™№?z®Gбzґ?              р?        %   f   яяяяяяяяяяяя,   x®Gбz„ї<   x®Gбz„?(   g   unknown%   h   яяяяяяяяяяяя-   x®Gбz„ї=   x®Gбz„?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ е  
+point%   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ ж  %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ Ш  %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?ё…лQё®?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   x®Gбz„їV   x®Gбz„?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   ~®Gбz¤?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ Ю  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?ё…лQё®?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ а  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?ё…лQё®?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ к  %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ й  %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ Ы  %   %   яяяяяяяяяяяяяяяяљ™™™™™№?z®Gбzґ?z®Gбzґ?      р?                %   r   яяяяяяяяяяяяC   x®Gбz„їY   x®Gбz„?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ з  %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ и  %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ в  %   %   яяяяяяяяяяяяяяяя№…лQёѕ?№…лQёѕ?лQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ д  %   %   яяяяяяяяяяяяяяяяz®Gбzґ?№…лQёѕ?лQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ б  %   %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?лQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ Я  %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?ё…лQё®?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ л  %   яяяяяяяяяяяяяяяя№…лQёѕ?z®Gбzґ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ м  %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ г  %   %   яяяяяяяяяяяяяяяяz®Gбzґ?z®Gбzґ?лQё…л±?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7885 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000493.sab
+BIN000000008710
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6V12_L2	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ Д?г?111111б?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ V12_L2н          ‰(Ђid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ о  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™™©ї	ЧЈp=
+·?z®Gбzґ?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ п  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя™™™™™™©ї	ЧЈp=
+·?ё…лQё®?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ р  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?ё…лQё®?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   
+ЧЈp=
+·ї-   
+ЧЈp=
+·?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ с  %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?ё…лQё®?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   
+ЧЈp=
+З?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   ™™™™™©їC   љ™™™™™©?%   D   unknown%   E   яяяяяяяяяяяяF   љ™™™™™©ї,   ™™™™™©?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ ф  vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя™™™™™™©їлQё…лБ?z®Gбzґ?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ т  %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?ё…лQё®?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ™™™™™™№?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ™™™™™™№?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ ш  %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?ё…лQё®?      рї                %   _   яяяяяяяяяяяяC   
+ЧЈp=
+·їF   
+ЧЈp=
+·?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ х  %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяялQё…лБї
+ЧЈp=
+·?z®Gбzґ?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ ч  %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?
+ЧЈp=
+·?z®Gбzґ?              р?        %   f   яяяяяяяяяяяя,   x®Gбz„ї<   x®Gбz„?(   g   unknown%   h   яяяяяяяяяяяя-   x®Gбz„ї=   x®Gбz„?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ    
+point%   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ у  %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?ё…лQё®?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   x®Gбz„їV   x®Gбz„?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   
+ЧЈp=
+З?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ щ  %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?ё…лQё®?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ ы  %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?ё…лQё®?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ ц  %   %   яяяяяяяяяяяяяяяя™™™™™™©їz®Gбz¤?z®Gбzґ?      р?                %   r   яяяяяяяяяяяяC   x®Gбz„їY   x®Gбz„?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?z®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ э  %   %   яяяяяяяяяяяяяяяяz®Gбz¤?лQё…лБ?лQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ я  %   %   яяяяяяяяяяяяяяяялQё…лБїлQё…лБ?лQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ ь  %   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?лQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ ъ  %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?ё…лQё®?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤?z®Gбz¤?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?ё…лQё®?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ ю  %   %   яяяяяяяяяяяяяяяялQё…лБїz®Gбz¤?лQё…л±?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7885 
+$end 'sab'
+$begin 'sab'
+NativeGeometryFiles/0000520.sab
+BIN000000008710
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MGHH_SM9UVY4D3VZVCD4XCB5_N6944NPTHCFCGC7D7DP3K85DBDRVJA6V2D5MJCNHUBRUKJ66YDNCN	body%      яяяяяяяяяяяя       яяяя   string_attrib%   name_attrib%   gen%   attrib%   яяяяяяяя   яяяя    ¦оЯ ATTRIB_XACIS_NAME%6V12_L3	lump%   яяяяяяяяяяяяяяяяяяяя       transform%   яяяяяяяя      р?                              р?                              р?                              р?%   %   %   %   яяяяяяяя          ¦оЯ SPAATTRIB_MATERIAL_NAME%9copper
+shell%
+   яяяяяяяяяяяяяяяяяяяяяяяя   яяяя   rgb_color%   st%   %   яяяяяяяя          ЖоЯ Д?г?111111б?	face%   	   яяяяяяяяяяяя
+         яяяя   properties%   ansoft%   %   яяяяяяяяяяяя       ҐоЫ V12_L3          ‰(Ђid%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ 	  %      яяяяяяяяяяяя         яяяя   
+	loop%   яяяяяяяяяяяяяяяяяяяя          
+plane%   surface%   яяяяяяяяяяяяяяяя™™™™™©?	ЧЈp=
+·їz®Gбzґ?                      р?      р?                %   %   %   яяяяяяяяяяяяяяяя
+   ҐоЫ 
+  %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя   
+       %   %   яяяяяяяяяяяяяяяя™™™™™©?	ЧЈp=
+·їё…лQё®?                      р?      р?                coedge%   яяяяяяяяяяяяяяяя               яяяя%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   %      яяяяяяяяяяяя         яяяя   %   яяяяяяяяяяяяяяяяяяяя          %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїё…лQё®?      р?                                      рї%   яяяяяяяяяяяяяяяя    !   "   #   
+   яяяя%   яяяяяяяяяяяяяяяя$      %   &      яяяя%   яяяяяяяяяяяяяяяя   $      '      яяяя%   яяяяяяяяяяяяяяяя(   )         
+*   яяяя	edge%   +   яяяяяяяяяяяя,   
+ЧЈp=
+·ї-   
+ЧЈp=
+·?   .   unknown%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   %   /   яяяяяяяяяяяя0   1      яяяя2   %   яяяяяяяяяяяяяяяяяяяя3          %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїё…лQё®?              рї                              рї%   яяяяяяяяяяяяяяяя4   5      '   
+   яяяя%   яяяяяяяяяяяяяяяя6      7   8   
+   яяяя%   яяяяяяяяяяяяяяяя   6   9   :   
+   яяяя%   яяяяяяяяяяяяяяяя)   (      #   *   яяяя%   ;   яяяяяяяяяяяя<           =   
+ЧЈp=
+З?   >   unknown%   яяяяяяяяяяяяяяяя      3   ?      яяяя%   яяяяяяяяяяяяяяяя@   A      &   
+1   яяяя%   B   яяяяяяяяяяяя-   љ™™™™™©їC   ™™™™™©?%   D   unknown%   E   яяяяяяяяяяяяF   ™™™™™©ї,   љ™™™™™©?   G   unknown%   яяяяяяяяяяяяяяяя"      5   H   *   яяяя%   яяяяяяяяяяяяяяяя   "   @   I   
+*   яяяя%   яяяяяяяяяяяяяяяяяяяя   0       %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   vertex%   J   яяяяяяяяяяяя   K   %   L   яяяяяяяяяяяя   M   straight%   
+curve%   яяяяяяяяяяяяяяяя™™™™™™©?z®Gбz¤їz®Gбzґ?      рї                %   %   %   яяяяяяяяяяяяяяяя   ҐоЫ   %   N   яяяяяяяяяяяяяяяя*      яяяяO   %   яяяяяяяяяяяяяяяяяяяя%          %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їё…лQё®?      рї                               Ђ      р?%   яяяяяяяяяяяяяяяяP   Q   $   ?   
+   яяяя%   яяяяяяяяяяяяяяяя7      Q   R      яяяя%   яяяяяяяяяяяяяяяя   7   (   H   
+   яяяя%   яяяяяяяяяяяяяяяя!       S   T   
+   яяяя%   яяяяяяяяяяяяяяяя5   4       8      яяяя%   U   яяяяяяяяяяяяV           <   ™™™™™™№?    W   unknown%   яяяяяяяяяяяяяяяяA   @   !   :   1   яяяя%   X   яяяяяяяяяяяя=           Y   ™™™™™™№?!   Z   unknown%   %   %   яяяяяяяяяяяяяяяя#   ҐоЫ   %   [   яяяяяяяяяяяя#   \   %   ]   яяяяяяяяяяяя#   ^   %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їё…лQё®?      рї                %   _   яяяяяяяяяяяяC   
+ЧЈp=
+·їF   
+ЧЈp=
+·?3   `   unknown%   яяяяяяяяяяяяяяяя9   %   )   I   1   яяяя%   яяяяяяяяяяяяяяяя%   9   P   a   
+1   яяяя%   %   %   яяяяяяяяяяяяяяяя&   ҐоЫ   %   b   яяяяяяяяяяяя&   c   %   %   яяяяяяяяяяяяяяяяz®Gбz¤ї
+ЧЈp=
+·їz®Gбzґ?              рї        %   %   %   яяяяяяяяяяяяяяяя'   ҐоЫ   %   d   яяяяяяяяяяяя?   e   %   %   яяяяяяяяяяяяяяяялQё…лБ?
+ЧЈp=
+·їz®Gбzґ?              р?        %   f   яяяяяяяяяяяя,   x®Gбz„ї<   x®Gбz„?(   g   unknown%   h   яяяяяяяяяяяя-   x®Gбz„ї=   x®Gбz„?)   i   unknown%   %   %   яяяяяяяяяяяяяяяя,   ҐоЫ   
+point%   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя-   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяя0   ҐоЫ   %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їё…лQё®?              р?       Ђ       Ђ              р?%   яяяяяяяяяяяяяяяяS   3   A   a      яяяя%   яяяяяяяяяяяяяяяя3   S   4   R   
+   яяяя%   j   яяяяяяяяяяяяF   x®Gбz„їV   x®Gбz„?Q   k   unknown%   яяяяяяяяяяяяяяяяQ   P   6   T      яяяя%   l   яяяяяяяяяяяяY           V   
+ЧЈp=
+З?6   m   unknown%   %   %   яяяяяяяяяяяяяяяя8   ҐоЫ   %   n   яяяяяяяяяяяяT   o   %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїё…лQё®?              р?        %   %   %   яяяяяяяяяяяяяяяя:   ҐоЫ   %   p   яяяяяяяяяяяя:   q   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їё…лQё®?              рї        %   %   %   яяяяяяяяяяяяяяяя<   ҐоЫ    %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їё…лQё®?%   %   %   яяяяяяяяяяяяяяяя=   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їё…лQё®?%   %   %   яяяяяяяяяяяяяяяя?   ҐоЫ   %   %   яяяяяяяяяяяяяяяя™™™™™™©?лQё…лБїz®Gбzґ?      р?                %   r   яяяяяяяяяяяяC   x®Gбz„їY   x®Gбz„?A   s   unknown%   %   %   яяяяяяяяяяяяяяяяC   ҐоЫ   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяF   ҐоЫ   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїz®Gбzґ?%   %   %   яяяяяяяяяяяяяяяяH   ҐоЫ   %   %   яяяяяяяяяяяяяяяялQё…лБ?z®Gбz¤їлQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяI   ҐоЫ   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їz®Gбz¤їлQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяR   ҐоЫ   %   %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїлQё…л±?       Ђ       Ђ      рї%   %   %   яяяяяяяяяяяяяяяяT   ҐоЫ   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїё…лQё®?      р?                %   %   %   яяяяяяяяяяяяяяяяV   ҐоЫ !  %   яяяяяяяяяяяяяяяялQё…лБ?лQё…лБїё…лQё®?%   %   %   яяяяяяяяяяяяяяяяY   ҐоЫ "  %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїё…лQё®?%   %   %   яяяяяяяяяяяяяяяяa   ҐоЫ   %   %   яяяяяяяяяяяяяяяяz®Gбz¤їлQё…лБїлQё…л±?       Ђ       Ђ      рїEnd-of-ACIS-data
+
+# Ansoft project setting data. Non-Ansoft programs
+# should not read the rest of this file.
+B_SETNGS 1.03
+ACIS BinaryFileT             SpatialACIS 29.0.1 NTMon May 10 15:45:15 2021      р?Ќнµ чЖ°>»ЅЧЩЯ|Ы=
+MF6ACP8J_DTTMBKPQ_VWCPSATT98MY6PC5CTKMZ74KCPCN6P73CKVSEQDFAJVP46CKCUKKEN2FAJ4Gtransform%      яяяя      р?                              р?                              р?                              р?
+point%      яяяяяяяяяяяя                        	flag%   ansoft%   attrib%   яяяяяяяя   яяяя    ҐоЫ     
+color%   %   %   яяяяяяяяяяяяяяяя   ҐоЫ я яЂ
+units%   %   %   яяяяяяяя          ҐоЫ mm     @Џ@%   %   %   яяяяяяяяяяяя       ҐоЫ АААЂEnd-of-ACIS-data
+E_SETNGS 
+
+B_SYMTAB 
+E_SYMTAB 
+ANSOFT OFFSET: 7885 
+$end 'sab'
+$end 'NativeGeometryFiles'
+$end 'AllReferencedFilesForComponent'

--- a/pyaedt/edb_core/stackup.py
+++ b/pyaedt/edb_core/stackup.py
@@ -5,6 +5,7 @@ This module contains the `EdbStackup` class.
 
 from __future__ import absolute_import  # noreorder
 
+import logging
 import math
 import os
 import warnings
@@ -21,6 +22,8 @@ try:
 except ImportError:
     if os.name != "posix":
         warnings.warn('This module requires the "pythonnet" package.')
+
+logger = logging.getLogger(__name__)
 
 
 class EdbStackup(object):
@@ -732,6 +735,98 @@ class EdbStackup(object):
             self._get_edb_value(math.cos(_angle)), self._get_edb_value(-1 * math.sin(_angle)), zero_data
         )
         cell_inst2.Set3DTransformation(point_loc, point_from, point_to, rotation, point3d_t)
+        return True
+
+    @pyaedt_function_handler()
+    def place_a3dcomp_3d_placement(self, a3dcomp_path, angle=0.0, offset_x=0.0, offset_y=0.0, place_on_top=True):
+        """Place current Cell into another cell using 3d placement method.
+        Flip the current layer stackup of a layout if requested. Transform parameters currently not supported.
+
+        Parameters
+        ----------
+        a3dcomp_path : str
+            Path to 3D Component file (*.a3dcomp) to place.
+        angle : double, optional
+            Clockwise rotation angle applied to the a3dcomp.
+        offset_x : double, optional
+            The x offset value.
+        offset_y : double, optional
+            The y offset value.
+        place_on_top : bool, optional
+            Whether to place the 3D Component on the top or bottom of this layout.
+            If False then the 3D Component will also be flipped over around its X axis.
+
+        Returns
+        -------
+        bool
+            ``True`` if successful and ``False`` if not.
+
+        Examples
+        --------
+        >>> edb1 = Edb(edbpath=targetfile1,  edbversion="2021.2")
+        >>> a3dcomp_path = "connector.a3dcomp"
+        >>> edb1.core_stackup.place_a3dcomp_3d_placement(a3dcomp_path, angle=0.0, offset_x="1mm",
+        ...                                   offset_y="2mm", flipped_stackup=False, place_on_top=True,
+        ...                                   )
+        """
+        zero_data = self._get_edb_value(0.0)
+        one_data = self._get_edb_value(1.0)
+        local_origin = self._edb.Geometry.Point3DData(zero_data, zero_data, zero_data)
+        rotation_axis_from = self._edb.Geometry.Point3DData(one_data, zero_data, zero_data)
+        _angle = angle * math.pi / 180.0
+        rotation_axis_to = self._edb.Geometry.Point3DData(
+            self._get_edb_value(math.cos(_angle)), self._get_edb_value(-1 * math.sin(_angle)), zero_data
+        )
+
+        stackup_target = self._active_layout.GetLayerCollection()
+        sig_set = self._edb.Cell.LayerTypeSet.SignalLayerSet
+        if is_ironpython:  # pragma: no cover
+            res = stackup_target.GetTopBottomStackupLayers(sig_set)
+            target_top_elevation = res[2]
+            target_bottom_elevation = res[4]
+        else:
+            target_top = None
+            target_top_elevation = Double(0.0)
+            target_bottom = None
+            target_bottom_elevation = Double(0.0)
+            res = stackup_target.GetTopBottomStackupLayers(
+                sig_set, target_top, target_top_elevation, target_bottom, target_bottom_elevation
+            )
+
+            target_top_elevation = res[2]
+            target_bottom_elevation = res[4]
+
+        flipAngle = self._get_edb_value("0deg")
+        if place_on_top:
+            elevation = target_top_elevation
+        else:
+            flipAngle = self._get_edb_value("180deg")
+            elevation = target_bottom_elevation
+        h_stackup = self._get_edb_value(elevation)
+        location = self._edb.Geometry.Point3DData(
+            self._get_edb_value(offset_x), self._get_edb_value(offset_y), h_stackup
+        )
+
+        mcad_model = self._edb.McadModel.Create3DComp(self._active_layout, a3dcomp_path)
+        if mcad_model.IsNull():
+            logger.error("Failed to create MCAD model from a3dcomp")
+            return False
+
+        cell_instance = mcad_model.GetCellInstance()
+        if cell_instance.IsNull():
+            logger.error("Cell instance of a3dcomp is null")
+            return False
+
+        if not cell_instance.SetIs3DPlacement(True):
+            logger.error("Failed to set 3D placement on a3dcomp cell instance")
+            return False
+
+        if not cell_instance.Set3DTransformation(
+            local_origin, rotation_axis_from, rotation_axis_to, flipAngle, location
+        ):
+            logger.error("Failed to set 3D transform on a3dcomp cell instance")
+            return False
+
         return True
 
     @pyaedt_function_handler()


### PR DESCRIPTION
Add place_a3dcomp_3d_placement method to place a 3D Component from an
a3dcomp file onto an EDB Layout.  Arguments provide for offset location,
rotation angle, and top or bottom placement on the target layout.  If
placed on the bottom the 3D Component is also flipped over around its X-axis.