### PR TITLE
pin group bug fix

### DIFF
--- a/pyaedt/edb_core/edb_data/sources.py
+++ b/pyaedt/edb_core/edb_data/sources.py
@@ -281,10 +281,13 @@ class PinGroup(object):
 
     def _create_terminal(self, is_reference=False):
         pg_term = self._edb_pin_group.GetPinGroupTerminal()
+        edb_net = self._edb_pin_group.GetNet()
+        if edb_net.IsNull():
+            edb_net = list(self._edb_pin_group.GetPins())[0].GetNet()
         if pg_term.IsNull():
             return self._pedb.edb.Cell.Terminal.PinGroupTerminal.Create(
                 self._active_layout,
-                self._edb_pin_group.GetNet(),
+                edb_net,
                 self.name,
                 self._edb_pin_group,
                 is_reference,

--- a/pyaedt/edb_core/siwave.py
+++ b/pyaedt/edb_core/siwave.py
@@ -1220,7 +1220,7 @@ class EdbSiwave(object):
         if name:
             pos_terminal.SetName(name)
         else:
-            name = generate_unique_name("vsource")
+            name = generate_unique_name("port")
             pos_terminal.SetName(name)
         neg_pin_group_name = self.pin_groups[neg_pin_group_name]
         neg_terminal = neg_pin_group_name.create_port_terminal(impedance)


### PR DESCRIPTION
If pin group is created from SIwave GUI, it has not net object assigned to it. It leads to failure in port creation by pyaedt