### PR TITLE
Upgrade ansys-sphinx-theme to 0.6.1

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -12,7 +12,7 @@ sphinx-notfound-page==0.8
 sphinx-copybutton==0.5.0
 sphinx-gallery==0.11.1
 sphinx-autodoc-typehints==1.19.2
-ansys-sphinx-theme==0.6.0
+ansys-sphinx-theme==0.6.1
 pypandoc==1.8.1
 nbsphinx==0.8.9
 ipywidgets==8.0.2


### PR DESCRIPTION
Fix the documentation rendering.
Some text and section on the left side were overlapping.