### PR TITLE
Lumped RLC boundary supports both parallel and serial type.

### DIFF
--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -493,6 +493,13 @@ class TestClass(BasisTest, object):
         assert imp.name in self.aedtapp.modeler.get_boundaries_name()
         assert imp.update()
 
+        box3 = self.aedtapp.modeler.create_box([0, 0, 20], [10, 10, 5], "rlc3", "copper")
+        lumped_rlc2 = self.aedtapp.create_lumped_rlc_between_objects(
+            "rlc2", "rlc3", self.aedtapp.AxisDir.XPos, Rvalue=50, Lvalue=1e-9, Cvalue=1e-9
+        )
+        assert lumped_rlc2.name in self.aedtapp.modeler.get_boundaries_name()
+        assert lumped_rlc2.update()
+
     def test_15_create_perfects_on_sheets(self):
         rect = self.aedtapp.modeler.create_rectangle(
             self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="RectBound", matname="Copper"
@@ -515,6 +522,15 @@ class TestClass(BasisTest, object):
             self.aedtapp.PLANE.XY, [0, 0, 0], [10, 2], name="rlcBound", matname="Copper"
         )
         imp = self.aedtapp.assign_lumped_rlc_to_sheet(rect.name, self.aedtapp.AxisDir.XPos, Rvalue=50, Lvalue=1e-9)
+        names = self.aedtapp.modeler.get_boundaries_name()
+        assert imp.name in self.aedtapp.modeler.get_boundaries_name()
+
+        rect2 = self.aedtapp.modeler.create_rectangle(
+            self.aedtapp.PLANE.XY, [0, 0, 10], [10, 2], name="rlcBound2", matname="Copper"
+        )
+        imp = self.aedtapp.assign_lumped_rlc_to_sheet(
+            rect.name, self.aedtapp.AxisDir.XPos, rlctype="Serial", Rvalue=50, Lvalue=1e-9
+        )
         names = self.aedtapp.modeler.get_boundaries_name()
         assert imp.name in self.aedtapp.modeler.get_boundaries_name()
 

--- a/pyaedt/hfss.py
+++ b/pyaedt/hfss.py
@@ -2822,7 +2822,7 @@ class Hfss(FieldAnalysis3D, object):
         sourcename : str, optional
             Perfect H name. The default is ``None``.
         rlctype : str, optional
-            Type of the RLC. Options are ``"Parallel"`` and ``"Series"``.
+            Type of the RLC. Options are ``"Parallel"`` and ``"Serial"``.
             The default is ``"Parallel"``.
         Rvalue : optional
             Resistance value in ohms. The default is ``None``,
@@ -2882,7 +2882,7 @@ class Hfss(FieldAnalysis3D, object):
             props = OrderedDict()
             props["Objects"] = [sheet_name]
             props["CurrentLine"] = OrderedDict({"Start": start, "End": stop})
-            props["RLC Type"] = [rlctype]
+            props["RLC Type"] = rlctype
             if Rvalue:
                 props["UseResist"] = True
                 props["Resistance"] = str(Rvalue) + "ohm"
@@ -3480,7 +3480,7 @@ class Hfss(FieldAnalysis3D, object):
         sourcename : str, optional
             Lumped RLC name. The default is ``None``.
         rlctype : str, optional
-            Type of the RLC. Options are ``"Parallel"`` and ``"Series"``. The default is ``"Parallel"``.
+            Type of the RLC. Options are ``"Parallel"`` and ``"Serial"``. The default is ``"Parallel"``.
         Rvalue : float, optional
             Resistance value in ohms. The default is ``None``, in which
             case this parameter is disabled.
@@ -3529,7 +3529,7 @@ class Hfss(FieldAnalysis3D, object):
             props = OrderedDict()
             props["Objects"] = [sheet_name]
             props["CurrentLine"] = OrderedDict({"Start": start, "End": stop})
-            props["RLC Type"] = [rlctype]
+            props["RLC Type"] = rlctype
             if Rvalue:
                 props["UseResist"] = True
                 props["Resistance"] = str(Rvalue) + "ohm"


### PR DESCRIPTION
RLC type is a string argument and not a list.
Fix #1336 .
Adding some unit tests to cover the serial lumped ports.