### PR TITLE
Collapse navigation always

### DIFF
--- a/doc/source/_templates/sidebar-nav-bs.html
+++ b/doc/source/_templates/sidebar-nav-bs.html
@@ -1,9 +1,0 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
-  <div class="bd-toc-item active">
-    {% if pagename.startswith("API") %}
-    {{ generate_nav_html("sidebar", startdepth=1, maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}
-    {% else %}
-    {{ generate_nav_html("sidebar", maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
-    {% endif %}
-  </div>
-</nav>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -146,8 +146,6 @@ inheritance_node_attrs = dict(shape="ellipse", fontsize=14, height=0.75, color="
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-# html_theme = 'alabaster'
-
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
@@ -256,6 +254,7 @@ html_theme_options = {
         "version_match": get_version_match(__version__),
     },
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
+    "collapse_navigation": True,
 }
 
 html_static_path = ["_static"]


### PR DESCRIPTION
It is possible to turn off the expandable navigation entirely by setting the collapse_navigation config option to `True`:

```py
html_theme_options = {
  "collapse_navigation": True
}
```

This tends to help improve documentation build times.

We previously did this in `sidebar-nav-bs.html`, but that option wasn't scalable as it didn't apply to all API pages. This PR removes that file and uses the cleaner option given by [pydata-sphinx-theme - Navigation](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/navigation.html).
