### PR TITLE
Fixed bad return value when a single variable name used and evaluate_expression is called

### DIFF
--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -3474,7 +3474,7 @@ class Design(AedtObjects):
         """
         # Set the value of an internal reserved design variable to the specified string
         if expression_string in self._variable_manager.variables:
-            return self._variable_manager.variables[expression_string]
+            return self._variable_manager.variables[expression_string].value
         else:
             try:
                 self._variable_manager.set_variable(


### PR DESCRIPTION
This error occurs when `_segment_array()` -> `value_in_object_units()` -> `evaluate_expression()` are called when creating an Angular Arc with a single variable name for one of the points. It does not get evaluated by `pyaedt_evaluator`, and instead of returning the variable value as the `else` branch of the if statement does, returns the `Vairable` instance. 

This results in an error `'my_z_valuemeter' is not a defined variable name in this context`

```
points = [[0,2,"my_z_value"],[0,0,"my_z_value"]]
arcline = app.modeler.create_polyline([points[0]],segment_type=PolylineSegment(type="AngularArc", arc_center=points[1], arc_angle="90deg", arc_plane="XY"))
```



