### PR TITLE
For a current, the solid property was disabled for magnetostatic and transientaphi solutions.

### DIFF
--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -112,15 +112,17 @@ class TestClass(BasisTest, object):
         assert self.aedtapp.assign_current(["Coil_Section1"], amplitude=2472)
         self.aedtapp.solution_type = "Magnetostatic"
         volt = self.aedtapp.assign_voltage(self.aedtapp.modeler["Coil_Section1"].faces[0].id, amplitude=1)
-        cur2 = self.aedtapp.assign_current(["Coil_Section1"], amplitude=212)
-        assert cur2
-        assert cur2.delete()
+        current2 = self.aedtapp.assign_current(["Coil_Section1"], amplitude=212)
+        assert current2
+        assert current2.props["IsSolid"]
+        assert current2.delete()
         assert volt
         assert volt.delete()
         self.aedtapp.solution_type = self.aedtapp.SOLUTIONS.Maxwell3d.TransientAPhiFormulation
-        cur2 = self.aedtapp.assign_current(["Coil_Section1"], amplitude=212)
-        assert cur2
-        assert cur2.delete()
+        current3 = self.aedtapp.assign_current(["Coil_Section1"], amplitude=212)
+        assert current3
+        assert current3.props["IsSolid"]
+        assert current3.delete()
         self.aedtapp.solution_type = "EddyCurrent"
 
     def test_05_winding(self):

--- a/pyaedt/maxwell.py
+++ b/pyaedt/maxwell.py
@@ -572,8 +572,8 @@ class Maxwell(object):
                 "TransientAPhiFormulation",
             ]:
                 props["Phase"] = phase
-                if self.solution_type not in ["DCConduction", "ElectricTransient"]:
-                    props["IsSolid"] = solid
+            if self.solution_type not in ["DCConduction", "ElectricTransient"]:
+                props["IsSolid"] = solid
             props["Point out of terminal"] = swap_direction
         else:
             if type(object_list[0]) is str:


### PR DESCRIPTION
Fix #1660 