### PR TITLE
Add Litz wire in Maxwell.

### DIFF
--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -49,15 +49,26 @@ class TestClass(BasisTest, object):
         self.aedtapp.materials["magnesium"].wire_type = "Round"
         self.aedtapp.materials["magnesium"].strand_number = 3
         self.aedtapp.materials["magnesium"].wire_diameter = "1mm"
+        assert self.aedtapp.materials["magnesium"].stacking_type == "Litz Wire"
+        assert self.aedtapp.materials["magnesium"].wire_type == "Round"
+        assert self.aedtapp.materials["magnesium"].strand_number == 3
+        assert self.aedtapp.materials["magnesium"].wire_diameter == "1mm"
 
         self.aedtapp.materials["magnesium"].wire_type = "Square"
         self.aedtapp.materials["magnesium"].wire_width = "2mm"
+        assert self.aedtapp.materials["magnesium"].wire_type == "Square"
+        assert self.aedtapp.materials["magnesium"].wire_width == "2mm"
 
         self.aedtapp.materials["magnesium"].wire_type = "Rectangular"
         self.aedtapp.materials["magnesium"].wire_width = "2mm"
         self.aedtapp.materials["magnesium"].wire_thickness = "1mm"
         self.aedtapp.materials["magnesium"].wire_thickness_direction = "V(2)"
         self.aedtapp.materials["magnesium"].wire_width_direction = "V(3)"
+        assert self.aedtapp.materials["magnesium"].wire_type == "Rectangular"
+        assert self.aedtapp.materials["magnesium"].wire_width == "2mm"
+        assert self.aedtapp.materials["magnesium"].wire_thickness == "1mm"
+        assert self.aedtapp.materials["magnesium"].wire_thickness_direction == "V(2)"
+        assert self.aedtapp.materials["magnesium"].wire_width_direction == "V(3)"
 
     def test_02_create_coil(self):
         center_hole = self.aedtapp.modeler.Position(119, 25, 49)

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -41,6 +41,24 @@ class TestClass(BasisTest, object):
         assert plate.solve_inside
         assert plate.material_name == "aluminum"
 
+    def test_01A_litz_wire(self):
+        cylinder = self.aedtapp.modeler.create_cylinder(
+            cs_axis="X", position=[50, 0, 0], radius=0.8, height=20, name="Wire", matname="magnesium"
+        )
+        self.aedtapp.materials["magnesium"].stacking_type = "Litz Wire"
+        self.aedtapp.materials["magnesium"].wire_type = "Round"
+        self.aedtapp.materials["magnesium"].strand_number = 3
+        self.aedtapp.materials["magnesium"].wire_diameter = "1mm"
+
+        self.aedtapp.materials["magnesium"].wire_type = "Square"
+        self.aedtapp.materials["magnesium"].wire_width = "2mm"
+
+        self.aedtapp.materials["magnesium"].wire_type = "Rectangular"
+        self.aedtapp.materials["magnesium"].wire_width = "2mm"
+        self.aedtapp.materials["magnesium"].wire_thickness = "1mm"
+        self.aedtapp.materials["magnesium"].wire_thickness_direction = "V(2)"
+        self.aedtapp.materials["magnesium"].wire_width_direction = "V(3)"
+
     def test_02_create_coil(self):
         center_hole = self.aedtapp.modeler.Position(119, 25, 49)
         center_coil = self.aedtapp.modeler.Position(94, 0, 49)

--- a/pyaedt/modules/Material.py
+++ b/pyaedt/modules/Material.py
@@ -1179,6 +1179,12 @@ class Material(CommonMaterial, object):
                     )
                 }
             )
+        if "stacking_type" in self._props:
+            self.stacking_type = self._props["stacking_type"]["Choice"]
+
+        if "wire_type" in self._props:
+            self.wire_type = self._props["wire_type"]["Choice"]
+
         for property in MatProperties.aedtname:
             tmods = None
             smods = None
@@ -1588,6 +1594,195 @@ class Material(CommonMaterial, object):
     def viscosity(self, value):
         self._viscosity.value = value
         self._update_props("viscosity", value)
+
+    @property
+    def stacking_type(self):
+        """Composition of the wire can either be "Solid", "Lamination" or "Litz Wire".
+
+        Returns
+        -------
+        string
+            Structure of the wire.
+
+        References
+        ----------
+
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._stacking_type
+
+    @stacking_type.setter
+    def stacking_type(self, value):
+        if not value in ["Solid", "Lamination", "Litz Wire"]:
+            raise ValueError("Composition of the wire can either be 'Solid', 'Lamination' or 'Litz Wire'.")
+
+        self._stacking_type = value
+        self._props["stacking_type"] = OrderedDict(
+            {
+                "property_type": "ChoiceProperty",
+                "Choice": value,
+            }
+        )
+        self.update()
+
+    @property
+    def wire_type(self):
+        """The type of the wire can either be "Round", "Square" or "Rectangular".
+
+        Returns
+        -------
+        string
+            Type of the wire.
+
+        References
+        ----------
+
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._wire_type
+
+    @wire_type.setter
+    def wire_type(self, value):
+        if not value in ["Round", "Square", "Rectangular"]:
+            raise ValueError("The type of the wire can either be 'Round', 'Square' or 'Rectangular'.")
+
+        self._wire_type = value
+        self._props["wire_type"] = OrderedDict({"property_type": "ChoiceProperty", "Choice": value})
+        self.update()
+
+    @property
+    def wire_thickness_direction(self):
+        """Thickness direction of the wire can either be "V(1)", "V(2)" or "V(3)".
+
+        Returns
+        -------
+        string
+            Thickness direction of the wire.
+
+        References
+        ----------
+
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._wire_thickness_direction
+
+    @wire_thickness_direction.setter
+    def wire_thickness_direction(self, value):
+        if not value in ["V(1)", "V(2)" or "V(3)"]:
+            raise ValueError("Thickness direction of the wire can either be 'V(1)', 'V(2)' or 'V(3)'.")
+
+        self.wire_thickness_direction = value
+        self._props["wire_thickness_direction"] = OrderedDict({"property_type": "ChoiceProperty", "Choice": value})
+        self.update()
+
+    @property
+    def wire_width_direction(self):
+        """Width direction of the wire can either be "V(1)", "V(2)" or "V(3)".
+
+        Returns
+        -------
+        string
+            Width direction of the wire.
+
+        References
+        ----------
+
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._wire_width_direction
+
+    @wire_width_direction.setter
+    def wire_width_direction(self, value):
+        if not value in ["V(1)", "V(2)" or "V(3)"]:
+            raise ValueError("Width direction of the wire can either be 'V(1)', 'V(2)' or 'V(3)'.")
+
+        self.wire_width_direction = value
+        self._props["wire_width_direction"] = OrderedDict({"property_type": "ChoiceProperty", "Choice": value})
+        self.update()
+
+    @property
+    def strand_number(self):
+        """Strand number for litz wire.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.Material.MatProperty`
+            Number of strands for the wire.
+
+        References
+        ----------
+
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._strand_number
+
+    @strand_number.setter
+    def strand_number(self, value):
+        self._strand_number = value
+        self._update_props("strand_number", value)
+
+    @property
+    def wire_thickness(self):
+        """Thickness of rectangular litz wire.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.Material.MatProperty`
+            Thickness of the litz wire.
+
+        References
+        ----------
+
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._wire_thickness
+
+    @wire_thickness.setter
+    def wire_thickness(self, value):
+        self._wire_thickness = value
+        self._wire_thickness("wire_thickness", value)
+
+    @property
+    def wire_diameter(self):
+        """Diameter of the round litz wire.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.Material.MatProperty`
+            Diameter of the litz wire.
+
+        References
+        ----------
+
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._wire_diameter
+
+    @wire_diameter.setter
+    def wire_diameter(self, value):
+        self._wire_diameter = value
+        self._wire_diameter("wire_diameter", value)
+
+    @property
+    def wire_width(self):
+        """Width of the rectangular or square litz wire.
+
+        Returns
+        -------
+        :class:`pyaedt.modules.Material.MatProperty`
+            Width of the litz wire.
+
+        References
+        ----------
+
+        >>> oDefinitionManager.EditMaterial
+        """
+        return self._wire_width
+
+    @wire_width.setter
+    def wire_width(self, value):
+        self._wire_width = value
+        self._wire_width("wire_width", value)
 
     @pyaedt_function_handler()
     def set_magnetic_coercitivity(self, value=0, x=1, y=0, z=0):

--- a/pyaedt/modules/Material.py
+++ b/pyaedt/modules/Material.py
@@ -1091,6 +1091,10 @@ class CommonMaterial(object):
             self._props[propname] = str(provpavlue)
             if update_aedt:
                 return self.update()
+        elif isinstance(provpavlue, OrderedDict):
+            self._props[propname] = provpavlue
+            if update_aedt:
+                return self.update()
         elif isinstance(provpavlue, list) and self.__dict__["_" + propname].type == "nonlinear":
             if propname == "permeability":
                 bh = OrderedDict({"DimUnits": ["", ""]})
@@ -1617,13 +1621,15 @@ class Material(CommonMaterial, object):
             raise ValueError("Composition of the wire can either be 'Solid', 'Lamination' or 'Litz Wire'.")
 
         self._stacking_type = value
-        self._props["stacking_type"] = OrderedDict(
-            {
-                "property_type": "ChoiceProperty",
-                "Choice": value,
-            }
+        self._update_props(
+            "stacking_type",
+            OrderedDict(
+                {
+                    "property_type": "ChoiceProperty",
+                    "Choice": value,
+                }
+            ),
         )
-        self.update()
 
     @property
     def wire_type(self):
@@ -1647,8 +1653,7 @@ class Material(CommonMaterial, object):
             raise ValueError("The type of the wire can either be 'Round', 'Square' or 'Rectangular'.")
 
         self._wire_type = value
-        self._props["wire_type"] = OrderedDict({"property_type": "ChoiceProperty", "Choice": value})
-        self.update()
+        self._update_props("wire_type", OrderedDict({"property_type": "ChoiceProperty", "Choice": value}))
 
     @property
     def wire_thickness_direction(self):
@@ -1668,12 +1673,13 @@ class Material(CommonMaterial, object):
 
     @wire_thickness_direction.setter
     def wire_thickness_direction(self, value):
-        if not value in ["V(1)", "V(2)" or "V(3)"]:
+        if not value in ["V(1)", "V(2)", "V(3)"]:
             raise ValueError("Thickness direction of the wire can either be 'V(1)', 'V(2)' or 'V(3)'.")
 
-        self.wire_thickness_direction = value
-        self._props["wire_thickness_direction"] = OrderedDict({"property_type": "ChoiceProperty", "Choice": value})
-        self.update()
+        self._wire_thickness_direction = value
+        self._update_props(
+            "wire_thickness_direction", OrderedDict({"property_type": "ChoiceProperty", "Choice": value})
+        )
 
     @property
     def wire_width_direction(self):
@@ -1693,12 +1699,11 @@ class Material(CommonMaterial, object):
 
     @wire_width_direction.setter
     def wire_width_direction(self, value):
-        if not value in ["V(1)", "V(2)" or "V(3)"]:
+        if not value in ["V(1)", "V(2)", "V(3)"]:
             raise ValueError("Width direction of the wire can either be 'V(1)', 'V(2)' or 'V(3)'.")
 
-        self.wire_width_direction = value
-        self._props["wire_width_direction"] = OrderedDict({"property_type": "ChoiceProperty", "Choice": value})
-        self.update()
+        self._wire_width_direction = value
+        self._update_props("wire_width_direction", OrderedDict({"property_type": "ChoiceProperty", "Choice": value}))
 
     @property
     def strand_number(self):
@@ -1740,7 +1745,7 @@ class Material(CommonMaterial, object):
     @wire_thickness.setter
     def wire_thickness(self, value):
         self._wire_thickness = value
-        self._wire_thickness("wire_thickness", value)
+        self._update_props("wire_thickness", value)
 
     @property
     def wire_diameter(self):
@@ -1761,7 +1766,7 @@ class Material(CommonMaterial, object):
     @wire_diameter.setter
     def wire_diameter(self, value):
         self._wire_diameter = value
-        self._wire_diameter("wire_diameter", value)
+        self._update_props("wire_diameter", value)
 
     @property
     def wire_width(self):
@@ -1782,7 +1787,7 @@ class Material(CommonMaterial, object):
     @wire_width.setter
     def wire_width(self, value):
         self._wire_width = value
-        self._wire_width("wire_width", value)
+        self._update_props("wire_width", value)
 
     @pyaedt_function_handler()
     def set_magnetic_coercitivity(self, value=0, x=1, y=0, z=0):


### PR DESCRIPTION
Litz wires are now available in Maxwell.

It is now possible to specify the stacking type as "litz wire" for a material.
Then it is possible to set the wire type: round, square or rectangular.
Finally the user can defined the wire dimensions (width, thickness...).

Fix #1473 