### PR TITLE
Test for IronPython before importing numpy

### DIFF
--- a/pyaedt/generic/python_optimizers.py
+++ b/pyaedt/generic/python_optimizers.py
@@ -1,7 +1,17 @@
 import sys
 import threading
+import warnings
 
-import numpy as np
+from pyaedt.generic.general_methods import is_ironpython
+
+if not is_ironpython:
+    try:
+        import numpy as np
+    except ImportError:
+        warnings.warn(
+            "The NumPy module is required to run some functionalities of PostProcess.\n"
+            "Install with \n\npip install numpy\n\nRequires CPython."
+        )
 
 
 class ThreadTrace(threading.Thread):


### PR DESCRIPTION
A bare import of numpy in python_optimizers.py would cause failures in
IronPython or AEDT.  Use the same logic from elsewhere to avoid.

Fixes #1291 