### PR TITLE
Remove licenses check.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -63,8 +63,8 @@ jobs:
           cd tmp
           python -c "import pyaedt; print('Imported pyaedt')"
 
-      - name: "Check licences of packages"
-        uses: pyansys/pydpf-actions/check-licenses@v2.0
+      # - name: "Check licences of packages"
+      #   uses: pyansys/pydpf-actions/check-licenses@v2.0
 
       - name: 'Unit testing'
         run: |


### PR DESCRIPTION
The license check actions must be updated. It is currently executing some shell commands.
We could have some cmd script performing it.