### PR TITLE
convert_to_microvias method added to EDB Padstack class

### DIFF
--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1690,5 +1690,5 @@ if not config["skip_edb"]:
             edbapp = Edb(target_path, edbversion=desktop_version)
             assert edbapp.core_padstack.padstacks["Padstack_Circle"].convert_to_microvias(False)
             assert edbapp.core_padstack.padstacks["Padstack_Rectangle"].convert_to_microvias(False)
-            assert edbapp.core_padstack.padstacks["Padstack_Polygon_p12"].convert_to_microvias(False, is_upside=True)
+            assert edbapp.core_padstack.padstacks["Padstack_Polygon_p12"].convert_to_microvias(False)
             edbapp.close_edb()

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1682,3 +1682,13 @@ if not config["skip_edb"]:
             loss_tan = [0.025, 0.026, 0.027, 0.028, 0.029, 0.030]
             assert edbapp.materials.add_multipole_debye_material("My_MP_Debye2", freq, rel_perm, loss_tan)
             edbapp.close_edb()
+
+        def test_128_microvias(self):
+            source_path = os.path.join(local_path, "example_models", test_subfolder, "padstacks.aedb")
+            target_path = os.path.join(self.local_scratch.path, "test_128_microvias.aedb")
+            self.local_scratch.copyfolder(source_path, target_path)
+            edbapp = Edb(target_path, edbversion=desktop_version)
+            assert edbapp.core_padstack.padstacks["Padstack_Circle"].convert_to_microvias(False)
+            assert edbapp.core_padstack.padstacks["Padstack_Rectangle"].convert_to_microvias(False)
+            assert edbapp.core_padstack.padstacks["Padstack_Polygon_p12"].convert_to_microvias(False)
+            edbapp.close_edb()

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -1690,5 +1690,5 @@ if not config["skip_edb"]:
             edbapp = Edb(target_path, edbversion=desktop_version)
             assert edbapp.core_padstack.padstacks["Padstack_Circle"].convert_to_microvias(False)
             assert edbapp.core_padstack.padstacks["Padstack_Rectangle"].convert_to_microvias(False)
-            assert edbapp.core_padstack.padstacks["Padstack_Polygon_p12"].convert_to_microvias(False)
+            assert edbapp.core_padstack.padstacks["Padstack_Polygon_p12"].convert_to_microvias(False, is_upside=True)
             edbapp.close_edb()

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -638,7 +638,7 @@ class EDBPadstack(object):
         convert_only_signal_vias : bool, optional
             Either to convert only vias belonging to signal nets or all vias. Defaults is ``True``.
         aspect_ratio : float, optional
-            Ratio between top and bottom face of trapezoid.
+            Ratio between top and bottom face of trapezoid. The default value is ``0.75``.
 
         Returns
         -------

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -655,7 +655,7 @@ class EDBPadstack(object):
             )
         if convert_only_signal_vias:
             signal_nets = [i for i in list(self._ppadstack._pedb.core_nets.signal_nets.keys())]
-        res, topl, topz, bottoml, bottomz = self._ppadstack._pedb.stackup.stackup_limits(True)
+        topl, topz, bottoml, bottomz = self._ppadstack._pedb.stackup.stackup_limits(True)
         start_elevation = layers[self.via_start_layer].elevation
 
         rad1 = self.hole_properties[0] / 2

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -630,7 +630,7 @@ class EDBPadstack(object):
         }
 
     @pyaedt_function_handler()
-    def convert_to_microvias(self, convert_only_signal_vias=True, aspect_ratio=0.75, is_upside=False):
+    def convert_to_microvias(self, convert_only_signal_vias=True, aspect_ratio=0.75):
         """Convert actual padstack instance to microvias with a given aspect ration.
 
         Parameters
@@ -639,9 +639,6 @@ class EDBPadstack(object):
             Either to convert only vias belonging to signal nets or all vias. Defaults is `True`.
         aspect_ratio : float, optional
             Ratio between top and bottom face of trapezoid.
-        is_upside : bool, optional
-            Either if Trapezioid biggest face is on bottom or top.
-            Default is `False` which have the biggest face on top.
 
         Returns
         -------
@@ -658,12 +655,14 @@ class EDBPadstack(object):
             )
         if convert_only_signal_vias:
             signal_nets = [i for i in list(self._ppadstack._pedb.core_nets.signal_nets.keys())]
+        res, topl, topz, bottoml, bottomz = self._ppadstack._pedb.stackup.stackup_limits(True)
+        start_elevation = layers[self.via_start_layer].elevation
+
         rad1 = self.hole_properties[0] / 2
         rad2 = rad1 * aspect_ratio
-        if is_upside:
+        if start_elevation < (topz + bottomz) / 2:
             rad1, rad2 = rad2, rad1
         i = 0
-
         for via in list(self.padstack_instances.values()):
             if convert_only_signal_vias and via.net_name in signal_nets or not convert_only_signal_vias:
                 pos = via.position

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -656,7 +656,7 @@ class EDBPadstack(object):
         if convert_only_signal_vias:
             signal_nets = [i for i in list(self._ppadstack._pedb.core_nets.signal_nets.keys())]
         topl, topz, bottoml, bottomz = self._ppadstack._pedb.stackup.stackup_limits(True)
-        start_elevation = layers[self.via_start_layer].elevation
+        start_elevation = layers[self.via_start_layer].lower_elevation
 
         rad1 = self.hole_properties[0] / 2
         rad2 = rad1 * aspect_ratio

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -636,7 +636,7 @@ class EDBPadstack(object):
         Parameters
         ----------
         convert_only_signal_vias : bool, optional
-            Either to convert only vias belonging to signal nets or all vias. Defaults is `True`.
+            Either to convert only vias belonging to signal nets or all vias. Defaults is ``True``.
         aspect_ratio : float, optional
             Ratio between top and bottom face of trapezoid.
 

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -698,7 +698,7 @@ class EDBPadstack(object):
                     via._edb_padstackinstance.GetNet(),
                     self._get_edb_value(pos[0]),
                     self._get_edb_value(pos[1]),
-                    self._get_edb_value(rad2 * aspect_ratio),
+                    self._get_edb_value(rad2),
                 )
                 if len(self.pad_by_layer[self.via_stop_layer].parameters) == 0:
                     self._edb.Cell.Primitive.Polygon.Create(

--- a/pyaedt/edb_core/edb_data/padstacks_data.py
+++ b/pyaedt/edb_core/edb_data/padstacks_data.py
@@ -630,13 +630,18 @@ class EDBPadstack(object):
         }
 
     @pyaedt_function_handler()
-    def convert_to_microvias(self, convert_only_signal_vias=True, aspect_ratio=0.75):
+    def convert_to_microvias(self, convert_only_signal_vias=True, aspect_ratio=0.75, is_upside=False):
         """Convert actual padstack instance to microvias with a given aspect ration.
 
         Parameters
         ----------
         convert_only_signal_vias : bool, optional
+            Either to convert only vias belonging to signal nets or all vias. Defaults is `True`.
         aspect_ratio : float, optional
+            Ratio between top and bottom face of trapezoid.
+        is_upside : bool, optional
+            Either if Trapezioid biggest face is on bottom or top.
+            Default is `False` which have the biggest face on top.
 
         Returns
         -------
@@ -653,8 +658,12 @@ class EDBPadstack(object):
             )
         if convert_only_signal_vias:
             signal_nets = [i for i in list(self._ppadstack._pedb.core_nets.signal_nets.keys())]
-        rad = self.hole_properties[0] / 2
+        rad1 = self.hole_properties[0] / 2
+        rad2 = rad1 * aspect_ratio
+        if is_upside:
+            rad1, rad2 = rad2, rad1
         i = 0
+
         for via in list(self.padstack_instances.values()):
             if convert_only_signal_vias and via.net_name in signal_nets or not convert_only_signal_vias:
                 pos = via.position
@@ -664,7 +673,7 @@ class EDBPadstack(object):
                     via._edb_padstackinstance.GetNet(),
                     self._get_edb_value(pos[0]),
                     self._get_edb_value(pos[1]),
-                    self._get_edb_value(rad),
+                    self._get_edb_value(rad1),
                 )
                 if len(self.pad_by_layer[self.via_start_layer].parameters) == 0:
                     self._edb.Cell.Primitive.Polygon.Create(
@@ -689,7 +698,7 @@ class EDBPadstack(object):
                     via._edb_padstackinstance.GetNet(),
                     self._get_edb_value(pos[0]),
                     self._get_edb_value(pos[1]),
-                    self._get_edb_value(rad * aspect_ratio),
+                    self._get_edb_value(rad2 * aspect_ratio),
                 )
                 if len(self.pad_by_layer[self.via_stop_layer].parameters) == 0:
                     self._edb.Cell.Primitive.Polygon.Create(


### PR DESCRIPTION
Edb now allows to convert viass from a padstack definition into 3d objects.