### PR TITLE
fixed return value of an edge length, for non line edges such as arcs

### DIFF
--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -468,19 +468,15 @@ class EdgePrimitive(EdgeTypePrimitive, object):
         Returns
         -------
         float or bool
-            Edge length in model units when edge has two vertices, ``False`` othwerise.
+            Edge length in model units.
 
         References
         ----------
 
-        >>> oEditor.GetVertexPosition
+        >>> oEditor.GetEdgeLength(edgeId)
 
         """
-        if len(self.vertices) == 2:
-            length = GeometryOperators.points_distance(self.vertices[0].position, self.vertices[1].position)
-            return float(length)
-        else:
-            return False
+        return float(self.oeditor.GetEdgeLength(self.id))
 
     def __repr__(self):
         return "EdgeId " + str(self.id)


### PR DESCRIPTION
routine now supports arcs and splines

old version was only valid for lines. For an arc or spline, the length of the edge is not the distance between to vertecies.