### PR TITLE
Export equivalent circuit Q3D/Q2D

### DIFF
--- a/_unittest/test_30_Q2D.py
+++ b/_unittest/test_30_Q2D.py
@@ -253,3 +253,4 @@ class TestClass(BasisTest, object):
         assert not q2d.export_equivalent_circuit(
             file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), file_type="test"
         )
+        self.aedtapp.close_project(q2d.project_name, False)

--- a/_unittest/test_30_Q2D.py
+++ b/_unittest/test_30_Q2D.py
@@ -176,3 +176,76 @@ class TestClass(BasisTest, object):
         assert q2d.export_matrix_data(os.path.join(self.local_scratch.path, "test_2d.txt"), g_unit="fSie")
         assert not q2d.export_matrix_data(os.path.join(self.local_scratch.path, "test_2d.txt"), g_unit="A")
         self.aedtapp.close_project(q2d.project_name, False)
+
+    def test_14_export_equivalent_circuit(self):
+        q2d = Q2d(self.test_matrix, specified_version=desktop_version)
+        q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.Float, "Circle2", "Test1")
+        q2d.matrices[1].name == "Test1"
+        q2d.analyze_setup(q2d.analysis_setup)
+        assert q2d.export_equivalent_circuit(os.path.join(self.local_scratch.path, "test_export_circuit.cir"))
+        assert not q2d.export_equivalent_circuit(os.path.join(self.local_scratch.path, "test_export_circuit.doc"))
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            setup_name="Setup1",
+            sweep="LastAdaptive",
+        )
+        assert not q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), setup_name="Setup2"
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            setup_name="Setup1",
+            sweep="LastAdaptive",
+            variations=["r1:0.3mm"],
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            setup_name="Setup1",
+            sweep="LastAdaptive",
+            variations=[" r1 : 0.3 mm "],
+        )
+        assert not q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            setup_name="Setup1",
+            sweep="LastAdaptive",
+            variations="r1:0.3mm",
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), matrix_name="Original"
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), matrix_name="Test1"
+        )
+        assert not q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), coupling_limit_type=2
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), coupling_limit_type=0
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), coupling_limit_type=1
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            coupling_limit_type=0,
+            res_limit="6Mohm",
+            ind_limit="12nH",
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), lumped_length="34mm"
+        )
+        assert not q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), lumped_length="34nounits"
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), rise_time="1e-6s"
+        )
+        assert not q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), rise_time="23m"
+        )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), file_type="WELement"
+        )
+        assert not q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), file_type="test"
+        )

--- a/_unittest/test_30_Q2D.py
+++ b/_unittest/test_30_Q2D.py
@@ -177,7 +177,7 @@ class TestClass(BasisTest, object):
         assert not q2d.export_matrix_data(os.path.join(self.local_scratch.path, "test_2d.txt"), g_unit="A")
         self.aedtapp.close_project(q2d.project_name, False)
 
-    def test_14_export_equivalent_circuit(self):
+    def test_15_export_equivalent_circuit(self):
         q2d = Q2d(self.test_matrix, specified_version=desktop_version)
         q2d.insert_reduced_matrix(q2d.MATRIXOPERATIONS.Float, "Circle2", "Test1")
         q2d.matrices[1].name == "Test1"
@@ -238,10 +238,14 @@ class TestClass(BasisTest, object):
             file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), lumped_length="34nounits"
         )
         assert q2d.export_equivalent_circuit(
-            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), rise_time="1e-6s"
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            rise_time_value="1e-6",
+            rise_time_unit="s",
         )
         assert not q2d.export_equivalent_circuit(
-            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), rise_time="23m"
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            rise_time_value="23",
+            rise_time_unit="m",
         )
         assert q2d.export_equivalent_circuit(
             file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), file_type="WELement"

--- a/_unittest/test_30_Q2D.py
+++ b/_unittest/test_30_Q2D.py
@@ -253,4 +253,10 @@ class TestClass(BasisTest, object):
         assert not q2d.export_equivalent_circuit(
             file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), file_type="test"
         )
+        assert q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), model_name="q2d_q3d"
+        )
+        assert not q2d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), model_name="test"
+        )
         self.aedtapp.close_project(q2d.project_name, False)

--- a/_unittest/test_31_Q3D.py
+++ b/_unittest/test_31_Q3D.py
@@ -350,3 +350,4 @@ class TestClass(BasisTest, object):
             ind_limit="9uH",
             res_limit="2ohm",
         )
+        self.aedtapp.close_project(q3d.project_name, False)

--- a/_unittest/test_31_Q3D.py
+++ b/_unittest/test_31_Q3D.py
@@ -350,4 +350,10 @@ class TestClass(BasisTest, object):
             ind_limit="9uH",
             res_limit="2ohm",
         )
+        assert q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), model_name="q2d_q3d"
+        )
+        assert not q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), model_name="test"
+        )
         self.aedtapp.close_project(q3d.project_name, False)

--- a/_unittest/test_31_Q3D.py
+++ b/_unittest/test_31_Q3D.py
@@ -303,3 +303,50 @@ class TestClass(BasisTest, object):
         assert q3d.export_matrix_data(file_name=os.path.join(self.local_scratch.path, "test.txt"), g_unit="fSie")
         assert not q3d.export_matrix_data(file_name=os.path.join(self.local_scratch.path, "test.txt"), g_unit="A")
         self.aedtapp.close_project(q3d.project_name, False)
+
+    def test_14_export_equivalent_circuit(self):
+        q3d = Q3d(self.test_matrix, specified_version=desktop_version)
+        q3d.insert_reduced_matrix("JoinSeries", ["Source1", "Sink4"], "JointTest")
+        q3d.matrices[1].name == "JointTest"
+        q3d.analyze_setup(q3d.analysis_setup)
+        assert q3d.export_equivalent_circuit(os.path.join(self.local_scratch.path, "test_export_circuit.cir"))
+        assert not q3d.export_equivalent_circuit(os.path.join(self.local_scratch.path, "test_export_circuit.doc"))
+        assert q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            setup_name="Setup1",
+            sweep="LastAdaptive",
+        )
+        assert not q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), setup_name="Setup2"
+        )
+        assert not q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            setup_name="Setup1",
+            sweep="Sweep1",
+        )
+        assert q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), matrix_name="Original"
+        )
+        assert q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), matrix_name="JointTest"
+        )
+        assert not q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), matrix_name="JointTest1"
+        )
+        assert not q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), coupling_limit_type=2
+        )
+        assert q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), coupling_limit_type=0
+        )
+        assert q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"), coupling_limit_type=1
+        )
+        assert q3d.export_equivalent_circuit(
+            file_name=os.path.join(self.local_scratch.path, "test_export_circuit.cir"),
+            coupling_limit_type=0,
+            cond_limit="3Sie",
+            cap_limit="4uF",
+            ind_limit="9uH",
+            res_limit="2ohm",
+        )

--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -238,8 +238,6 @@ def _find_units_in_dependent_variables(variable_value, full_variables={}):
         if len(set(m2)) <= 1:
             return m2[0]
         else:
-            if "e" in m2 or "E" in m2:
-                m2.remove(m2[0])
             if unit_system(m2[0]):
                 return SI_UNITS[unit_system(m2[0])]
     else:

--- a/pyaedt/application/Variables.py
+++ b/pyaedt/application/Variables.py
@@ -238,6 +238,8 @@ def _find_units_in_dependent_variables(variable_value, full_variables={}):
         if len(set(m2)) <= 1:
             return m2[0]
         else:
+            if "e" in m2 or "E" in m2:
+                m2.remove(m2[0])
             if unit_system(m2[0]):
                 return SI_UNITS[unit_system(m2[0])]
     else:

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -709,6 +709,53 @@ class QExtractor(FieldAnalysis3D, object):
                 self.logger.error("Export of matrix data was unsuccessful.")
                 return False
 
+    def export_equivalent_circuit(
+        self,
+        solution=None,
+        variation=None,
+        file_name=None,
+        export_settings=None,
+        matrix_name=None,
+        num_cells=None,
+        user_changed_settings=None,
+        include_cap=None,
+        include_dcr=None,
+        include_dcl=None,
+        include_acr=None,
+        include_acl=None,
+        include_r=None,
+        include_l=None,
+        export_distributed=None,
+        lumped_length=None,
+        rise_time=None,
+        add_resistance=None,
+        coupling_limit_type=None,
+        coupling_limits_parameters=None,
+        cap_limit=None,
+        ind_limit=None,
+        res_limit=None,
+        cond_limit=None,
+        cap_fraction=None,
+        ind_fraction=None,
+        res_fraction=None,
+        cond_fraction=None,
+        model_name=None,
+        freq=None,
+    ):
+        """Export matrix data.
+
+        Parameters
+        ----------
+        solution : str
+            Solution to export the equivalent circuit from.
+
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` when failed.
+        """
+        pass
+
 
 class Q3d(QExtractor, object):
     """Provides the Q3D app interface.

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -749,17 +749,17 @@ class QExtractor(FieldAnalysis3D, object):
         ----------
         file_name : str
             Full path to save the equivalent circuit to.
-            Options for file extensions are CIR, SML, SP, PKG, SPC, LIB, CKT, BSP, 
+            Options for file extensions are CIR, SML, SP, PKG, SPC, LIB, CKT, BSP,
             DML, and ICM.
         setup_name : str, optional
-            Setup name. The default value is ``None``, in which case the first
-            analysis setup is used.
+            Setup name.
+            The default value is ``None``, in which case the first analysis setup is used.
         sweep : str, optional
             Solution frequency. The default is ``None``, in which case
             the default adaptive is used.
         variations : list or str, optional
             Design variation. The default is ``None``, in which case the
-            current nominal variation is used. If you are provide a
+            current nominal variation is used. If you provide a
             design variation, use the format ``{Name}:{Value}``.
         matrix_name : str, optional
             Name of the matrix to show. The default is ``"Original"``.

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -762,8 +762,7 @@ class QExtractor(FieldAnalysis3D, object):
             current nominal variation is used. If you are provide a
             design variation, use the format ``{Name}:{Value}``.
         matrix_name : str, optional
-            Name of the matrix to display.
-            Default value is ``"Original"``.
+            Name of the matrix to show. The default is ``"Original"``.
         num_cells : int, optional
             Number of cells in export.
             Default value is 2.

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -847,7 +847,6 @@ class QExtractor(FieldAnalysis3D, object):
             "RLGC": Nexxim/HSPICE RLGC W Element file format
             Default value is Hspice.
 
-
         Returns
         -------
         bool
@@ -999,6 +998,12 @@ class QExtractor(FieldAnalysis3D, object):
         else:
             coupling_limit_value = "None"
             coupling_limits.append(coupling_limit_value)
+
+        if model_name is None:
+            model_name = self.project_name
+        elif model_name != self.project_name:
+            self.logger.error("Invalid project name.")
+            return False
 
         if decompose_variable_value(lumped_length)[1] not in [
             "cm",

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -727,9 +727,7 @@ class QExtractor(FieldAnalysis3D, object):
         include_r=True,
         include_l=True,
         add_resistance=True,
-        include_cpp=False,
         parse_pin_names=False,
-        cs="Global",
         export_distributed=True,
         lumped_length="1meter",
         rise_time_value=None,
@@ -803,9 +801,6 @@ class QExtractor(FieldAnalysis3D, object):
             Default value is True.
         parse_pin_names : bool, optional
             Parse pin names.
-            Default value is False.
-        include_cpp : bool, optional
-            Include chip package protocol.
             Default value is False.
         cs : str, optional
             Coordinate system for chip package control.
@@ -1005,10 +1000,6 @@ class QExtractor(FieldAnalysis3D, object):
             coupling_limit_value = "None"
             coupling_limits.append(coupling_limit_value)
 
-        # if include_cpp and not [x for x in [include_dcr, include_acr, include_dcl, include_acl, add_resistance] if x]:
-        #     self.logger.error("Cannot include chip package protocol.")
-        #     return False
-
         if decompose_variable_value(lumped_length)[1] not in [
             "cm",
             "dm",
@@ -1049,6 +1040,7 @@ class QExtractor(FieldAnalysis3D, object):
             return False
 
         if self.modeler._is3d:
+            # IncludeCPP always False, unable to access chip package information.
             try:
                 self.oanalysis.ExportCircuit(
                     analysis_setup,

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -746,7 +746,7 @@ class QExtractor(FieldAnalysis3D, object):
         Parameters
         ----------
         file_name : str
-            Full path to save the equivalent circuit to.
+            Full path for saving the matrix data to.
             Options for file extensions are CIR, SML, SP, PKG, SPC, LIB, CKT, BSP,
             DML, and ICM.
         setup_name : str, optional

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -749,7 +749,8 @@ class QExtractor(FieldAnalysis3D, object):
         ----------
         file_name : str
             Full path to save the equivalent circuit to.
-            Options for file extensions are: .cir, .sml, .sp, .pkg, .spc, .lib, .ckt, .bsp, .dml, .icm.
+            Options for file extensions are CIR, SML, SP, PKG, SPC, LIB, CKT, BSP, 
+            DML, and ICM.
         setup_name : str, optional
             Setup name. The default value is ``None``, in which case the first
             analysis setup is used.

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -1044,7 +1044,7 @@ class QExtractor(FieldAnalysis3D, object):
 
         rise_time = rise_time_value + rise_time_unit
 
-        if file_type.lower() not in ["hspice", "welement", "rlcg"]:
+        if file_type.lower() not in ["hspice", "welement", "rlgc"]:
             self.logger.error("Invalid file type, possible solutions are Hspice, Welement, RLGC.")
             return False
 

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -759,8 +759,8 @@ class QExtractor(FieldAnalysis3D, object):
             the default adaptive is used.
         variations : list or str, optional
             Design variation. The default is ``None``, in which case the
-            current nominal variation is used.
-            If provided by user give the value as "{Name}:{Value}".
+            current nominal variation is used. If you are provide a
+            design variation, use the format ``{Name}:{Value}``.
         matrix_name : str, optional
             Name of the matrix to display.
             Default value is ``"Original"``.

--- a/pyaedt/q3d.py
+++ b/pyaedt/q3d.py
@@ -732,7 +732,8 @@ class QExtractor(FieldAnalysis3D, object):
         cs="Global",
         export_distributed=True,
         lumped_length="1meter",
-        rise_time=None,
+        rise_time_value=None,
+        rise_time_unit=None,
         coupling_limit_type=None,
         cap_limit=None,
         ind_limit=None,
@@ -815,9 +816,12 @@ class QExtractor(FieldAnalysis3D, object):
         lumped_length : str, optional
             Length of the design.
             Default value is 1 meter.
-        rise_time : str, optional
+        rise_time_value : str, optional
             Rise time to calculate the number of cells.
-            Default value is 1e-09s.
+            Default value is 1e-09.
+        rise_time_unit : str, optional
+            Rise time unit.
+            Default is s.
         cap_limit : str, optional
             Capacitance limit.
             Default value is 1pF if coupling_limit_type is 0.
@@ -1028,12 +1032,17 @@ class QExtractor(FieldAnalysis3D, object):
             self.logger.error("Invalid lumped length unit.")
             return False
 
-        if rise_time:
-            if decompose_variable_value(rise_time)[1] not in ["fs", "ps", "ns", "us", "ms", "s", "min", "hour", "day"]:
+        if rise_time_value is None:
+            rise_time_value = "1e-9"
+
+        if rise_time_unit:
+            if rise_time_unit not in ["fs", "ps", "ns", "us", "ms", "s", "min", "hour", "day"]:
                 self.logger.error("Invalid rise time unit.")
                 return False
         else:
-            rise_time = "1e-09s"
+            rise_time_unit = "s"
+
+        rise_time = rise_time_value + rise_time_unit
 
         if file_type.lower() not in ["hspice", "welement", "rlcg"]:
             self.logger.error("Invalid file type, possible solutions are Hspice, Welement, RLGC.")


### PR DESCRIPTION
Export equivalent circuit Q3D/Q2D

@maxcapodi78 @MaxJPRey @Samuelopez-ansys 
there's a part of the method ExportCircuit not implemented.
It's the include Chip Package Control (include_cpp bool), I couldn't get my head around how to extract this info and apparently is not even accessible so I left it False. Maybe we should state it somewhere.
I'm going to open a defect in tfs for this.
![image](https://user-images.githubusercontent.com/103059376/189178983-9c48052f-44d0-4570-a3d0-55716a086e17.png)
![image](https://user-images.githubusercontent.com/103059376/189179026-2468837b-c8cb-4893-bfbb-6b6ea8757ae3.png)
