### PR TITLE
Changed way non-Graphical is evaluated when Desktop is initialized

### DIFF
--- a/examples/02-SBR+/SBR_Time_Plot.py
+++ b/examples/02-SBR+/SBR_Time_Plot.py
@@ -11,7 +11,7 @@ and save it to a GIF file. This example works only on CPython.
 # Perform requried imports.
 
 import os
-from pyaedt import Hfss, examples
+from pyaedt import Hfss, downloads
 
 ###############################################################################
 # Set non-graphical mode
@@ -27,7 +27,7 @@ non_graphical = os.getenv("PYAEDT_NON_GRAPHICAL", "False").lower() in ("true", "
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Launch AEDT and load the project.
 
-project_file = examples.download_sbr_time()
+project_file = downloads.download_sbr_time()
 
 hfss = Hfss(project_file, specified_version="2022.2", non_graphical=non_graphical, new_desktop_session=True)
 

--- a/examples/07-Circuit/Touchstone_Management.py
+++ b/examples/07-Circuit/Touchstone_Management.py
@@ -13,9 +13,9 @@ This example runs only on Windows using CPython.
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 # Perform required imports and set the local path to the path for PyAEDT.
 
-from pyaedt import examples
+from pyaedt import downloads
 
-example_path = examples.download_touchstone()
+example_path = downloads.download_touchstone()
 
 ###############################################################################
 # Import libraries and Touchstone file

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -206,6 +206,7 @@ class Design(AedtObjects):
         self._mttime = None
         self._design_type = design_type
         self._desktop = main_module.oDesktop
+        settings.enable_desktop_logs = main_module.oDesktop.GetIsNonGraphical()
         self._desktop_install_dir = main_module.sDesktopinstallDirectory
         self._odesign = None
         self._oproject = None

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -547,6 +547,7 @@ class Desktop(object):
         self._main.oDesktop.RestoreWindow()
         self._main.sDesktopinstallDirectory = self._main.oDesktop.GetExeDir()
         self._main.pyaedt_initialized = True
+        settings.enable_desktop_logs = self._main.oDesktop.GetIsNonGraphical()
 
     def _set_version(self, specified_version, student_version):
         student_version_flag = False
@@ -594,8 +595,6 @@ class Desktop(object):
             oAnsoftApp = StandalonePyScriptWrapper.CreateObjectNew(non_graphical)
         else:
             oAnsoftApp = StandalonePyScriptWrapper.CreateObject(version)
-        if non_graphical:
-            settings.enable_desktop_logs = False
         self._main.oDesktop = oAnsoftApp.GetAppDesktop()
         self._main.isoutsideDesktop = True
         sys.path.append(os.path.join(base_path, "common", "commonfiles", "IronPython", "DLLs"))
@@ -654,8 +653,6 @@ class Desktop(object):
             StandalonePyScriptWrapper.CreateObjectNew(non_graphical)
         else:
             StandalonePyScriptWrapper.CreateObject(version)
-        if non_graphical:
-            settings.enable_desktop_logs = False
         processID2 = []
         if IsWindows:
             processID2 = com_active_sessions(version, student_version, non_graphical)
@@ -761,8 +758,6 @@ class Desktop(object):
             self._main.isoutsideDesktop = True
             self._main.oDesktop = self._main.oAnsoftApplication.GetAppDesktop()
             _proc = self._main.oDesktop.GetProcessID()
-            if non_graphical:
-                settings.enable_desktop_logs = False
             if new_aedt_session:
                 message = "{} {} version started with process ID {}.".format(
                     version, "Student" if student_version else "", _proc

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -1595,7 +1595,7 @@ class Settings(object):
     @property
     def enable_desktop_logs(self):
         """Get the content for the environment variable."""
-        return self._enable_desktop_logs
+        return False if self.non_graphical else self._enable_desktop_logs
 
     @enable_desktop_logs.setter
     def enable_desktop_logs(self, val):


### PR DESCRIPTION
Now settings.non_graphical is evaluated directly from AEDT API