### PR TITLE
Remove any usage of unicode and basestring.

### DIFF
--- a/pyaedt/application/AEDT_File_Management.py
+++ b/pyaedt/application/AEDT_File_Management.py
@@ -121,8 +121,8 @@ def change_objects_visibility(origfile, solid_list):
             )
             # Replacing string
             # fmt: off
-            ViewStr = u"Drawings[" + unicode(str(len(solid_list))) + u": " + unicode(str(solid_list).strip("["))
-            s = pattern.sub(r"\1" + ViewStr + r"\3", content)
+            view_str = u"Drawings[" + str(len(solid_list)) + u": " + str(solid_list).strip("[")
+            s = pattern.sub(r"\1" + view_str + r"\3", content)
             # fmt: on
             # writing file content
             n.write(str(s))
@@ -190,10 +190,8 @@ def change_model_orientation(origfile, bottom_dir):
                 r"(\$begin 'EditorWindow'\n.+?)(OrientationMatrix\(.+?\))(.+\n\s*\$end 'EditorWindow')", re.UNICODE
             )
             # Replacing string
-            OrientStr = unicode(orientation[bottom_dir])
-            # ViewStr = u"Drawings[" + unicode(str(len(SolidList))) +
-            # u": " + unicode(str(SolidList).strip("["))
-            s = pattern.sub(r"\1" + OrientStr + r"\3", content)
+            orientation_str = orientation[bottom_dir]
+            s = pattern.sub(r"\1" + orientation_str + r"\3", content)
 
             # Writing file content
             n.write(str(s))

--- a/pyaedt/modeler/Model3DLayout.py
+++ b/pyaedt/modeler/Model3DLayout.py
@@ -5,7 +5,6 @@ from warnings import warn
 from pyaedt import settings
 from pyaedt.edb import Edb
 from pyaedt.generic.constants import AEDT_UNITS
-from pyaedt.generic.general_methods import _pythonver
 from pyaedt.generic.general_methods import _retry_ntimes
 from pyaedt.generic.general_methods import generate_unique_name
 from pyaedt.generic.general_methods import get_filename_without_extension
@@ -503,7 +502,7 @@ class Modeler3DLayout(Modeler, Primitives3DLayout):
         -------
 
         """
-        if isinstance(value, str if _pythonver >= 3 else basestring):
+        if isinstance(value, str):
             return value
         else:
             return str(value) + self.model_units

--- a/pyaedt/modeler/Modeler.py
+++ b/pyaedt/modeler/Modeler.py
@@ -18,7 +18,6 @@ from collections import OrderedDict
 from pyaedt.generic.constants import AEDT_UNITS
 from pyaedt.generic.DataHandlers import _dict2arg
 from pyaedt.generic.general_methods import PropsManager
-from pyaedt.generic.general_methods import _pythonver
 from pyaedt.generic.general_methods import _retry_ntimes
 from pyaedt.generic.general_methods import generate_unique_name
 from pyaedt.generic.general_methods import pyaedt_function_handler
@@ -4528,7 +4527,7 @@ class GeometryModeler(Modeler, object):
         -------
 
         """
-        if isinstance(value, str if _pythonver >= 3 else basestring):
+        if isinstance(value, str):
             return value
         else:
             return str(value) + self.model_units


### PR DESCRIPTION
Since Python 3, all strings are unicode.
The `unicode()` function does not exist anymore.
`basestring` could be seen as a gateway to support both `unicode` and plain `str`.

Because PyAEDT is supporting Python>=3.7, there is no need to support anymore this structure for the `str`.

Fix #2206 .