### PR TITLE
Add CableModeling to the API index of the documentation.

### DIFF
--- a/doc/source/API/index.rst
+++ b/doc/source/API/index.rst
@@ -16,6 +16,7 @@ to view API documentation.
    Primitives
    CoreModules
    Mesh
+   CableModeling
    Setup
    Post
 

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -1825,13 +1825,14 @@ class SimulationConfiguration(object):
         """Add a dc ground source terminal for Siwave.
 
         Parameters
-        -----------
+        ----------
+        source_name : str, optional
+            The source name to assign the reference node to.
+            Default value is ``None``.
 
-        source_name = str
-            The source name to assign the reference node
-
-        node_to_ground = int
-            Value must be 0: unspecified, 1: negative node, 2: positive node.
+        node_to_ground : int, optional
+            Value must be ``0``: unspecified, ``1``: negative node, ``2``: positive node.
+            Default value is ``1``.
 
         """
         if source_name:

--- a/pyaedt/edb_core/stackup.py
+++ b/pyaedt/edb_core/stackup.py
@@ -750,8 +750,9 @@ class EdbStackup(object):
         """Return the layout thickness.
 
         Returns
-        --------
-        Float, the thickness value.
+        -------
+        float
+            The thickness value.
         """
         layers_name = list(self.stackup_layers.layers.keys())
         bottom_layer = self.stackup_layers.layers[layers_name[0]]

--- a/pyaedt/generic/configurations.py
+++ b/pyaedt/generic/configurations.py
@@ -173,7 +173,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.export_boundaries = False  # Disable the boundaries export
@@ -193,7 +193,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.export_mesh_operations = False  # Disable the mesh operations export
@@ -213,7 +213,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.export_coordinate_systems = False  # Disable the coordinate systems export
@@ -253,7 +253,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.export_export_materials = False  # Disable the materials export
@@ -273,7 +273,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.export_object_properties = False  # Disable the object properties export
@@ -293,7 +293,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_variables = False  # Disable the variables import
@@ -313,7 +313,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_setups = False  # Disable the setup import
@@ -333,7 +333,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_optimizations = False  # Disable the optimization import
@@ -353,7 +353,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_parametrics = False  # Disable the parametrics import
@@ -373,7 +373,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_boundaries = False  # Disable the boundaries import
@@ -393,7 +393,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_mesh_operations = False  # Disable the mesh operations import
@@ -413,7 +413,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_coordinate_systems = False  # Disable the coordinate systems import
@@ -453,7 +453,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_import_materials = False  # Disable the materials import
@@ -473,7 +473,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.import_object_properties = False  # Disable the object properties import
@@ -493,7 +493,7 @@ class ConfigurationsOptions(object):
         bool
 
         Examples
-        ---------
+        --------
         >>> from pyaedt import Hfss
         >>> hfss = Hfss()
         >>> hfss.configurations.options.skip_import_if_exists = False  # Disable the update of existing properties

--- a/pyaedt/modeler/object3dlayout.py
+++ b/pyaedt/modeler/object3dlayout.py
@@ -824,7 +824,7 @@ class Pins3DLayout(Objec3DLayout, object):
         """Retrieve the hole diameter of the pin.
 
         Returns
-        --------
+        -------
         float
            Hole diameter of the pin.
 


### PR DESCRIPTION
Fix warnings in the documentation including one about the cable documentation.
![image](https://user-images.githubusercontent.com/87315832/198095995-8e8c97c8-c8e4-4bcf-af52-9a3c1511746c.png)
