### PR TITLE
Wrong float conversion

### DIFF
--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -884,7 +884,7 @@ class TestClass(BasisTest, object):
         assert bound.slant_angle == "30deg"
         assert bound.polarization == "Slant"
         bound.azimuth_start = 20
-        assert bound.azimuth_start == "20.0deg"
+        assert bound.azimuth_start == "20deg"
         assert bound.delete()
         bound = self.aedtapp.insert_infinite_sphere(
             definition="Az Over El",

--- a/pyaedt/modeler/Object3d.py
+++ b/pyaedt/modeler/Object3d.py
@@ -225,6 +225,8 @@ def _dim_arg(value, units):
     """
     try:
         val = float(value)
+        if isinstance(value, int):
+            val = value
         return str(val) + units
     except:
         return value


### PR DESCRIPTION
This float conversion was affecting rotation in Circuit. For example, for a Port created if you tried to rotate it, it was failing because it expected an int and not a float