### PR TITLE
Remove useless imports to improve performance.

### DIFF
--- a/pyaedt/generic/DataHandlers.py
+++ b/pyaedt/generic/DataHandlers.py
@@ -31,12 +31,12 @@ def _tuple2dict(t, d):
     """
     k = t[0]
     v = t[1]
-    if type(v) is list and len(t) > 2:
+    if isinstance(v, list) and len(t) > 2:
         d[k] = v
-    elif type(v) is list and len(t) == 2 and not v:
+    elif isinstance(v, list) and len(t) == 2 and not v:
         d[k] = None
     elif (
-        type(v) is list and type(v[0]) is tuple and len(t) == 2
+        isinstance(v, list) and isinstance(v[0], tuple) and len(t) == 2
     ):  # len check is to avoid expanding the list with a 3rd element=None
         if k in d:
             if not isinstance(d[k], list):
@@ -59,13 +59,9 @@ def _dict2arg(d, arg_out):
 
     Parameters
     ----------
-    d :
+    d : dict
 
     arg_out :
-
-
-    Returns
-    -------
 
     """
     for k, v in d.items():

--- a/pyaedt/generic/plot.py
+++ b/pyaedt/generic/plot.py
@@ -413,16 +413,17 @@ def plot_2d_chart(plot_data, size=(2000, 1000), show_legend=True, xlabel="", yla
         `[x points, y points, label]`.
     size : tuple, optional
         Image size in pixel (width, height).
-    show_legend : bool
-        Either to show legend or not.
-    xlabel : str
-        Plot X label.
-    ylabel : str
-        Plot Y label.
-    title : str
-        Plot Title label.
-    snapshot_path : str
+    show_legend : bool, optional
+        Either to show legend or not. The default value is ``True``.
+    xlabel : str, optional
+        Plot X label. The default value is ``""``.
+    ylabel : str, optional
+        Plot Y label. The default value is ``""``.
+    title : str, optional
+        Plot Title label. The default value is ``""``.
+    snapshot_path : str, optional
         Full path to image file if a snapshot is needed.
+        The default value is ``None``.
 
     Returns
     -------

--- a/pyaedt/modules/SolveSetup.py
+++ b/pyaedt/modules/SolveSetup.py
@@ -908,22 +908,22 @@ class SetupCircuit(CommonSetup):
             userelative = 0
 
         list_data = ["NAME:ExpressionCache"]
-        if type(expression_list) is list:
+        if isinstance(expression_list, list):
             i = 0
             while i < len(expression_list):
                 expression = expression_list[i]
                 name = expression.replace("(", "_") + "1"
                 name = name.replace(")", "_")
                 name = name.replace(" ", "_")
-                if type(report_type_list) is list:
+                if isinstance(report_type_list, list):
                     report_type = report_type_list[i]
                 else:
                     report_type = report_type_list
-                if type(isconvergence_list) is list:
+                if isinstance(isconvergence_list, list):
                     isconvergence = isconvergence_list[i]
                 else:
                     isconvergence = isconvergence_list
-                if type(intrinsics_list) is list:
+                if isinstance(intrinsics_list, list):
                     intrinsics = intrinsics_list[i]
                 else:
                     intrinsics = intrinsics_list

--- a/pyaedt/rpc/rpyc_services.py
+++ b/pyaedt/rpc/rpyc_services.py
@@ -3,7 +3,6 @@ import os
 import random
 import tempfile
 import shutil
-import site
 import logging
 import signal
 import sys


### PR DESCRIPTION
By runing the following command, you can evaluate the time for imports in a python module:
`python -X importtime pyaedt_script.py`

In `rpc_services.py` the `site` import was never used.
Here is the time (in μs) required by this import.
![image](https://user-images.githubusercontent.com/87315832/209560084-a6f0682d-609b-4be2-9bea-5045be8853d8.png)
