### PR TITLE
Fix failing tests

### DIFF
--- a/_unittest/test_21_Circuit.py
+++ b/_unittest/test_21_Circuit.py
@@ -98,7 +98,7 @@ class TestClass(BasisTest, object):
         assert LNA_setup.name == "LNA"
 
     def test_06b_add_3dlayout_component(self):
-        setup = self.aedtapp.create_setup("LNA")
+        setup = self.aedtapp.create_setup("test_06b_LNA")
         setup.add_sweep_step(start_point=0, end_point=5, step_size=0.01)
         myedb = self.aedtapp.modeler.schematic.add_subcircuit_3dlayout("Galileo_G87173_204")
         assert type(myedb.id) is int
@@ -125,10 +125,11 @@ class TestClass(BasisTest, object):
         assert type(my_model) is int
 
     def test_07a_push_excitation(self):
-        setup = self.aedtapp.create_setup("LNA")
+        setup_name = "test_07a_LNA"
+        setup = self.aedtapp.create_setup(setup_name)
         setup.add_sweep_step(start_point=0, end_point=5, step_size=0.01)
-        assert self.aedtapp.push_excitations(instance_name="U1", setup_name="LNA", thevenin_calculation=False)
-        assert self.aedtapp.push_excitations(instance_name="U1", setup_name="LNA", thevenin_calculation=True)
+        assert self.aedtapp.push_excitations(instance_name="U1", setup_name=setup_name, thevenin_calculation=False)
+        assert self.aedtapp.push_excitations(instance_name="U1", setup_name=setup_name, thevenin_calculation=True)
 
     def test_08_import_mentor_netlist(self):
         self.aedtapp.insert_design("MentorSchematicImport")

--- a/_unittest/test_21_Circuit.py
+++ b/_unittest/test_21_Circuit.py
@@ -98,6 +98,8 @@ class TestClass(BasisTest, object):
         assert LNA_setup.name == "LNA"
 
     def test_06b_add_3dlayout_component(self):
+        setup = self.aedtapp.create_setup("LNA")
+        setup.add_sweep_step(start_point=0, end_point=5, step_size=0.01)
         myedb = self.aedtapp.modeler.schematic.add_subcircuit_3dlayout("Galileo_G87173_204")
         assert type(myedb.id) is int
         ports = myedb.pins
@@ -123,6 +125,8 @@ class TestClass(BasisTest, object):
         assert type(my_model) is int
 
     def test_07a_push_excitation(self):
+        setup = self.aedtapp.create_setup("LNA")
+        setup.add_sweep_step(start_point=0, end_point=5, step_size=0.01)
         assert self.aedtapp.push_excitations(instance_name="U1", setup_name="LNA", thevenin_calculation=False)
         assert self.aedtapp.push_excitations(instance_name="U1", setup_name="LNA", thevenin_calculation=True)
 

--- a/pyaedt/generic/general_methods.py
+++ b/pyaedt/generic/general_methods.py
@@ -922,14 +922,22 @@ def com_active_sessions(version=None, student_version=False, non_graphical=False
         keys = ["ansysedtsv.exe"]
     else:
         keys = ["ansysedt.exe"]
+    long_version = None
+    if len(version) > 6:
+        version = version[-6:]
     if version and "." in version:
+        long_version = version
         version = version[-4:].replace(".", "")
-    if version < "222":
+    if version < "221":
         version = version[:2] + "." + version[2]
+        long_version = "20{}".format(version)
     sessions = []
     for p in psutil.process_iter():
         try:
             if p.name() in keys:
+                if long_version and _check_installed_version(os.path.dirname(p.exe()), long_version):
+                    sessions.append(p.pid)
+                    continue
                 cmd = p.cmdline()
                 if non_graphical and "-ng" in cmd or not non_graphical:
                     if not version or (version and version in cmd[0]):
@@ -1391,6 +1399,34 @@ def _dim_arg(value, units):
         return str(val) + units
     except:
         return value
+
+
+@pyaedt_function_handler()
+def _check_installed_version(install_path, long_version):
+    """Check installation folder to determine if it is for specified Ansys EM version.
+
+    Parameters
+    ----------
+    install_path: str
+        Installation folder to check.  For example, ``"C:\\Program Files\\AnsysEM\\v231\\Win64"``.
+    long_version: str
+        Long form of version number.  For example, ``"2023.1"``.
+
+    Returns
+    -------
+    bool
+
+    """
+    product_list_path = os.path.join(install_path, "config", "ProductList.txt")
+    if os.path.isfile(product_list_path):
+        try:
+            with open(product_list_path, "r") as f:
+                install_version = f.readline().strip()[-6:]
+                if install_version == long_version:
+                    return True
+        except:
+            pass
+    return False
 
 
 class Settings(object):


### PR DESCRIPTION
Two tests in test_21_Circuit.py were failing:

- test_06b_add_3dlayout_component appears to expect a linear network analysis setup to exist by way of referencing self.aedtapp.nominal_adaptive but none exists
- test_07a_push_excitations appears to expect a linear network analysis named LNA to exist but none exists

Fixes #2460 