### PR TITLE
New method to export Circuit log file

### DIFF
--- a/_unittest/test_21_Circuit.py
+++ b/_unittest/test_21_Circuit.py
@@ -461,3 +461,22 @@ class TestClass(BasisTest, object):
     def test_37_draw_graphical_primitives(self):
         line = self.aedtapp.modeler.components.create_line([[0, 0], [1, 1]])
         assert line
+
+    def test_38_browse_log_file(self):
+        self.aedtapp.insert_design("data_block1")
+        with open(os.path.join(self.local_scratch.path, "lc.net"), "w") as f:
+            for i in range(10):
+                f.write("L{} net_{} net_{} 1e-9\n".format(i, i, i + 1))
+                f.write("C{} net_{} 0 5e-12\n".format(i, i + 1))
+        self.aedtapp.modeler.components.create_interface_port("net_0", (0, 0))
+        self.aedtapp.modeler.components.create_interface_port("net_10", (0.01, 0))
+        lna = self.aedtapp.create_setup("mylna", self.aedtapp.SETUPS.NexximLNA)
+        lna.props["SweepDefinition"]["Data"] = "LINC 0Hz 1GHz 101"
+
+        assert not self.aedtapp.browse_log_file()
+        self.aedtapp.analyze_nominal()
+        assert self.aedtapp.browse_log_file()
+        self.aedtapp.save_project()
+        assert self.aedtapp.browse_log_file()
+        assert not self.aedtapp.browse_log_file(os.path.join(self.aedtapp.working_directory, "logfiles"))
+        assert self.aedtapp.browse_log_file(self.aedtapp.working_directory)

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -1763,4 +1763,6 @@ class Circuit(FieldAnalysisCircuit, object):
             self.logger.error("Design not solved")
             return None
 
-        return shutil.copy(latest_file, filepath)
+        shutil.copy(latest_file, filepath)
+        filename = os.path.basename(latest_file)
+        return os.path.join(filepath, filename)

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -1742,7 +1742,7 @@ class Circuit(FieldAnalysisCircuit, object):
         if filepath and not os.path.exists(os.path.normpath(filepath)):
             self.logger.error("Path does not exist.")
             return None
-        else:
+        elif not filepath:
             filepath = os.path.join(os.path.normpath(self.working_directory), "logfile")
             if not os.path.exists(filepath):
                 os.mkdir(filepath)

--- a/pyaedt/circuit.py
+++ b/pyaedt/circuit.py
@@ -3,10 +3,12 @@
 
 from __future__ import absolute_import  # noreorder
 
+import glob
 import io
 import math
 import os
 import re
+import shutil
 
 from pyaedt.application.AnalysisNexxim import FieldAnalysisCircuit
 from pyaedt.generic import ibis_reader
@@ -1722,3 +1724,43 @@ class Circuit(FieldAnalysisCircuit, object):
             ["NAME:DataBlock", "name:=", datablock_name, "filename:=", netlist_file, "filelocation:=", 0]
         )
         return True
+
+    @pyaedt_function_handler()
+    def browse_log_file(self, filepath=None):
+        """Save most recent log file into a new directory.
+
+        Parameters
+        ----------
+        filepath : str, optional
+            New log file path. The default is the pyaedt folder.
+
+        Returns
+        -------
+        str
+            File Path
+        """
+        if filepath and not os.path.exists(os.path.normpath(filepath)):
+            self.logger.error("Path does not exist.")
+            return None
+        else:
+            filepath = os.path.join(os.path.normpath(self.working_directory), "logfile")
+            if not os.path.exists(filepath):
+                os.mkdir(filepath)
+
+        results_path = os.path.join(os.path.normpath(self.results_directory), self.design_name)
+        results_temp_path = os.path.join(results_path, "temp")
+
+        # Check if .log exist in temp folder
+        if os.path.exists(results_temp_path) and glob.glob(os.path.join(results_temp_path, "*.log")):
+            # Check the most recent
+            files = glob.glob(os.path.join(results_temp_path, "*.log"))
+            latest_file = max(files, key=os.path.getctime)
+        elif os.path.exists(results_path) and glob.glob(os.path.join(results_path, "*.log")):
+            # Check the most recent
+            files = glob.glob(os.path.join(results_path, "*.log"))
+            latest_file = max(files, key=os.path.getctime)
+        else:
+            self.logger.error("Design not solved")
+            return None
+
+        return shutil.copy(latest_file, filepath)


### PR DESCRIPTION
This is an interesting capability in Circuit which is not exposed in the API. This method saves the most recent Log file into a new path because sometimes if the project is saved, the log files could dissapear.
![image](https://user-images.githubusercontent.com/85613111/189299501-fe2c85c5-b876-414e-8526-0d403582d391.png)
