### PR TITLE
When Log report is selected, disabling Minor Tick Option

### DIFF
--- a/pyaedt/modules/report_templates.py
+++ b/pyaedt/modules/report_templates.py
@@ -1345,7 +1345,7 @@ class CommonReport(object):
             props.append(["NAME:Min", "Value:=", min_scale])
         if max_scale:
             props.append(["NAME:Max", "Value:=", max_scale])
-        if minor_tick_divs:
+        if minor_tick_divs and linear_scaling:
             props.append(["NAME:Minor Tick Divs", "Value:=", str(minor_tick_divs)])
         if min_spacing:
             props.append(["NAME:Spacing", "Value:=", min_spacing])
@@ -1502,7 +1502,7 @@ class CommonReport(object):
             props.append(["NAME:Min", "Value:=", min_scale])
         if max_scale:
             props.append(["NAME:Max", "Value:=", max_scale])
-        if minor_tick_divs:
+        if minor_tick_divs and linear_scaling:
             props.append(["NAME:Minor Tick Divs", "Value:=", str(minor_tick_divs)])
         if min_spacing:
             props.append(["NAME:Spacing", "Value:=", min_spacing])


### PR DESCRIPTION
When Log Scale is selected, the option Minor Tick is not taken into account, and the API returns an error even if it does not have an impact.
![image](https://user-images.githubusercontent.com/85613111/175482386-e40ef49f-abbd-4a11-9737-aea31d805f41.png)
