### PR TITLE
In a workflow, the same identifier cannot be used more than once within the same scope.

### DIFF
--- a/.github/workflows/full_documentation.yml
+++ b/.github/workflows/full_documentation.yml
@@ -186,13 +186,6 @@ jobs:
       #     path: pyaedt-doc-flatten-json-v${{ steps.version.outputs.PYAEDT_VERSION }}.zip
       #     retention-days: 7
 
-      - name: Get Bot Application Token
-        id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v2
-        with:
-          application_id: ${{ secrets.BOT_APPLICATION_ID }}
-          application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
-
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4.4.0
         with:


### PR DESCRIPTION
That should fix the current issue with the `FullDocumentation` workflow when generating new releases.