### PR TITLE
Separate doc upload from generation into 2 stages

### DIFF
--- a/.github/workflows/nightly-docs.yml
+++ b/.github/workflows/nightly-docs.yml
@@ -43,12 +43,16 @@ jobs:
           path: doc/_build/html
           retention-days: 7
 
+  docs_upload:
+    needs: docs_build
+    runs-on: ubuntu-latest
+    steps:
+
       - name: Deploy development documentation
         uses: pyansys/actions/doc-deploy-dev@v2
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
-
 
   # docstring_testing:
   #   runs-on: Windows


### PR DESCRIPTION
My feeling is that your workflow was failing because of this. It seems to me that the artifact is not accessible since you are still on the same stage/job. Separation of docs generation and upload into two jobs/stages will potentially solve the issue