### PR TITLE
'hybrid' and 'composite' properties value are always updated.

### DIFF
--- a/pyaedt/application/design_solutions.py
+++ b/pyaedt/application/design_solutions.py
@@ -645,8 +645,8 @@ class HFSSDesignSolution(DesignSolution, object):
         """HFSS hybrid mode for the active solution."""
         if self._aedt_version < "2021.2":
             return False
-        if self._hybrid is None and self.solution_type is not None:
-            self._hybrid = "Hybrid" in self._solution_options[self.solution_type]["name"]
+        if self.solution_type is not None:
+            self._hybrid = "Hybrid" in self._odesign.GetSolutionType()
         return self._hybrid
 
     @hybrid.setter
@@ -671,7 +671,7 @@ class HFSSDesignSolution(DesignSolution, object):
         if self._aedt_version < "2021.2":
             return False
         if self._composite is None and self.solution_type is not None:
-            self._composite = "Composite" in self._solution_options[self.solution_type]["name"]
+            self._composite = "Composite" in self._odesign.GetSolutionType()
         return self._composite
 
     @composite.setter


### PR DESCRIPTION
Previously if a user was defining the value of the properties `hybrid` or `composite` with a script and then modified those properties interactively, then the value returned by those properties were not updated accordingly. The values set by the script were always returned.
This is due to the fact that those properties were based on `self._solution_options[self.solution_type]` which use a `copy.deepcopy` in the initialization of `DesignSolution` class. 

Fix #1730 .