### PR TITLE
Allowing dependabot to update GH Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     labels:
       - "maintenance"
       - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
The @pyansys/pyansys-core team has recently discovered that dependabot can automatically update GH actions (in a similar fashion to requirements). Proposing implementation in various repositories to keep them up to date.