### PR TITLE
Set default culture to work around EDB bug

### DIFF
--- a/pyaedt/__init__.py
+++ b/pyaedt/__init__.py
@@ -43,6 +43,15 @@ if os.name == "posix" and "IronPython" not in sys.version and ".NETFramework" no
         msg = "pythonnet or dotnetcore not installed. Pyaedt will work only in client mode."
         warnings.warn(msg)
 
+# work around a number formatting bug in the EDB API for non-English locales
+# described in #1980
+import clr as _clr
+
+_clr.AddReference("System.Runtime")
+from System.Globalization import CultureInfo as _CultureInfo
+
+_CultureInfo.DefaultThreadCurrentCulture = _CultureInfo.InvariantCulture
+
 from pyaedt.generic import constants
 from pyaedt.generic.general_methods import _pythonver
 from pyaedt.generic.general_methods import _retry_ntimes


### PR DESCRIPTION
If the decimal separator is the comma as in some .NET cultures (locales) then EDB operations using Value objects will interpret numbers that include the decimal separator incorrectly.  To resolve this, set the default culture to the .NET invariant culture as early as possible.

To reproduce the issue:

1. Set your system's decimal separator to the comma character
2. With PyAEDT prior to this commit, run _unittest/test_00_EDB.py::TestClass::test_50_set_padstack and note that it fails with a message that 0.0 != 0.3
3. Repeat with this commit and note that the test now passes

Fixes #1980 