### PR TITLE
Edb primitives enhancement - new create_cutout_multithread method

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -601,7 +601,8 @@ if not config["skip_edb"]:
             assert os.path.exists(os.path.join(output, "edb.def"))
             edbapp.close_edb()
 
-        def test_55c_create_cutout(self):
+        @pytest.mark.skipif(is_ironpython, reason="Method works in CPython only")
+        def test_55c_create_custom_cutout(self):
             source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
             target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_2.aedb")
             self.local_scratch.copyfolder(source_path, target_path)
@@ -617,7 +618,8 @@ if not config["skip_edb"]:
             target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_3.aedb")
             self.local_scratch.copyfolder(source_path, target_path)
 
-        def test_55d_create_cutout(self):
+        @pytest.mark.skipif(is_ironpython, reason="Method works in CPython only")
+        def test_55d_create_custom_cutout(self):
             source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
             target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_3.aedb")
             self.local_scratch.copyfolder(source_path, target_path)

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -568,11 +568,11 @@ if not config["skip_edb"]:
             assert len(list(component.LayoutObjs)) == 2
 
         def test_55b_create_cutout(self):
-            source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
-            target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_1.aedb")
-            self.local_scratch.copyfolder(source_path, target_path)
-            edbapp = Edb(target_path, edbversion=desktop_version)
-            assert edbapp.create_cutout(
+            output = os.path.join(self.local_scratch.path, "cutout.aedb")
+            assert self.edbapp.create_cutout(
+                ["A0_N", "A0_P"], ["GND"], output_aedb_path=output, open_cutout_at_end=False
+            )
+            assert self.edbapp.create_cutout(
                 ["A0_N", "A0_P"],
                 ["GND"],
                 output_aedb_path=output,
@@ -589,7 +589,7 @@ if not config["skip_edb"]:
             points.append([bounding[0][0], bounding[0][1]])
             output = os.path.join(self.local_scratch.path, "cutout2.aedb")
 
-            assert edbapp.create_cutout_on_point_list(
+            assert self.edbapp.create_cutout_on_point_list(
                 points,
                 nets_to_include=["GND", "V3P3_S0"],
                 output_aedb_path=output,

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -646,6 +646,7 @@ if not config["skip_edb"]:
                 signal_list=["V3P3_S0"],
                 reference_list=["GND"],
                 number_of_threads=4,
+                extent_type="Bounding",
                 custom_extent=points,
             )
             edbapp.close_edb()

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -568,8 +568,9 @@ if not config["skip_edb"]:
             assert len(list(component.LayoutObjs)) == 2
 
         def test_55b_create_cutout(self):
-            output = os.path.join(self.local_scratch.path, "cutout.aedb")
-            target_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
+            source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
+            target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_1.aedb")
+            self.local_scratch.copyfolder(source_path, target_path)
             edbapp = Edb(target_path, edbversion=desktop_version)
             assert edbapp.create_cutout(
                 ["A0_N", "A0_P"],
@@ -596,6 +597,19 @@ if not config["skip_edb"]:
                 include_partial_instances=True,
             )
             assert os.path.exists(os.path.join(output, "edb.def"))
+
+        def test_55c_create_cutout(self):
+            source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
+            target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_2.aedb")
+            self.local_scratch.copyfolder(source_path, target_path)
+            edbapp = Edb(target_path, edbversion=desktop_version)
+
+            assert edbapp.create_cutout_multithread(
+                signal_list=["V3P3_S0"],
+                reference_list=["GND"],
+                number_of_threads=4,
+            )
+            assert "A0_N" not in edbapp.core_nets.nets
 
         def test_56_rvalue(self):
             assert resistor_value_parser("100meg")

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -599,6 +599,7 @@ if not config["skip_edb"]:
                 include_partial_instances=True,
             )
             assert os.path.exists(os.path.join(output, "edb.def"))
+            edbapp.close_edb()
 
         def test_55c_create_cutout(self):
             source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
@@ -612,6 +613,7 @@ if not config["skip_edb"]:
                 number_of_threads=4,
             )
             assert "A0_N" not in edbapp.core_nets.nets
+            edbapp.close_edb()
 
         def test_56_rvalue(self):
             assert resistor_value_parser("100meg")

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -568,18 +568,20 @@ if not config["skip_edb"]:
             assert len(list(component.LayoutObjs)) == 2
 
         def test_55b_create_cutout(self):
+            source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
+            target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_1.aedb")
+            self.local_scratch.copyfolder(source_path, target_path)
+            edbapp = Edb(target_path, edbversion=desktop_version)
             output = os.path.join(self.local_scratch.path, "cutout.aedb")
-            assert self.edbapp.create_cutout(
-                ["A0_N", "A0_P"], ["GND"], output_aedb_path=output, open_cutout_at_end=False
-            )
-            assert self.edbapp.create_cutout(
+            assert edbapp.create_cutout(["A0_N", "A0_P"], ["GND"], output_aedb_path=output, open_cutout_at_end=False)
+            assert edbapp.create_cutout(
                 ["A0_N", "A0_P"],
                 ["GND"],
                 output_aedb_path=output,
                 open_cutout_at_end=False,
             )
             assert os.path.exists(os.path.join(output, "edb.def"))
-            bounding = self.edbapp.get_bounding_box()
+            bounding = edbapp.get_bounding_box()
             cutout_line_x = 41
             cutout_line_y = 30
             points = [[bounding[0][0], bounding[0][1]]]
@@ -589,7 +591,7 @@ if not config["skip_edb"]:
             points.append([bounding[0][0], bounding[0][1]])
             output = os.path.join(self.local_scratch.path, "cutout2.aedb")
 
-            assert self.edbapp.create_cutout_on_point_list(
+            assert edbapp.create_cutout_on_point_list(
                 points,
                 nets_to_include=["GND", "V3P3_S0"],
                 output_aedb_path=output,

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -614,6 +614,30 @@ if not config["skip_edb"]:
             )
             assert "A0_N" not in edbapp.core_nets.nets
             edbapp.close_edb()
+            target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_3.aedb")
+            self.local_scratch.copyfolder(source_path, target_path)
+
+        def test_55d_create_cutout(self):
+            source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
+            target_path = os.path.join(self.local_scratch.path, "Galileo_cutout_3.aedb")
+            self.local_scratch.copyfolder(source_path, target_path)
+
+            edbapp = Edb(target_path, edbversion=desktop_version)
+            bounding = edbapp.get_bounding_box()
+            cutout_line_x = 41
+            cutout_line_y = 30
+            points = [[bounding[0][0], bounding[0][1]]]
+            points.append([cutout_line_x, bounding[0][1]])
+            points.append([cutout_line_x, cutout_line_y])
+            points.append([bounding[0][0], cutout_line_y])
+            points.append([bounding[0][0], bounding[0][1]])
+            assert edbapp.create_cutout_multithread(
+                signal_list=["V3P3_S0"],
+                reference_list=["GND"],
+                number_of_threads=4,
+                custom_extent=points,
+            )
+            edbapp.close_edb()
 
         def test_56_rvalue(self):
             assert resistor_value_parser("100meg")

--- a/pyaedt/aedt_logger.py
+++ b/pyaedt/aedt_logger.py
@@ -196,6 +196,10 @@ class AedtLogger(object):
                 break
         self.info("New logger file {} added to handlers.".format(filename))
         self._files_handlers.append(_file_handler)
+        _project.info_timer = self.info_timer
+        _project.reset_timer = self.reset_timer
+        _project._timer = time.time()
+
         return _project
 
     def remove_file_logger(self, project_name):
@@ -625,7 +629,7 @@ class AedtLogger(object):
         """Write an info message to the global logger."""
         if args:
             try:
-                msg1 = msg % args
+                msg1 = msg % [str(i) for i in args]
             except TypeError:
                 msg1 = msg
         else:
@@ -648,7 +652,7 @@ class AedtLogger(object):
             msg += " Elapsed time: {}m {}sec".format(round(m), round(s))
         if args:
             try:
-                msg1 = msg % args
+                msg1 = msg % [str(i) for i in args]
             except TypeError:
                 msg1 = msg
         else:
@@ -660,7 +664,7 @@ class AedtLogger(object):
         """Write a warning message to the global logger."""
         if args:
             try:
-                msg1 = msg % args
+                msg1 = msg % [str(i) for i in args]
             except TypeError:
                 msg1 = msg
         else:
@@ -672,7 +676,7 @@ class AedtLogger(object):
         """Write an error message to the global logger."""
         if args:
             try:
-                msg1 = msg % args
+                msg1 = msg % [str(i) for i in args]
             except TypeError:
                 msg1 = msg
         else:
@@ -684,7 +688,7 @@ class AedtLogger(object):
         """Write a debug message to the global logger."""
         if args:
             try:
-                msg1 = msg % args
+                msg1 = msg % [str(i) for i in args]
             except TypeError:
                 msg1 = msg
         else:

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1161,7 +1161,6 @@ class Edb(object):
         >>>      if "3V3" in net:
         >>>           signal_list.append(net)
         >>> power_list = ["PGND"]
-        >>> all_list = signal_list + power_list
         >>> edb.create_cutout_multithread(signal_list=signal_list, reference_list=power_list, extent_type="Conforming")
         >>> end_time = str((time.time() - start)/60)
         >>> edb.logger.info("Total pyaedt cutout time in min %s", end_time)
@@ -1195,15 +1194,16 @@ class Edb(object):
                 i.delete()
         self.logger.info_timer("Net clean up")
         self.logger.reset_timer()
-        net_signals = convert_py_list_to_net_list(
-            [net for net in list(self.active_layout.Nets) if net.GetName() in signal_list]
-        )
+
         if custom_extent and isinstance(custom_extent, list):
             plane = self.core_primitives.Shape("polygon", points=custom_extent)
             _poly = self.core_primitives.shape_to_polygon_data(plane)
         elif custom_extent:
             _poly = custom_extent
         else:
+            net_signals = convert_py_list_to_net_list(
+                [net for net in list(self.active_layout.Nets) if net.GetName() in signal_list]
+            )
             _poly = self._create_extent(
                 net_signals,
                 extent_type,

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1099,6 +1099,7 @@ class Edb(object):
             self._init_objects()
         return True
 
+    @pyaedt_function_handler()
     def create_cutout_multithread(
         self,
         signal_list=[],
@@ -1106,7 +1107,7 @@ class Edb(object):
         extent_type="Conforming",
         expansion_size=0.002,
         use_round_corner=False,
-        number_of_threads=12,
+        number_of_threads=4,
     ):
         """Create a cutout using an approach entirely based on pyaedt.
         It does in sequence:
@@ -1130,6 +1131,8 @@ class Edb(object):
             Expansion size ratio in meters. The default is ``0.002``.
         use_round_corner : bool, optional
             Whether to use round corners. The default is ``False``.
+        number_of_threads : int, optional
+            Number of thread to use. Default is 4
 
         Returns
         -------
@@ -1241,6 +1244,7 @@ class Edb(object):
         self.core_components.delete_single_pin_rlc()
         self.logger.info_timer("Single Pins components deleted")
         self.logger.reset_timer()
+        return True
 
     @pyaedt_function_handler()
     def get_conformal_polygon_from_netlist(self, netlist=None):

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1206,7 +1206,7 @@ class Edb(object):
             _poly = self.core_primitives.shape_to_polygon_data(plane)
         elif custom_extent:
             _poly = custom_extent
-        if extent_type == "Conforming":
+        elif extent_type == "Conforming":
             _poly = self.active_layout.GetExpandedExtentFromNets(
                 net_signals, self.edb.Geometry.ExtentType.Conforming, expansion_size, False, use_round_corner, 1
             )

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1187,15 +1187,15 @@ class Edb(object):
         else:
             all_list = signal_list + reference_list
 
-        for i in self.core_nets.nets.values():
-            if i.name not in all_list:
-                i.net_object.Delete()
         for i in self.core_padstack.padstack_instances.values():
             if i.net_name not in all_list:
                 i.delete_padstack_instance()
         for i in self.core_primitives.primitives:
             if i.net_name not in all_list:
                 i.delete()
+        for i in self.core_nets.nets.values():
+            if i.name not in all_list:
+                i.net_object.Delete()
         self.logger.info_timer("Net clean up")
         self.logger.reset_timer()
 
@@ -1254,11 +1254,13 @@ class Edb(object):
                     prims_to_delete.append(prim_1)
 
         def pins_clean(pinst):
-            if pinst.net_name in reference_list and not pinst.in_polygon(_poly):
+            if pinst.net_name in reference_list and not pinst.in_polygon(_poly, simple_check=True):
                 pins_to_delete.append(pinst)
 
         with ThreadPoolExecutor(number_of_threads) as pool:
             pool.map(lambda item: pins_clean(item), pinsts)
+        # for item in pinsts:
+        #     pins_clean(item)
 
         for pin in pins_to_delete:
             pin.delete_padstack_instance()

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1109,6 +1109,7 @@ class Edb(object):
         use_round_corner=False,
         number_of_threads=4,
         simulation_setup=None,
+        custom_extent=None,
     ):
         """Create a cutout using an approach entirely based on pyaedt.
         It does in sequence:
@@ -1136,6 +1137,9 @@ class Edb(object):
             Number of thread to use. Default is 4
         simulation_setup : edb_data.simulation_configuration.SimulationConfiguration object, optional
             Simulation setup to use to overwrite the other parameters. The default is ``None``.
+        custom_extent : list, optional
+            Custom extent to use for the cutout. It has to be a list of points [[x1,y1],[x2,y2]....] or
+            Edb PolygonData object.
 
         Returns
         -------
@@ -1197,7 +1201,11 @@ class Edb(object):
         net_signals = convert_py_list_to_net_list(
             [net for net in list(self.active_layout.Nets) if net.GetName() in signal_list]
         )
-
+        if custom_extent and isinstance(custom_extent, list):
+            plane = self.core_primitives.Shape("polygon", points=custom_extent)
+            _poly = self.core_primitives.shape_to_polygon_data(plane)
+        elif custom_extent:
+            _poly = custom_extent
         if extent_type == "Conforming":
             _poly = self.active_layout.GetExpandedExtentFromNets(
                 net_signals, self.edb.Geometry.ExtentType.Conforming, expansion_size, False, use_round_corner, 1

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1139,6 +1139,26 @@ class Edb(object):
         bool
             ``True`` when successful, ``False`` when failed.
 
+        Examples
+        --------
+        >>> edb = Edb(r'C:.aedb', edbversion="2022.2")
+        >>> edb.logger.info_timer("Edb Opening")
+        >>> edb.logger.reset_timer()
+        >>> start = time.time()
+        >>> signal_list = []
+        >>> for net in edb.core_nets.nets.keys():
+        >>>      if "3V3" in net:
+        >>>           signal_list.append(net)
+        >>> power_list = ["PGND"]
+        >>> all_list = signal_list + power_list
+        >>> edb.create_cutout_multithread(signal_list=signal_list, reference_list=power_list, extent_type="Conforming")
+        >>> end_time = str((time.time() - start)/60)
+        >>> edb.logger.info("Total pyaedt cutout time in min %s", end_time)
+        >>> edb.core_nets.plot(signal_list, None, color_by_net=True)
+        >>> edb.core_nets.plot(power_list, None, color_by_net=True)
+        >>> edb.save_edb()
+        >>> edb.close_edb()
+
         """
         if is_ironpython:
             self.logger.error("Method working only in Cpython")

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1108,6 +1108,7 @@ class Edb(object):
         expansion_size=0.002,
         use_round_corner=False,
         number_of_threads=4,
+        simulation_setup=None,
     ):
         """Create a cutout using an approach entirely based on pyaedt.
         It does in sequence:
@@ -1133,6 +1134,8 @@ class Edb(object):
             Whether to use round corners. The default is ``False``.
         number_of_threads : int, optional
             Number of thread to use. Default is 4
+        simulation_setup : edb_data.simulation_configuration.SimulationConfiguration object, optional
+            Simulation setup to use to overwrite the other parameters. The default is ``None``.
 
         Returns
         -------
@@ -1165,6 +1168,18 @@ class Edb(object):
             return False
         from concurrent.futures import ThreadPoolExecutor
 
+        expansion_size = self.edb_value(expansion_size).ToDouble()
+        if simulation_setup and isinstance(simulation_setup, SimulationConfiguration):
+            signal_list = simulation_setup.signal_nets
+            reference_list = simulation_setup.power_nets
+            if simulation_setup.cutout_subdesign_type == CutoutSubdesignType.Conformal:
+                extent_type = "Conforming"
+            elif simulation_setup.cutout_subdesign_type == CutoutSubdesignType.BoundingBox:
+                extent_type = "Bounding"
+            else:
+                extent_type = "ConvexHull"
+            expansion_size = float(simulation_setup.cutout_subdesign_expansion)
+            use_round_corner = bool(simulation_setup.cutout_subdesign_round_corner)
         self.logger.reset_timer()
         all_list = signal_list + reference_list
 

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1277,6 +1277,14 @@ class Edb(object):
         self.logger.reset_timer()
 
         self.core_components.delete_single_pin_rlc()
+        i = 0
+        for comp, val in self.core_components.components.items():
+            if val.numpins == 0:
+                val.edbcomponent.Delete()
+                i += 1
+        self.core_components.refresh_components()
+        self.logger.info("Deleted {} additional components".format(i))
+
         self.logger.info_timer("Single Pins components deleted")
         self.logger.reset_timer()
         return True

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1141,7 +1141,7 @@ class Edb(object):
             Number of thread to use. Default is 4
         custom_extent : list, optional
             Custom extent to use for the cutout. It has to be a list of points [[x1,y1],[x2,y2]....] or
-            Edb PolygonData object.
+            Edb PolygonData object. In this case, both signal_list and reference_list will be cut.
         output_aedb_path : str, optional
             Full path and name for the new AEDB file. If None, then current aedb will be cutout.
 

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -1181,7 +1181,11 @@ class Edb(object):
         expansion_size = self.edb_value(expansion_size).ToDouble()
 
         self.logger.reset_timer()
-        all_list = signal_list + reference_list
+        if custom_extent:
+            reference_list = reference_list + signal_list
+            all_list = reference_list
+        else:
+            all_list = signal_list + reference_list
 
         for i in self.core_nets.nets.values():
             if i.name not in all_list:

--- a/pyaedt/edb_core/components.py
+++ b/pyaedt/edb_core/components.py
@@ -1317,14 +1317,12 @@ class Components(object):
         """
         deleted_comps = []
         for comp, val in self.components.items():
-            if val.numpins < 2 and (val.type == "Resistor" or val.type == "Capacitor" or val.type == "Inductor"):
-                edb_cmp = self.get_component_by_name(comp)
-                if edb_cmp is not None:
-                    edb_cmp.Delete()
-                    deleted_comps.append(comp)
-                    self._pedb._logger.info("Component {} deleted".format(comp))
-        for el in deleted_comps:
-            del self.components[el]
+            if val.numpins < 2 and val.type in ["Resistor", "Capacitor", "Inductor"]:
+                val.edbcomponent.Delete()
+                deleted_comps.append(comp)
+        self.refresh_components()
+        self._pedb._logger.info("Deleted {} components".format(len(deleted_comps)))
+
         return deleted_comps
 
     @pyaedt_function_handler()

--- a/pyaedt/edb_core/edb_data/nets_data.py
+++ b/pyaedt/edb_core/edb_data/nets_data.py
@@ -1,3 +1,5 @@
+from pyaedt.edb_core.edb_data.padstacks_data import EDBPadstackInstance
+from pyaedt.edb_core.edb_data.primitives_data import EDBPrimitives
 from pyaedt.generic.general_methods import pyaedt_function_handler
 
 
@@ -51,11 +53,16 @@ class EDBNetsData(object):
         -------
         list of :class:`pyaedt.edb_core.edb_data.primitives_data.EDBPrimitives`
         """
-        prims = []
-        for el in self._core_primitive.primitives:
-            if self.name == el.net_name:
-                prims.append(el)
-        return prims
+        return [EDBPrimitives(i, self._app) for i in self.net_object.Primitives]
+
+    @property
+    def padstack_instances(self):
+        """Return the list of primitives that belongs to the net.
+
+        Returns
+        -------
+        list of :class:`pyaedt.edb_core.edb_data.padstacks_data.EDBPadstackInstance`"""
+        return [EDBPadstackInstance(i, self._app) for i in self.net_object.PadstackInstances]
 
     @property
     def is_power_ground(self):

--- a/pyaedt/edb_core/edb_data/nets_data.py
+++ b/pyaedt/edb_core/edb_data/nets_data.py
@@ -62,7 +62,10 @@ class EDBNetsData(object):
         Returns
         -------
         list of :class:`pyaedt.edb_core.edb_data.padstacks_data.EDBPadstackInstance`"""
-        return [EDBPadstackInstance(i, self._app) for i in self.net_object.PadstackInstances]
+        name = self.name
+        return [
+            EDBPadstackInstance(i, self._app) for i in self.net_object.PadstackInstances if i.GetNet().GetName() == name
+        ]
 
     @property
     def is_power_ground(self):

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -665,12 +665,7 @@ class EDBPadstackInstance(object):
         """
         if self._bounding_box:
             return self._bounding_box
-        bbox = (
-            self._edb_padstackinstance.GetLayout()
-            .GetLayoutInstance()
-            .GetLayoutObjInstance(self._edb_padstackinstance, None)
-            .GetBBox()
-        )
+        bbox = self.object_instance.GetBBox()
         self._bounding_box = [
             [bbox.Item1.X.ToDouble(), bbox.Item1.Y.ToDouble()],
             [bbox.Item2.X.ToDouble(), bbox.Item2.Y.ToDouble()],

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -645,6 +645,7 @@ class EDBPadstackInstance(object):
 
     @property
     def object_instance(self):
+        """Edb Object Instance."""
         if not self._object_instance:
             self._object_instance = (
                 self._edb_padstackinstance.GetLayout()

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -641,6 +641,17 @@ class EDBPadstackInstance(object):
         self._edb_padstackinstance = edb_padstackinstance
         self._pedb = _pedb
         self._bounding_box = []
+        self._object_instance = None
+
+    @property
+    def object_instance(self):
+        if not self._object_instance:
+            self._object_instance = (
+                self._edb_padstackinstance.GetLayout()
+                .GetLayoutInstance()
+                .GetLayoutObjInstance(self._edb_padstackinstance, None)
+            )
+        return self._object_instance
 
     @property
     def bounding_box(self):
@@ -666,7 +677,7 @@ class EDBPadstackInstance(object):
         return self._bounding_box
 
     @pyaedt_function_handler()
-    def in_polygon(self, polygon_data, include_partial=True):
+    def in_polygon(self, polygon_data, include_partial=True, simple_check=False):
         """Check if padstack Instance is in given polygon data.
 
         Parameters
@@ -680,9 +691,22 @@ class EDBPadstackInstance(object):
         bool
             ``True`` when successful, ``False`` when failed.
         """
-        plane = self._pedb.core_primitives.Shape("rectangle", pointA=self.bounding_box[0], pointB=self.bounding_box[1])
-        rectangle_data = self._pedb.core_primitives.shape_to_polygon_data(plane)
-        int_val = polygon_data.GetIntersectionType(rectangle_data)
+        if simple_check:
+            int_val = (
+                1
+                if polygon_data.PointInPolygon(
+                    self._pedb.edb.Geometry.PointData(
+                        self._pedb.edb_value(self.position[0]), self._pedb.edb_value(self.position[1])
+                    )
+                )
+                else 0
+            )
+        else:
+            plane = self._pedb.core_primitives.Shape(
+                "rectangle", pointA=self.bounding_box[0], pointB=self.bounding_box[1]
+            )
+            rectangle_data = self._pedb.core_primitives.shape_to_polygon_data(plane)
+            int_val = polygon_data.GetIntersectionType(rectangle_data)
         # Intersection type:
         # 0 = objects do not intersect
         # 1 = this object fully inside other (no common contour points)

--- a/pyaedt/edb_core/edb_data/simulation_configuration.py
+++ b/pyaedt/edb_core/edb_data/simulation_configuration.py
@@ -181,6 +181,7 @@ class SimulationConfiguration(object):
         self._sources = []
         self._mesh_sizefactor = 0.0
         self._read_cfg()
+        self._use_default_cutout = True
 
     @property
     def filename(self):  # pragma: no cover
@@ -197,6 +198,20 @@ class SimulationConfiguration(object):
     def filename(self, value):
         if isinstance(value, str):  # pragma: no cover
             self._filename = value
+
+    @property
+    def use_default_cutout(self):  # pragma: no cover
+        """Either if use the default EDB Cutout or new pyaedt cutout.
+
+        Returns
+        -------
+        bool
+        """
+        return self._use_default_cutout
+
+    @use_default_cutout.setter
+    def use_default_cutout(self, value):  # pragma: no cover
+        self._use_default_cutout = value
 
     @property
     def generate_solder_balls(self):  # pragma: no cover

--- a/pyaedt/edb_core/layout.py
+++ b/pyaedt/edb_core/layout.py
@@ -32,9 +32,7 @@ class EdbLayout(object):
     """
 
     def __init__(self, p_edb):
-        self._prims = []
         self._pedb = p_edb
-        # self.update_primitives()
 
     @property
     def _edb(self):
@@ -80,24 +78,6 @@ class EdbLayout(object):
         """
         return self._pedb.core_stackup.stackup_layers.layers
 
-    @pyaedt_function_handler()
-    def update_primitives(self):
-        """
-        Update a primitives list from the EDB database.
-
-        Returns
-        -------
-        bool
-            ``True`` when successful, ``False`` when failed.
-        """
-        if self._active_layout:
-            self._prims = []
-            for lay_obj in list(self._active_layout.Primitives):
-                self._prims.append(EDBPrimitives(lay_obj, self._pedb))
-            self._logger.info("Primitives Updated")
-            return True
-        return False
-
     @property
     def primitives(self):
         """Primitives.
@@ -107,9 +87,11 @@ class EdbLayout(object):
         list of :class:`pyaedt.edb_core.edb_data.primitives_data.EDBPrimitives`
             List of primitives.
         """
-        if not self._prims:
-            self.update_primitives()
-        return self._prims
+        _prims = []
+        if self._active_layout:
+            for lay_obj in list(self._active_layout.Primitives):
+                _prims.append(EDBPrimitives(lay_obj, self._pedb))
+        return _prims
 
     @property
     def polygons_by_layer(self):
@@ -126,8 +108,20 @@ class EdbLayout(object):
         return _primitives_by_layer
 
     @property
-    def _primitives_by_layer(self):
-        return self.polygons_by_layer
+    def primitives_by_layer(self):
+        """Primitives with layer names as keys.
+
+        Returns
+        -------
+        dict
+            Dictionary of primitives with layer names as keys.
+        """
+        _primitives_by_layer = {}
+        for lay in self.layers:
+            _primitives_by_layer[lay] = [
+                EDBPrimitives(i, self._pedb) for i in self._active_layout.Primitives if i.GetLayer().GetName() == lay
+            ]
+        return _primitives_by_layer
 
     @property
     def rectangles(self):
@@ -448,15 +442,6 @@ class EdbLayout(object):
         if polygon.IsNull():
             self._logger.error("Null path created")
             return False
-        else:
-            if not self._prims:
-                self.update_primitives()
-            else:
-                self._prims.append(EDBPrimitives(polygon, self._pedb))
-                if layer_name in self._primitives_by_layer:
-                    self._primitives_by_layer[layer_name].append(polygon)
-                else:
-                    self._primitives_by_layer[layer_name] = [polygon]
         return polygon
 
     @pyaedt_function_handler()
@@ -532,12 +517,18 @@ class EdbLayout(object):
             Polygon when successful, ``False`` when failed.
         """
         net = self._pedb.core_nets.find_or_create_net(net_name)
-        polygonData = self.shape_to_polygon_data(main_shape)
+        if isinstance(main_shape, EdbLayout.Shape):
+            polygonData = self.shape_to_polygon_data(main_shape)
+        else:
+            polygonData = main_shape
         if polygonData is None or polygonData.IsNull() or polygonData is False:
             self._logger.error("Failed to create main shape polygon data")
             return False
         for void in voids:
-            voidPolygonData = self.shape_to_polygon_data(void)
+            if isinstance(void, EdbLayout.Shape):
+                voidPolygonData = self.shape_to_polygon_data(void)
+            else:
+                voidPolygonData = void
             if voidPolygonData is None or voidPolygonData.IsNull() or polygonData is False:
                 self._logger.error("Failed to create void polygon data")
                 return False
@@ -547,14 +538,6 @@ class EdbLayout(object):
             self._logger.error("Null polygon created")
             return False
         else:
-            if not self._prims:
-                self.update_primitives()
-            else:
-                self._prims.append(EDBPrimitives(polygon, self._pedb))
-                if layer_name in list(self._primitives_by_layer.keys()):
-                    self._primitives_by_layer[layer_name].append(polygon)
-                else:
-                    self._primitives_by_layer[layer_name] = [polygon]
             return polygon
 
     @pyaedt_function_handler()
@@ -654,10 +637,9 @@ class EdbLayout(object):
         if not isinstance(net_names, list):  # pragma: no cover
             net_names = [net_names]
 
-        for p in self.primitives:
+        for p in self.primitives[:]:
             if p.net_name in net_names:
                 p.delete()
-        self.update_primitives()
         return True
 
     @pyaedt_function_handler()
@@ -727,7 +709,6 @@ class EdbLayout(object):
             if res:
                 cloned_circle.SetIsNegative(True)
                 void_circle.Delete()
-        self.update_primitives()
         return True
 
     @pyaedt_function_handler()
@@ -1062,7 +1043,6 @@ class EdbLayout(object):
                 p1 = self._pedb.core_padstack.padstacks[pad].edb_padstack.GetData()
                 if len(p1.GetLayerNames()) > 1:
                     self._pedb.core_padstack.remove_pads_from_padstack(pad)
-        self.update_primitives()
         return True
 
     @pyaedt_function_handler()

--- a/pyaedt/edb_core/nets.py
+++ b/pyaedt/edb_core/nets.py
@@ -593,11 +593,11 @@ class EdbNets(object):
         self._pedb.core_padstack.delete_padstack_instances(netlist)
 
         nets_deleted = []
+
         for i in self._pedb.core_nets.nets.values():
-            if i.name not in nets_deleted:
+            if i.name in netlist:
                 i.net_object.Delete()
                 nets_deleted.append(i.name)
-
         return nets_deleted
 
     @pyaedt_function_handler()

--- a/pyaedt/edb_core/padstack.py
+++ b/pyaedt/edb_core/padstack.py
@@ -145,10 +145,12 @@ class EdbPadstacks(object):
             List of padstacks via padstack definitions.
 
         """
-        if self._padstacks:
-            return self._padstacks
-        self.update_padstacks()
-        return self._padstacks
+        _padstacks = {}
+        for padstackdef in self.db.PadstackDefs:
+            PadStackData = padstackdef.GetData()
+            if len(PadStackData.GetLayerNames()) >= 1:
+                _padstacks[padstackdef.GetName()] = EDBPadstack(padstackdef, self)
+        return _padstacks
 
     @property
     def padstack_instances(self):
@@ -160,10 +162,11 @@ class EdbPadstacks(object):
             List of padstack instances.
 
         """
-        if self._padstack_instances:
-            return self._padstack_instances
-        self.update_padstack_instances()
-        return self._padstack_instances
+        layout_lobj_collection = list(self._active_layout.PadstackInstances)
+        _padstack_instances = {}
+        for lobj in layout_lobj_collection:
+            _padstack_instances[lobj.GetId()] = EDBPadstackInstance(lobj, self._pedb)
+        return _padstack_instances
 
     @property
     def pingroups(self):
@@ -193,21 +196,6 @@ class EdbPadstacks(object):
             )
 
         return PadType
-
-    @pyaedt_function_handler()
-    def update_padstacks(self):
-        """Update Padstack Dictionary.
-
-        Returns
-        -------
-        dict
-            Dictionary of Padstacks.
-        """
-        self._padstacks = {}
-        for padstackdef in self.db.PadstackDefs:
-            PadStackData = padstackdef.GetData()
-            if len(PadStackData.GetLayerNames()) >= 1:
-                self._padstacks[padstackdef.GetName()] = EDBPadstack(padstackdef, self)
 
     @pyaedt_function_handler()
     def create_circular_padstack(
@@ -310,7 +298,6 @@ class EdbPadstacks(object):
                     value0,
                 )
         PadStack.SetData(new_PadStackData)
-        self.update_padstacks()
 
     @pyaedt_function_handler
     def delete_padstack_instances(self, net_names):
@@ -709,7 +696,6 @@ class EdbPadstacks(object):
         padstackDefinition = self._edb.Definition.PadstackDef.Create(self.db, padstackname)
         padstackDefinition.SetData(padstackData)
         self._logger.info("Padstack %s create correctly", padstackname)
-        self.update_padstacks()
         return padstackname
 
     @pyaedt_function_handler()
@@ -744,7 +730,6 @@ class EdbPadstacks(object):
 
         padstack_definition = self._edb.Definition.PadstackDef.Create(self.db, new_padstack_name)
         padstack_definition.SetData(new_padstack_definition_data)
-        self.update_padstacks()
 
         return new_padstack_name
 
@@ -820,7 +805,6 @@ class EdbPadstacks(object):
                 None,
             )
             padstack_instance.SetIsLayoutPin(is_pin)
-            self.update_padstack_instances()
             return padstack_instance.GetId()
         else:
             return False
@@ -856,7 +840,6 @@ class EdbPadstacks(object):
             newPadstackDefinitionData.SetPadParameters(lay, pad_type, pad_geo, params, vals, vals, vals)
 
         self.padstacks[padstack_name].edb_padstack.SetData(newPadstackDefinitionData)
-        self.update_padstacks()
         return True
 
     @pyaedt_function_handler()
@@ -959,16 +942,7 @@ class EdbPadstacks(object):
                 antipad_rotation,
             )
         self.padstacks[padstack_name].edb_padstack.SetData(new_padstack_def)
-        self.update_padstacks()
         return True
-
-    @pyaedt_function_handler()
-    def update_padstack_instances(self):
-        """Update Padstack Instance List."""
-        layout_lobj_collection = list(self._active_layout.PadstackInstances)
-        self._padstack_instances = {}
-        for lobj in layout_lobj_collection:
-            self._padstack_instances[lobj.GetId()] = EDBPadstackInstance(lobj, self._pedb)
 
     @pyaedt_function_handler()
     def get_padstack_instance_by_net_name(self, net_name):

--- a/pyaedt/generic/constants.py
+++ b/pyaedt/generic/constants.py
@@ -636,7 +636,7 @@ class SolverType(object):
 
 
 class CutoutSubdesignType(object):
-    (Conformal, BoundingBox, Invalid) = range(0, 3)
+    (Conformal, BoundingBox, ConvexHull, Invalid) = range(0, 4)
 
 
 class RadiationBoxType(object):


### PR DESCRIPTION
Added new method to create cutout based on Edb only methods without using CreateCutout method. 
The method is:
- deleting all nets out of cutout
- create extent
- delete vias out of the extent
- cut polygon to extent
- delete components with less than 2 pins
