### PR TITLE
Set points coordinates for BP curve coreloss.

### DIFF
--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -430,3 +430,16 @@ class TestClass(BasisTest, object):
             if bound.name == "Symmetry_Test_IsEven":
                 assert bound.type == "Symmetry"
                 assert not bound.props["IsOdd"]
+
+    def test_36_set_bp_curve_loss(self):
+        bp_curve_box = self.aedtapp.modeler.create_box([0, 0, 0], [10, 10, 10], name="bp_curve_box")
+        bp_curve_box.material = "magnesium"
+        assert self.aedtapp.materials["magnesium"].set_bp_curve_coreloss(
+            [[0, 0], [0.6, 1.57], [1.0, 4.44], [1.5, 20.562], [2.1, 44.23]],
+            kdc=0.002,
+            cut_depth=0.0009,
+            punit="w/kg",
+            bunit="tesla",
+            frequency=50,
+            thickness="0.5mm",
+        )

--- a/pyaedt/modules/Material.py
+++ b/pyaedt/modules/Material.py
@@ -1778,9 +1778,24 @@ class Material(CommonMaterial, object):
         self._props["core_loss_curves"]["Frequency"] = "{}Hz".format(frequency)
         self._props["core_loss_curves"]["Thickness"] = thickness
         self._props["core_loss_curves"]["IsTemperatureDependent"] = False
-        self._props["core_loss_curves"]["Point"] = []
+        self._props["core_loss_curves"]["BPCoordinates"] = OrderedDict({})
+
+        self._props["core_loss_curves"]["BPCoordinates"]["Point"] = []
+        # self._props["AttachedData"] = OrderedDict(
+        #     {
+        #         "MatAppearanceData": OrderedDict(
+        #             {
+        #                 "property_data": "appearance_data",
+        #                 "Red": self._material_appearance[0],
+        #                 "Green": self._material_appearance[1],
+        #                 "Blue": self._material_appearance[2],
+        #             }
+        #         )
+        #     }
+        # )
+
         for points in point_list:
-            self._props["core_loss_curves"]["Point"].append(points)
+            self._props["core_loss_curves"]["BPCoordinates"]["Point"].append(points)
         return self.update()
 
     @pyaedt_function_handler()

--- a/pyaedt/modules/Material.py
+++ b/pyaedt/modules/Material.py
@@ -1778,22 +1778,9 @@ class Material(CommonMaterial, object):
         self._props["core_loss_curves"]["Frequency"] = "{}Hz".format(frequency)
         self._props["core_loss_curves"]["Thickness"] = thickness
         self._props["core_loss_curves"]["IsTemperatureDependent"] = False
+
         self._props["core_loss_curves"]["BPCoordinates"] = OrderedDict({})
-
         self._props["core_loss_curves"]["BPCoordinates"]["Point"] = []
-        # self._props["AttachedData"] = OrderedDict(
-        #     {
-        #         "MatAppearanceData": OrderedDict(
-        #             {
-        #                 "property_data": "appearance_data",
-        #                 "Red": self._material_appearance[0],
-        #                 "Green": self._material_appearance[1],
-        #                 "Blue": self._material_appearance[2],
-        #             }
-        #         )
-        #     }
-        # )
-
         for points in point_list:
             self._props["core_loss_curves"]["BPCoordinates"]["Point"].append(points)
         return self.update()


### PR DESCRIPTION
The method `set_bp_curve_coreloss()` was not allowing the creation of the the point coordinates properly and consequently, the core loss curve was not updated.

![image](https://user-images.githubusercontent.com/87315832/183059327-3f7d8ed7-99e3-4d30-b684-feaafc218c06.png)

Now the curve is created properly.

Fix #1490 