### PR TITLE
Dependabot for gh-actions wrongly configured

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,6 @@ updates:
       - "dependencies"
 
   - package-ecosystem: "github-actions"
-    directory: "/.github"
+    directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
It looks like unless we define it at "/" it will not work. Solved it at PyDisco already and it is now working fine.