### PR TITLE
New feature to hide a list of variables

### DIFF
--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -304,6 +304,9 @@ class TestClass(BasisTest, object):
     def test_31_make_hidden_variable(self):
         self.aedtapp["my_hidden_variable"] = "15mm"
         assert self.aedtapp.hidden_variable("my_hidden_variable")
+        self.aedtapp.hidden_variable("my_hidden_variable", False)
+        assert self.aedtapp.hidden_variable(["my_oo_variable", "$dim", "my_hidden_variable"])
+        self.aedtapp.hidden_variable(["my_oo_variable", "$dim"], False)
 
     def test_32_make_read_only_variable(self):
         self.aedtapp["my_read_only_variable"] = "15mm"

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -1829,8 +1829,8 @@ class Design(AedtObjects):
 
         Parameters
         ----------
-        variable_name : str
-            Name of the variable.
+        variable_name : str or list
+            One or more variable names.
         value : bool, optional
             Whether to hide the variable. The default is ``True``, in which case the variable
             is hidden. When ``False,`` the variable is unhidden.
@@ -1853,7 +1853,29 @@ class Design(AedtObjects):
         >>> hfss.make_hidden_variable("my_hidden_leaf")
 
         """
-        self.variable_manager[variable_name].hidden = value
+        if not isinstance(variable_name, list):
+            self.variable_manager[variable_name].hidden = value
+        else:
+            design_variables = ["NAME:ChangedProps"]
+            project_variables = ["NAME:ChangedProps"]
+            for name in variable_name:
+                if name in self.variable_manager.design_variable_names:
+                    design_variables.append(["NAME:" + name, "Hidden:=", value])
+                elif name in self.variable_manager.project_variable_names:
+                    project_variables.append(["NAME:" + name, "Hidden:=", value])
+
+            if len(design_variables) > 1:
+                command = [
+                    "NAME:AllTabs",
+                    ["NAME:LocalVariableTab", ["NAME:PropServers", "LocalVariables"], design_variables],
+                ]
+                self.odesign.ChangeProperty(command)
+            if len(project_variables) > 1:
+                command = [
+                    "NAME:AllTabs",
+                    ["NAME:ProjectVariableTab", ["NAME:PropServers", "ProjectVariables"], project_variables],
+                ]
+                self.oproject.ChangeProperty(command)
         return True
 
     @pyaedt_function_handler


### PR DESCRIPTION
Close #1896 

Allow a list as an input of the "hidden_variable method". Then the method applies all the modifications at once and it is faster than doing them one by one. 
