### PR TITLE
fixed bug in X.analyze_setup(...)

### DIFF
--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -1694,7 +1694,7 @@ class Analysis(Design, object):
             update_hpc_option(target_name, "DesignType", self.design_type, True)
             if self.design_type == "Icepak":
                 use_auto_settings = False
-            update_hpc_option(target_name, "UseAutoSettings", self.design_type, use_auto_settings)
+            update_hpc_option(target_name, "UseAutoSettings", use_auto_settings, False)
 
             if settings.remote_rpc_session:
                 remote_name = (


### PR DESCRIPTION
Appears to be a copy/paste error.  Without the fix the .acf file will contain 'UseAutoSettings=<self.design_type>' e.g.  UseAutoSettings='HFSS'

With the fix the .acf file will contain UseAutoSettings=True or UseAutoSettings=False I tested import functionality through the HPC and Analysis options in the GUI. The capitalized True/False that are written to the .acf file import without error and demonstrate the expected behavior.