### PR TITLE
Add dictionary context in get_solution_data

### DIFF
--- a/_unittest/test_12_PostProcessing.py
+++ b/_unittest/test_12_PostProcessing.py
@@ -306,15 +306,6 @@ class TestClass(BasisTest, object):
             context="Poly1",
             report_category="Fields",
         )
-        data = self.field_test.post.get_solution_data(
-            "Mag_E",
-            self.field_test.nominal_adaptive,
-            variations=variations2,
-            primary_sweep_variable="Theta",
-            context="Poly1",
-            report_category="Fields",
-        )
-        assert data.units_sweeps["Phase"] == "deg"
         new_report = self.field_test.post.reports_by_category.fields("Mag_H", self.field_test.nominal_adaptive)
         new_report.variations = variations2
         new_report.polyline = "Poly1"
@@ -331,6 +322,15 @@ class TestClass(BasisTest, object):
         new_report = self.field_test.post.reports_by_category.modal_solution("S(1,1)")
         new_report.plot_type = "Smith Chart"
         assert new_report.create()
+        data = self.field_test.post.get_solution_data(
+            "Mag_E",
+            self.field_test.nominal_adaptive,
+            variations=variations2,
+            primary_sweep_variable="Theta",
+            context="Poly1",
+            report_category="Fields",
+        )
+        assert data.units_sweeps["Phase"] == "deg"
         pass
 
     def test_09b_export_report(self):  # pragma: no cover

--- a/_unittest/test_12_PostProcessing.py
+++ b/_unittest/test_12_PostProcessing.py
@@ -615,6 +615,10 @@ class TestClass(BasisTest, object):
         data2 = self.circuit_test.post.get_solution_data(["V(net_11)"], "Transient", "Time")
         assert data2.primary_sweep == "Time"
         assert data2.data_magnitude()
+        context = {"algorithm": "FFT", "max_frequency": "100MHz", "time_stop": "200ns", "time_start": "0ps"}
+        data3 = self.circuit_test.post.get_solution_data(["V(net_11)"], "Transient", "Spectral", context=context)
+        assert data3.units_sweeps["Freq"] == "MHz"
+        assert data3.data_real()
         new_report = self.circuit_test.post.reports_by_category.spectral(["dB(V(net_11))"], "Transient")
         new_report.window = "Hanning"
         new_report.max_freq = "1GHz"

--- a/_unittest/test_12_PostProcessing.py
+++ b/_unittest/test_12_PostProcessing.py
@@ -306,6 +306,15 @@ class TestClass(BasisTest, object):
             context="Poly1",
             report_category="Fields",
         )
+        data = self.field_test.post.get_solution_data(
+            "Mag_E",
+            self.field_test.nominal_adaptive,
+            variations=variations2,
+            primary_sweep_variable="Theta",
+            context="Poly1",
+            report_category="Fields",
+        )
+        assert data.units_sweeps["Phase"] == "deg"
         new_report = self.field_test.post.reports_by_category.fields("Mag_H", self.field_test.nominal_adaptive)
         new_report.variations = variations2
         new_report.polyline = "Poly1"
@@ -615,7 +624,7 @@ class TestClass(BasisTest, object):
         data2 = self.circuit_test.post.get_solution_data(["V(net_11)"], "Transient", "Time")
         assert data2.primary_sweep == "Time"
         assert data2.data_magnitude()
-        context = {"algorithm": "FFT", "max_frequency": "100MHz", "time_stop": "200ns", "time_start": "0ps"}
+        context = {"algorithm": "FFT", "max_frequency": "100MHz", "time_stop": "200ns", "test": ""}
         data3 = self.circuit_test.post.get_solution_data(["V(net_11)"], "Transient", "Spectral", context=context)
         assert data3.units_sweeps["Spectrum"] == "GHz"
         assert data3.data_real()

--- a/_unittest/test_12_PostProcessing.py
+++ b/_unittest/test_12_PostProcessing.py
@@ -617,7 +617,7 @@ class TestClass(BasisTest, object):
         assert data2.data_magnitude()
         context = {"algorithm": "FFT", "max_frequency": "100MHz", "time_stop": "200ns", "time_start": "0ps"}
         data3 = self.circuit_test.post.get_solution_data(["V(net_11)"], "Transient", "Spectral", context=context)
-        assert data3.units_sweeps["Freq"] == "MHz"
+        assert data3.units_sweeps["Spectrum"] == "GHz"
         assert data3.data_real()
         new_report = self.circuit_test.post.reports_by_category.spectral(["dB(V(net_11))"], "Transient")
         new_report.window = "Hanning"

--- a/pyaedt/modules/PostProcessor.py
+++ b/pyaedt/modules/PostProcessor.py
@@ -1623,7 +1623,7 @@ class PostProcessorCommon(object):
                 else:
                     self.logger.warning("Parameter " + attribute + " is not available, check syntax.")
         elif context:
-            if hasattr(self.modeler, "lines_names") and context in self.modeler.line_names:
+            if hasattr(self.modeler, "line_names") and context in self.modeler.line_names:
                 report.polyline = context
         solution_data = report.get_solution_data()
         return solution_data

--- a/pyaedt/modules/report_templates.py
+++ b/pyaedt/modules/report_templates.py
@@ -2521,7 +2521,7 @@ class Spectral(CommonReport):
         self.window = "Rectangular"
         self.kaiser_coeff = 0
         self.adjust_coherent_gain = True
-        self.max_freq = "10MHz"
+        self.max_frequency = "10MHz"
         self.plot_continous_spectrum = False
         self.primary_sweep = "Spectrum"
 
@@ -2669,7 +2669,7 @@ class Spectral(CommonReport):
                 it,
                 "MF",
                 False,
-                self.max_freq,
+                self.max_frequency,
                 "NUMLEVELS",
                 False,
                 "0",

--- a/pyaedt/modules/solutions.py
+++ b/pyaedt/modules/solutions.py
@@ -60,6 +60,11 @@ class SolutionData(object):
             self._primary_sweep = self._sweeps_names[0]
         self.active_variation = self.variations[0]
         self.units_sweeps = {}
+        for intrinsic in self.intrinsics:
+            try:
+                self.units_sweeps[intrinsic] = self.nominal_variation.GetSweepUnits(intrinsic)
+            except:
+                self.units_sweeps[intrinsic] = None
         self._init_solutions_data()
         self._ifft = None
 


### PR DESCRIPTION
- Fixed Bug in report_templates for Spectrum report
- Add the option to define a dictionary in the context for solution_data. Useful to define the setup values in reports.
- Get units sweep
- Unittest