### PR TITLE
allow adding both faces and objects to the same BoundaryObject

### DIFF
--- a/pyaedt/modules/Boundary.py
+++ b/pyaedt/modules/Boundary.py
@@ -661,6 +661,9 @@ class BoundaryObject(BoundaryCommon, object):
             ``True`` when successful, ``False`` when failed.
 
         """
+
+        out = ["Name:" + self.name]
+
         if "Faces" in self.props:
             faces = self.props["Faces"]
             faces_out = []
@@ -671,18 +674,22 @@ class BoundaryObject(BoundaryCommon, object):
                     faces_out.append(f.id)
                 else:
                     faces_out.append(f)
-            self._app.oboundary.ReassignBoundary(["Name:" + self.name, "Faces:=", faces_out])
-        elif "Objects" in self.props:
+            out += [ "Faces:=", faces_out]
+
+        if "Objects" in self.props:
             pr = []
             for el in self.props["Objects"]:
                 try:
                     pr.append(self._app.modeler[el].name)
                 except (KeyError, AttributeError):
                     pass
+            out += ["Objects:=", pr]
 
-            self._app.oboundary.ReassignBoundary(["Name:" + self.name, "Objects:=", pr])
-        else:
+        if len(out) == 1:
             return False
+
+        self._app.oboundary.ReassignBoundary(out)
+
         return True
 
 

--- a/pyaedt/modules/Boundary.py
+++ b/pyaedt/modules/Boundary.py
@@ -674,7 +674,7 @@ class BoundaryObject(BoundaryCommon, object):
                     faces_out.append(f.id)
                 else:
                     faces_out.append(f)
-            out += [ "Faces:=", faces_out]
+            out += ["Faces:=", faces_out]
 
         if "Objects" in self.props:
             pr = []


### PR DESCRIPTION
Logic previously would only assign `Faces` array to `BoundaryObject`, even if `Objects` array contained items. It is possible to assign both in the UI. This fixes `update_assignment()` to allow both `Objects` and `Faces` to be assigned to the same `BoundaryObject`