### PR TITLE
Expose the globalcontext and searchindex files for the dev portal.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -74,6 +74,8 @@ jobs:
               y=${x// /-};
               mv -n ${x// /\ } "./doc-flatten-json/${y////-}";
           done
+          # echo Make sure all the file has .json extensions instead of the .fjson
+          # for file in doc-flatten-json/*.fjson ; do mv -- "$file" "${file%.fjson}.json" ; done;
           # Move all static image files to the JSON flatten folder.
           mv -n doc-json/json/_images doc-flatten-json/_images;
 

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -65,13 +65,17 @@ jobs:
       - name: Flatten the generated nested files into a single directory
         run: |
           echo Flattening a nested directory
-          mkdir doc-flatten-json;
-          echo Move all the JSON file to the flatten directory.
-          find . -name "*.fjson" -exec mv "{}" --backup=numbered ./doc-flatten-json \;
-          echo Make sure all the file has .json extensions instead of the .fjson
-          for file in doc-flatten-json/*.fjson ; do mv -- "$file" "${file%.fjson}.json" ; done;
-          echo Move all static image files to the JSON flatten folder.
-          mv doc-json/json/_images doc-flatten-json/_images;
+          mkdir -p doc-flatten-json;
+          # Move all the JSON file to the flatten directory.
+          JSON_FILES=$(find doc-json/json -type f -name "*.fjson" -o -name "*.json*");
+          for filename in $JSON_FILES
+          do
+              x=${filename#./};
+              y=${x// /-};
+              mv -n ${x// /\ } "./doc-flatten-json/${y////-}";
+          done
+          # Move all static image files to the JSON flatten folder.
+          mv -n doc-json/json/_images doc-flatten-json/_images;
 
       - name: zip the flattened JSON directory
         run: |


### PR DESCRIPTION
The two following files were missing for the dev portal documentation: `globalcontext.json` and `searchindex.json`.