### PR TITLE
Add return code to Siwave.open_project

### DIFF
--- a/pyaedt/siwave.py
+++ b/pyaedt/siwave.py
@@ -233,12 +233,17 @@ class Siwave:
 
         Returns
         -------
+        bool
+            ``True`` when successful, ``False`` when failed.
 
         """
 
         if os.path.exists(proj_path):
-            self.oSiwave.OpenProject(proj_path)
+            open_result = self.oSiwave.OpenProject(proj_path)
             self._oproject = self.oSiwave.GetActiveProject()
+            return open_result
+        else:
+            return False
 
     @pyaedt_function_handler()
     def save_project(self, projectpath=None, projectName=None):


### PR DESCRIPTION
Relative paths that pass `os.path.exists` can still fail to open.
Added a return value so calling code can throw an error if the project fails to open.