### PR TITLE
2023 R1 COM Fallback

### DIFF
--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -435,7 +435,7 @@ class Desktop(object):
             if "oDesktop" in dir(self._main):
                 del self._main.oDesktop
             self._main.student_version, version_key, version = self._set_version(specified_version, student_version)
-            if not new_desktop_session:
+            if not new_desktop_session:  # pragma: no cover
                 sessions = active_sessions(
                     version=version_key, student_version=student_version, non_graphical=non_graphical
                 )
@@ -691,7 +691,7 @@ class Desktop(object):
         student_version,
         version_key,
         aedt_process_id=None,
-    ):
+    ):  # pragma: no cover
         import pythoncom
 
         from pyaedt.generic.clr_module import _clr
@@ -807,7 +807,7 @@ class Desktop(object):
                             "Multiple AEDT gRPC sessions are found. Setting the active session on port %s", self.port
                         )
                 else:
-                    if os.name != "posix":
+                    if os.name != "posix":  # pragma: no cover
                         if com_active_sessions(
                             version=version, student_version=student_version, non_graphical=non_graphical
                         ):

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -83,7 +83,7 @@ def _find_free_port(port_start=40001, port_end=55000):
     s = socket.socket()
     for port in list_ports:
         try:
-            s.connect((socket.getfqdn(), port))
+            s.connect(("localhost", port))
         except socket.error:
             return port
         else:

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -69,7 +69,7 @@ def _check_grpc_port(port, machine_name=""):
     s = socket.socket()
     try:
         if not machine_name:
-            machine_name = "localhost"
+            machine_name = "127.0.0.1"
         s.connect((machine_name, port))
     except socket.error:
         return False
@@ -83,7 +83,7 @@ def _find_free_port(port_start=40001, port_end=55000):
     s = socket.socket()
     for port in list_ports:
         try:
-            s.connect(("localhost", port))
+            s.connect(("127.0.0.1", port))
         except socket.error:
             return port
         else:
@@ -112,6 +112,12 @@ def exception_to_desktop(ex_value, tb_data):  # pragma: no cover
 
 
 def _delete_objects():
+    settings._non_graphical = False
+    settings._aedt_version = None
+    settings.remote_api = False
+    settings._use_grpc_api = None
+    settings.machine = ""
+    settings.port = 0
     module = sys.modules["__main__"]
     try:
         del module.COMUtil


### PR DESCRIPTION
Starting from 2023.1 Pyaedt uses GRPC as default connection method to AEDT. Anyway user can still use COM and now it's possible to fallback to active COM session in case no GRPC sessions are found and new_aedt_session is set to False.
