### PR TITLE
Deprecate method

### DIFF
--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -3043,7 +3043,7 @@ class Design(AedtObjects):
 
     @pyaedt_function_handler()
     def copy_design_from(self, project_fullname, design_name, save_project=True, set_active_design=True):
-        """Copy a design from a project into the active design.
+        """Copy a design from a project into the active project.
 
         Parameters
         ----------

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -888,6 +888,9 @@ class Desktop:
     def copy_design(self, project_name=None, design_name=None, target_project=None):
         """Copy a design and paste it in an existing project or new project.
 
+        .. deprecated:: 0.6.31
+           Use :func:`copy_design_from` instead.
+
         Parameters
         ----------
         project_name : str, optional
@@ -903,11 +906,11 @@ class Desktop:
         bool
             ``True`` when successful, ``False`` when failed.
         """
-        if not project_name:
+        if not project_name:  # pragma: no cover
             oproject = self.odesktop.GetActiveProject()
-        else:
+        else:  # pragma: no cover
             oproject = self.odesktop.SetActiveProject(project_name)
-        if oproject:
+        if oproject:  # pragma: no cover
             if not design_name:
                 odesign = oproject.GetActiveDesign()
             else:


### PR DESCRIPTION
Copy_design method is not tested in the unittest and there is an equivalent method 'copy_design_from'. I think we should deprecate it.