### PR TITLE
Fix import spice model in Circuit. 

### DIFF
--- a/pyaedt/modeler/PrimitivesNexxim.py
+++ b/pyaedt/modeler/PrimitivesNexxim.py
@@ -1951,7 +1951,7 @@ class NexximComponents(CircuitComponents):
             else:
                 arg2.append([False, "", "", False])
         arg.append(arg2)
-        self.o_component_manager.ImportModelsFromFile(model_path, arg)
+        self.o_component_manager.ImportModelsFromFile(model_path.replace("\\", "/"), arg)
 
         return self.create_component(
             None,


### PR DESCRIPTION
The import was working but the component was useless because the path format allowed by the API method is just allowing "/" and not "\\"

Close #1723 