### PR TITLE
Provide thickness to a new pad stack layer while defining the start layer.

### DIFF
--- a/_unittest/test_16_3d_stackup.py
+++ b/_unittest/test_16_3d_stackup.py
@@ -23,6 +23,7 @@ class TestClass(BasisTest, object):
         self.st.add_dielectric_layer("diel3", thickness=1.2)
         p1 = self.st.add_signal_layer("p1", thickness=0)
         gnd2 = self.st.add_ground_layer("gnd2", thickness=0)
+        self.st.add
         assert gnd
         assert lay1
         assert top
@@ -59,8 +60,9 @@ class TestClass(BasisTest, object):
     def test_03_padstackline(self):
         p1 = self.st.add_padstack("Massimo", material="aluminum")
         p1.plating_ratio = 0.7
-        p1.set_start_layer("lay1")
-        p1.set_stop_layer("top")
+        assert p1.set_start_layer("lay1")
+        assert p1.set_stop_layer("top")
+        assert p1.set_start_layer("lay1")
         p1.set_all_pad_value(1)
         p1.set_all_antipad_value(3)
         p1.num_sides = 8

--- a/_unittest/test_16_3d_stackup.py
+++ b/_unittest/test_16_3d_stackup.py
@@ -23,7 +23,6 @@ class TestClass(BasisTest, object):
         self.st.add_dielectric_layer("diel3", thickness=1.2)
         p1 = self.st.add_signal_layer("p1", thickness=0)
         gnd2 = self.st.add_ground_layer("gnd2", thickness=0)
-        self.st.add
         assert gnd
         assert lay1
         assert top
@@ -62,7 +61,6 @@ class TestClass(BasisTest, object):
         p1.plating_ratio = 0.7
         assert p1.set_start_layer("lay1")
         assert p1.set_stop_layer("top")
-        assert p1.set_start_layer("lay1")
         p1.set_all_pad_value(1)
         p1.set_all_antipad_value(3)
         p1.num_sides = 8

--- a/_unittest/test_16_3d_stackup.py
+++ b/_unittest/test_16_3d_stackup.py
@@ -59,6 +59,10 @@ class TestClass(BasisTest, object):
     def test_03_padstackline(self):
         p1 = self.st.add_padstack("Massimo", material="aluminum")
         p1.plating_ratio = 0.7
+        try:
+            p1.set_start_layer("non_existing_layer")
+        except ValueError:
+            assert True
         assert p1.set_start_layer("lay1")
         assert p1.set_stop_layer("top")
         p1.set_all_pad_value(1)

--- a/_unittest/test_26_emit.py
+++ b/_unittest/test_26_emit.py
@@ -84,7 +84,7 @@ class TestClass(BasisTest, object):
         antenna = self.aedtapp.modeler.components.create_component("Antenna")
         # Default pattern filename is empty string
         pattern_filename = antenna.get_pattern_filename()
-        assert pattern_filename is ""
+        assert pattern_filename == ""
         # Default orientation is 0 0 0
         orientation = antenna.get_orientation_rpy()
         assert orientation == (0.0, 0.0, 0.0)

--- a/pyaedt/modeler/stackup_3d.py
+++ b/pyaedt/modeler/stackup_3d.py
@@ -1052,6 +1052,7 @@ class Padstack(object):
             if not found and k in list(self._padstacks_by_layer.keys()):
                 new_stackup[k] = self._padstacks_by_layer[k]
         self._padstacks_by_layer = new_stackup
+        return True
 
     @pyaedt_function_handler()
     def add_via(self, position_x=0, position_y=0, instance_name=None, reference_system=None):

--- a/pyaedt/modeler/stackup_3d.py
+++ b/pyaedt/modeler/stackup_3d.py
@@ -1021,9 +1021,11 @@ class Padstack(object):
             if k == layer:
                 found = True
             if found and layer not in self._padstacks_by_layer:
-                new_stackup[k] = PadstackLayer(self, k, v.elevation)
+                new_stackup[k] = PadstackLayer(self, k, v.elevation, v.thickness)
             elif found:
                 new_stackup[k] = self._padstacks_by_layer[k]
+            else:
+                raise ValueError("The layer named: '{}' does not exist".format(layer))
         self._padstacks_by_layer = new_stackup
         return True
 

--- a/pyaedt/modeler/stackup_3d.py
+++ b/pyaedt/modeler/stackup_3d.py
@@ -1024,8 +1024,8 @@ class Padstack(object):
                 new_stackup[k] = PadstackLayer(self, k, v.elevation, v.thickness)
             elif found:
                 new_stackup[k] = self._padstacks_by_layer[k]
-            else:
-                raise ValueError("The layer named: '{}' does not exist".format(layer))
+        if not found:
+            raise ValueError("The layer named: '{}' does not exist".format(layer))
         self._padstacks_by_layer = new_stackup
         return True
 


### PR DESCRIPTION
You must provide the `thickness` when instantiating the `PadstackLayer`.

Fix #1505.