### PR TITLE
Numpy stopped supporting Python 3.7 since release 1.22.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ matplotlib==3.5.2; python_version > '3.6'
 # License: https://github.com/matplotlib/matplotlib/blob/master/LICENSE/LICENSE
 # License: PSF
 
-numpy==1.23.1; python_version > '3.6'
+numpy==1.21.6; python_version > '3.6'
 # License: BSD-3-Clause License
 
 ipython==8.4.0; python_version > '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,8 @@ matplotlib==3.5.2; python_version > '3.6'
 # License: https://github.com/matplotlib/matplotlib/blob/master/LICENSE/LICENSE
 # License: PSF
 
-numpy==1.21.6; python_version > '3.6'
+numpy==1.21.6; python_version <= '3.7'
+numpy==1.23.1; python_version > '3.7'
 # License: BSD-3-Clause License
 
 ipython==8.4.0; python_version > '3.6'

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
 pyvista==0.36.1
 matplotlib==3.5.2
-numpy==1.21.6
+numpy==1.21.6; python_version <= '3.7'
+numpy==1.23.1; python_version > '3.7'
 pytest==7.1.2
 pytest-cov==3.0.0
 codecov==2.1.12

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 pyvista==0.36.1
 matplotlib==3.5.2
-numpy==1.23.1
+numpy==1.21.6
 pytest==7.1.2
 pytest-cov==3.0.0
 codecov==2.1.12


### PR DESCRIPTION
Numpy is not supporting Python 3.7 starting with release 1.22.0
See: https://numpy.org/devdocs/release/1.22.0-notes.html

Fix #1437 .