### PR TITLE
Replace all os.name checks with is_windows, is_linux booleans

### DIFF
--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -19,6 +19,7 @@ from pyaedt import Hfss3dLayout
 from pyaedt.application.aedt_objects import AedtObjects
 from pyaedt.application.design_solutions import model_names
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt.generic.general_methods import is_linux
 from pyaedt.generic.general_methods import settings
 
 test_subfolder = "T01"
@@ -244,7 +245,7 @@ class TestClass(BasisTest, object):
         props = self.aedtapp.get_components3d_vars("Dipole_Antenna_DM")
         assert len(props) == 3
 
-    @pytest.mark.skipif(os.name == "posix", reason="Not needed in Linux.")
+    @pytest.mark.skipif(is_linux, reason="Not needed in Linux.")
     def test_21_generate_temp_project_directory(self):
         proj_dir1 = self.aedtapp.generate_temp_project_directory("Example")
         assert os.path.exists(proj_dir1)

--- a/_unittest/test_21_Circuit.py
+++ b/_unittest/test_21_Circuit.py
@@ -7,6 +7,7 @@ from _unittest.conftest import local_path
 
 from pyaedt import Circuit  # Setup paths for module imports
 from pyaedt import is_ironpython
+from pyaedt import is_linux
 
 try:
     import pytest  # noqa: F401
@@ -231,7 +232,7 @@ class TestClass(BasisTest, object):
         ]
         assert LNA_setup.update()
 
-    @pytest.mark.skipif(os.name == "posix", reason="To be investigated on linux.")
+    @pytest.mark.skipif(is_linux, reason="To be investigated on linux.")
     def test_18_export_touchstone(self):
         assert self.aedtapp.analyze("Dom_LNA")
         time.sleep(30)

--- a/_unittest/test_28_Maxwell3D.py
+++ b/_unittest/test_28_Maxwell3D.py
@@ -11,6 +11,7 @@ from _unittest.conftest import local_path
 from pyaedt import Maxwell3d
 from pyaedt.generic.constants import SOLUTIONS
 from pyaedt.generic.general_methods import generate_unique_name
+from pyaedt.generic.general_methods import is_linux
 
 try:
     import pytest
@@ -355,7 +356,7 @@ class TestClass(BasisTest, object):
         assert int(udp_from_python.bounding_dimension[0]) == 22.0
         assert int(udp_from_python.bounding_dimension[1]) == 22.0
 
-    @pytest.mark.skipif(os.name == "posix", reason="Feature not supported in Linux")
+    @pytest.mark.skipif(is_linux, reason="Feature not supported in Linux")
     def test_27_create_udm(self):
         my_udmPairs = []
         mypair = ["ILD Thickness (ILD)", "0.006mm"]

--- a/_unittest/test_41_3dlayout_modeler.py
+++ b/_unittest/test_41_3dlayout_modeler.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     import _unittest_ironpython.conf_unittest as pytest  # noqa: F401
 
+from pyaedt.generic.general_methods import is_linux
+
 test_subfolder = "T41"
 # Input Data and version for the test
 test_project_name = "Test_RadioBoard"
@@ -494,7 +496,7 @@ class TestClass(BasisTest, object):
         assert os.path.exists(self.aedtapp.export_profile("RFBoardSetup3"))
         assert os.path.exists(self.aedtapp.export_mesh_stats("RFBoardSetup3"))
 
-    @pytest.mark.skipif(os.name == "posix", reason="To be investigated on linux.")
+    @pytest.mark.skipif(is_linux, reason="To be investigated on linux.")
     def test_19C_export_touchsthone(self):
         filename = os.path.join(self.aedtapp.working_directory, "touchstone.s2p")
         solution_name = "RFBoardSetup3"
@@ -614,7 +616,7 @@ class TestClass(BasisTest, object):
         output = self.aedtapp.export_3d_model()
         assert os.path.exists(output)
 
-    @pytest.mark.skipif(os.name == "posix", reason="Failing on linux")
+    @pytest.mark.skipif(is_linux, reason="Failing on linux")
     def test_36_import_gerber(self):
         gerber_file = self.local_scratch.copyfile(
             os.path.join(local_path, "example_models", "cad", "Gerber", "gerber1.zip")
@@ -659,7 +661,7 @@ class TestClass(BasisTest, object):
         assert p2.name == "poly_test_41_void"
         assert not self.aedtapp.modeler.create_polygon_void("Top", points2, "another_object", name="poly_43_void")
 
-    @pytest.mark.skipif(os.name == "posix", reason="Bug on linux")
+    @pytest.mark.skipif(is_linux, reason="Bug on linux")
     def test_90_set_differential_pairs(self):
         assert self.hfss3dl.set_differential_pair(
             positive_terminal="Port3",
@@ -673,7 +675,7 @@ class TestClass(BasisTest, object):
         )
         assert self.hfss3dl.set_differential_pair(positive_terminal="Port3", negative_terminal="Port5")
 
-    @pytest.mark.skipif(os.name == "posix", reason="Bug on linux")
+    @pytest.mark.skipif(is_linux, reason="Bug on linux")
     def test_91_load_and_save_diff_pair_file(self):
         diff_def_file = os.path.join(local_path, "example_models", test_subfolder, "differential_pairs_definition.txt")
         diff_file = self.local_scratch.copyfile(diff_def_file)

--- a/_unittest_ironpython/run_unittests.py
+++ b/_unittest_ironpython/run_unittests.py
@@ -18,8 +18,9 @@ if os.path.exists(os.path.join(tempfile.gettempdir(), "test.log")):
 settings.logger_file_path = log_path
 
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt.generic.general_methods import is_windows
 
-if os.name != "posix":
+if is_windows:
     ansysem_install_dir = os.environ.get("ANSYSEM_INSTALL_DIR", "")
     if not ansysem_install_dir:
         ansysem_install_dir = os.environ["ANSYSEM_ROOT222"]

--- a/_unittest_ironpython/test_26_emit.py
+++ b/_unittest_ironpython/test_26_emit.py
@@ -1,7 +1,8 @@
 from conf_unittest import test_generator, PytestMockup
+from pyaedt.generic.general_methods import is_windows
 import os
 
-if os.name != "posix":
+if is_windows:
     test_filter = "test_"
 
     test_name = os.path.basename(__file__).replace(".py", "")

--- a/_unittest_ironpython/test_34_TwinBuilder.py
+++ b/_unittest_ironpython/test_34_TwinBuilder.py
@@ -1,7 +1,8 @@
 from conf_unittest import test_generator, PytestMockup
+from pyaedt.generic.general_methods import is_windows
 import os
 
-if os.name != "posix":
+if is_windows:
     test_filter = "test_"
 
     test_name = os.path.basename(__file__).replace(".py", "")

--- a/_unittest_ironpython/test_35_MaxwellCircuit.py
+++ b/_unittest_ironpython/test_35_MaxwellCircuit.py
@@ -1,7 +1,8 @@
 from conf_unittest import test_generator, PytestMockup
+from pyaedt.generic.general_methods import is_windows
 import os
 
-if os.name != "posix":
+if is_windows:
     test_filter = "test_"
 
     test_name = os.path.basename(__file__).replace(".py", "")

--- a/pyaedt/application/Analysis.py
+++ b/pyaedt/application/Analysis.py
@@ -15,6 +15,8 @@ import time
 import warnings
 
 from pyaedt import is_ironpython
+from pyaedt import is_linux
+from pyaedt import is_windows
 from pyaedt import settings
 from pyaedt.application.Design import Design
 from pyaedt.application.JobManager import update_hpc_option
@@ -45,7 +47,7 @@ from pyaedt.modules.SolveSetup import SetupMaxwell
 from pyaedt.modules.SolveSetup import SetupSBR
 from pyaedt.modules.SolveSweeps import SetupProps
 
-if os.name == "posix" and is_ironpython:
+if is_linux and is_ironpython:
     import subprocessdotnet as subprocess
 else:
     import subprocess
@@ -1877,7 +1879,7 @@ class Analysis(Design, object):
         if os.path.exists(queue_file_completed):
             os.unlink(queue_file_completed)
 
-        if os.name == "posix" and settings.use_lsf_scheduler:
+        if is_linux and settings.use_lsf_scheduler:
             options = [
                 "-ng",
                 "-BatchSolve",
@@ -1902,9 +1904,9 @@ class Analysis(Design, object):
                     design_name, "Nominal" if setup_name in self.setup_names else "Optimetrics", setup_name
                 )
             )
-        if os.name == "posix" and not settings.use_lsf_scheduler:
+        if is_linux and not settings.use_lsf_scheduler:
             batch_run = [inst_dir + "/ansysedt"]
-        elif os.name == "posix" and settings.use_lsf_scheduler:  # pragma: no cover
+        elif is_linux and settings.use_lsf_scheduler:  # pragma: no cover
             if settings.lsf_queue:
                 batch_run = [
                     "bsub",
@@ -1938,7 +1940,7 @@ class Analysis(Design, object):
         dont have old .asol files etc
         """
         self.logger.info("Solving model in batch mode on " + machine)
-        if run_in_thread and os.name != "posix":
+        if run_in_thread and is_windows:
             DETACHED_PROCESS = 0x00000008
             subprocess.Popen(batch_run, creationflags=DETACHED_PROCESS)
             self.logger.info("Batch job launched.")

--- a/pyaedt/application/Design.py
+++ b/pyaedt/application/Design.py
@@ -46,6 +46,7 @@ from pyaedt.generic.general_methods import check_and_download_file
 from pyaedt.generic.general_methods import generate_unique_name
 from pyaedt.generic.general_methods import is_ironpython
 from pyaedt.generic.general_methods import is_project_locked
+from pyaedt.generic.general_methods import is_windows
 from pyaedt.generic.general_methods import open_file
 from pyaedt.generic.general_methods import pyaedt_function_handler
 from pyaedt.generic.general_methods import read_csv
@@ -2901,12 +2902,12 @@ class Design(AedtObjects):
             try:
                 self.set_active_design(fallback_design)
             except:
-                if os.name != "posix":
+                if is_windows:
                     self._init_variables()
                 self._odesign = None
                 return False
         else:
-            if os.name != "posix":
+            if is_windows:
                 self._init_variables()
             self._odesign = None
         return True

--- a/pyaedt/desktop.py
+++ b/pyaedt/desktop.py
@@ -24,18 +24,15 @@ import traceback
 import warnings
 
 from pyaedt import is_ironpython
+from pyaedt import is_linux
+from pyaedt import is_windows
 from pyaedt import pyaedt_logger
 
-if os.name == "nt":
-    IsWindows = True
-else:
-    IsWindows = False
+if is_linux:
     os.environ["ANS_NODEPCHECK"] = str(1)
 
-if not IsWindows and is_ironpython:
+if is_linux and is_ironpython:
     import subprocessdotnet as subprocess
-
-
 else:
     import subprocess
 
@@ -58,7 +55,7 @@ modules = [tup[1] for tup in pkgutil.iter_modules()]
 
 if is_ironpython:
     _com = "ironpython"
-elif IsWindows and "pythonnet" in modules:  # pragma: no cover
+elif is_windows and "pythonnet" in modules:  # pragma: no cover
     _com = "pythonnet_v3"
 else:
     _com = "gprc_v3"
@@ -752,7 +749,7 @@ class Desktop(object):
 
         from pyaedt.generic.clr_module import _clr
 
-        if os.name == "posix":
+        if is_linux:
             raise Exception(
                 "PyAEDT supports COM initialization in Windows only. To use in Linux, upgrade to AEDT 2022 R2 or later."
             )
@@ -768,7 +765,7 @@ class Desktop(object):
         StandalonePyScriptWrapper = AnsoftCOMUtil.Ansoft.CoreCOMScripting.COM.StandalonePyScriptWrapper
         self.logger.info("Launching AEDT with module PythonNET.")
         processID = []
-        if IsWindows:
+        if is_windows:
             processID = com_active_sessions(version, student_version, non_graphical)
         if student_version and not processID:  # Opens an instance if processID is an empty list
             self._run_student()
@@ -778,7 +775,7 @@ class Desktop(object):
         else:
             StandalonePyScriptWrapper.CreateObject(version)
         processID2 = []
-        if IsWindows:
+        if is_windows:
             processID2 = com_active_sessions(version, student_version, non_graphical)
         proc = [i for i in processID2 if i not in processID]  # Looking for the "new" process
         if (
@@ -816,7 +813,7 @@ class Desktop(object):
         base_path = self._main.sDesktopinstallDirectory
         sys.path.insert(0, base_path)
         sys.path.insert(0, os.path.join(base_path, "PythonFiles", "DesktopPlugin"))
-        if os.name == "posix":
+        if is_linux:
             if os.environ.get("LD_LIBRARY_PATH"):
                 os.environ["LD_LIBRARY_PATH"] = (
                     os.path.join(base_path, "defer") + os.pathsep + os.environ["LD_LIBRARY_PATH"]
@@ -863,7 +860,7 @@ class Desktop(object):
                             "Multiple AEDT gRPC sessions are found. Setting the active session on port %s", self.port
                         )
                 else:
-                    if os.name != "posix":  # pragma: no cover
+                    if is_windows:  # pragma: no cover
                         if com_active_sessions(
                             version=version, student_version=student_version, non_graphical=non_graphical
                         ):
@@ -886,7 +883,7 @@ class Desktop(object):
             self.logger.info("AEDT session is starting on gRPC port %s", self.port)
             new_aedt_session = True
 
-        if new_aedt_session and settings.use_lsf_scheduler and os.name == "posix":  # pragma: no cover
+        if new_aedt_session and settings.use_lsf_scheduler and is_linux:  # pragma: no cover
             out, self.machine = launch_aedt_in_lsf(non_graphical, self.port)
             if out:
                 ScriptEnv._doInitialize(version, None, False, non_graphical, self.machine, self.port)

--- a/pyaedt/downloads.py
+++ b/pyaedt/downloads.py
@@ -6,6 +6,7 @@ import tempfile
 import zipfile
 
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt.generic.general_methods import is_linux
 from pyaedt.generic.general_methods import settings
 from pyaedt.misc import list_installed_ansysem
 
@@ -48,7 +49,7 @@ def _retrieve_file(url, filename, directory, destination=None):
     if not os.path.isdir(destination_dir):
         os.makedirs(destination_dir)
     # Perform download
-    if os.name == "posix":
+    if is_linux:
         command = "wget {} -O {}".format(url, local_path)
         os.system(command)
     elif is_ironpython:

--- a/pyaedt/edb.py
+++ b/pyaedt/edb.py
@@ -50,11 +50,13 @@ from pyaedt.generic.general_methods import env_value
 from pyaedt.generic.general_methods import generate_unique_name
 from pyaedt.generic.general_methods import inside_desktop
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt.generic.general_methods import is_linux
+from pyaedt.generic.general_methods import is_windows
 from pyaedt.generic.general_methods import pyaedt_function_handler
 from pyaedt.generic.process import SiwaveSolve
 from pyaedt.misc.misc import list_installed_ansysem
 
-if os.name == "posix" and is_ironpython:
+if is_linux and is_ironpython:
     import subprocessdotnet as subprocess
 else:
     import subprocess
@@ -152,7 +154,7 @@ class Edb(object):
             self.isreadonly = isreadonly
             self.cellname = cellname
             if not edbpath:
-                if os.name != "posix":
+                if is_windows:
                     edbpath = os.getenv("USERPROFILE")
                     if not edbpath:
                         edbpath = os.path.expanduser("~")
@@ -293,7 +295,7 @@ class Edb(object):
     @pyaedt_function_handler()
     def _init_dlls(self):
         """Initialize DLLs."""
-        if os.name == "posix":
+        if is_linux:
             if env_value(self.edbversion) in os.environ or settings.edb_dll_path:
                 if settings.edb_dll_path:
                     self.base_path = settings.edb_dll_path
@@ -549,7 +551,7 @@ class Edb(object):
             command = anstranslator_full_path
         else:
             command = os.path.join(self.base_path, "anstranslator")
-            if os.name != "posix":
+            if is_windows:
                 command += ".exe"
 
         if not working_dir:
@@ -563,7 +565,7 @@ class Edb(object):
         if not use_ppe:
             cmd_translator.append("-ppe=false")
         if control_file and input_file[-3:] not in ["brd"]:
-            if os.name == "posix":
+            if is_linux:
                 cmd_translator.append("-c={}".format(control_file))
             else:
                 cmd_translator.append('-c="{}"'.format(control_file))

--- a/pyaedt/generic/clr_module.py
+++ b/pyaedt/generic/clr_module.py
@@ -6,7 +6,9 @@ import warnings
 modules = [tup[1] for tup in pkgutil.iter_modules()]
 pyaedt_path = os.path.dirname(os.path.dirname(__file__))
 cpython = "IronPython" not in sys.version and ".NETFramework" not in sys.version
-if os.name == "posix" and cpython:  # pragma: no cover
+is_linux = os.name == "posix"
+is_windows = not is_linux
+if is_linux and cpython:  # pragma: no cover
     try:
         if os.environ.get("DOTNET_ROOT") is None:
             try:
@@ -53,7 +55,7 @@ try:  # work around a number formatting bug in the EDB API for non-English local
     edb_initialized = True
 
 except ImportError:  # pragma: no cover
-    if os.name != "posix":
+    if is_windows:
         warnings.warn(
             "The clr is missing. Install PythonNET or use an IronPython version if you want to use the EDB module."
         )

--- a/pyaedt/generic/process.py
+++ b/pyaedt/generic/process.py
@@ -1,9 +1,10 @@
 import os.path
 
 from pyaedt import is_ironpython
+from pyaedt import is_linux
 from pyaedt.generic.general_methods import env_path
 
-if os.name == "posix" and is_ironpython:
+if is_linux and is_ironpython:
     import subprocessdotnet as subprocess
 else:
     import subprocess
@@ -26,7 +27,7 @@ class SiwaveSolve(object):
             executable = "siwave_ng"
         else:
             executable = "siwave"
-        if os.name == "posix":
+        if is_linux:
             self._exe = os.path.join(self.installer_path, executable)
         else:
             self._exe = os.path.join(self.installer_path, executable + ".exe")
@@ -74,7 +75,7 @@ class SiwaveSolve(object):
     def solve(self):
         # supporting non graphical solve only
         if self.nongraphical:
-            if os.name == "posix":
+            if is_linux:
                 exe_path = os.path.join(self.installer_path, "siwave_ng")
             else:
                 exe_path = os.path.join(self.installer_path, "siwave_ng.exe")
@@ -146,7 +147,7 @@ class SiwaveSolve(object):
             f.write("oDoc.ScrExport3DModel('{}', q3d_filename)\n".format(format_3d))
             f.write("oDoc.ScrCloseProject()\n")
             f.write("oApp.Quit()\n")
-        if os.name == "posix":
+        if is_linux:
             _exe = '"' + os.path.join(self.installer_path, "siwave") + '"'
         else:
             _exe = '"' + os.path.join(self.installer_path, "siwave.exe") + '"'
@@ -266,7 +267,7 @@ class SiwaveSolve(object):
             f.write("proj.ScrCloseProject()\n")
 
             f.write("oApp.Quit()\n")
-        if os.name == "posix":
+        if is_linux:
             _exe = '"' + os.path.join(self.installer_path, "siwave") + '"'
         else:
             _exe = '"' + os.path.join(self.installer_path, "siwave.exe") + '"'

--- a/pyaedt/generic/toolkit.py
+++ b/pyaedt/generic/toolkit.py
@@ -77,12 +77,13 @@ from zipfile import ZIP_DEFLATED
 from zipfile import ZipFile
 
 from pyaedt import is_ironpython
+from pyaedt import is_linux
 from pyaedt.desktop import Desktop
 import pyaedt.edb_core.edb_data.simulation_configuration
 from pyaedt.generic.clr_module import _clr
 from pyaedt.generic.general_methods import pyaedt_function_handler
 
-if os.name == "posix" and is_ironpython:
+if is_linux and is_ironpython:
     import subprocessdotnet as subprocess
 else:
     import subprocess

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -9,9 +9,10 @@ import os
 import warnings
 
 from pyaedt import is_ironpython
+from pyaedt import is_linux
 from pyaedt.modules.SetupTemplates import SetupKeys
 
-if os.name == "posix" and is_ironpython:
+if is_linux and is_ironpython:
     import subprocessdotnet as subprocess
 else:
     import subprocess

--- a/pyaedt/misc/Console.py_build
+++ b/pyaedt/misc/Console.py_build
@@ -11,7 +11,8 @@ interactive Python session.
 """
 import os
 import sys
-if os.name == "posix":
+is_linux = os.name == "posix"
+if is_linux:
     import subprocessdotnet as subprocess
 else:
     import subprocess
@@ -24,7 +25,7 @@ def main():
     pyaedt_toolkit_dir = os.path.normpath(os.path.join(current_dir, r"##TOOLKIT_REL_LIB_DIR##"))
     python_exe = r"##IPYTHON_EXE##" % version
     pyaedt_script = os.path.join(pyaedt_toolkit_dir, "console_setup.py")
-    if os.name == "posix":
+    if is_linux:
         term = get_linux_terminal()
         if not term:
             oDesktop.AddMessage("", "", 2, "No Terminals found.")

--- a/pyaedt/misc/Jupyter.py_build
+++ b/pyaedt/misc/Jupyter.py_build
@@ -9,7 +9,8 @@ directory and launches it.
 import os
 import random
 import string
-if os.name == "posix":
+is_linux = os.name == "posix"
+if is_linux:
     import subprocessdotnet as subprocess
 else:
     import subprocess
@@ -40,7 +41,7 @@ with open(template, "r") as source:
                 "AEDTVERSION", oDesktop.GetVersion()[:6]
             )
             t.write(line)
-if os.name == "posix":
+if is_linux:
     command = ["{}".format(jupyter_exe), "lab", "{}".format(target)]
 else:
     command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target)]

--- a/pyaedt/misc/Run_PyAEDT_Script.py_build
+++ b/pyaedt/misc/Run_PyAEDT_Script.py_build
@@ -13,7 +13,8 @@ was launched as well as the AEDT instance that has them open.
 
 """
 import os
-if os.name == "posix":
+is_linux = os.name == "posix"
+if is_linux:
     import subprocessdotnet as subprocess
     import clr
     clr.AddReference("System.Windows.Forms")

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -15,7 +15,8 @@ pyaedt_path = os.path.normpath(
 )
 sys.path.append(os.path.normpath(os.path.join(pyaedt_path, "..")))
 
-
+is_linux = os.name == "posix"
+is_windows = not is_linux
 pid = 0
 
 
@@ -30,7 +31,7 @@ def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False
         if os.path.exists(pers1):
             d.logger.info("PersonalLib already mapped")
         else:
-            if is_windows():
+            if is_windows:
                 os.system('mklink /D "{}" "{}"'.format(pers1, pyaedt_path))
             else:
                 os.system('ln -s "{}" "{}"'.format(pyaedt_path, pers1))
@@ -157,17 +158,9 @@ def write_pretty_xml(root, file_path):
 
 
 def exe():
-    if is_windows():
+    if is_windows:
         return ".exe"
     return ""
-
-
-def is_windows():
-    return not is_linux()
-
-
-def is_linux():
-    return os.name == "posix"
 
 
 if __name__ == "__main__":

--- a/pyaedt/misc/console_setup.py
+++ b/pyaedt/misc/console_setup.py
@@ -25,6 +25,7 @@ except ImportError:
 pyaedt.settings.use_grpc_api = False
 from pyaedt import Desktop
 from pyaedt.generic.general_methods import active_sessions
+from pyaedt.generic.general_methods import is_windows
 
 aedt_process_id = int(sys.argv[1])
 version = sys.argv[2]
@@ -75,7 +76,7 @@ if port:
         close_on_exit=False,
         student_version=student_version,
     )
-elif os.name != "posix":
+elif is_windows:
     desktop = Desktop(
         specified_version=version,
         aedt_process_id=aedt_process_id,

--- a/pyaedt/modeler/cad/components_3d.py
+++ b/pyaedt/modeler/cad/components_3d.py
@@ -784,6 +784,7 @@ class UserDefinedComponent(object):
             Pyaedt object.
         """
         from pyaedt.generic.design_types import get_pyaedt_app
+        from pyaedt.generic.general_methods import is_linux
 
         project_list = [i for i in self._primitives._app.project_list]
 
@@ -800,9 +801,7 @@ class UserDefinedComponent(object):
             self._primitives._app.odesktop.SetActiveProject(new_project[0])
             project = self._primitives._app.odesktop.GetActiveProject()
             project_name = project.GetName()
-            import os
-
-            if os.name == "posix":
+            if is_linux:
                 design_name = project.GetDesigns()[0].GetName()
             else:
                 design_name = project.GetActiveDesign().GetName()

--- a/pyaedt/rpc/rpyc_services.py
+++ b/pyaedt/rpc/rpyc_services.py
@@ -12,8 +12,10 @@ from pyaedt import generate_unique_name
 from pyaedt.generic.general_methods import env_path
 
 from pyaedt import is_ironpython
+from pyaedt import is_linux
+from pyaedt import is_windows
 
-if os.name == "posix" and is_ironpython:
+if is_linux and is_ironpython:
     import subprocessdotnet as subprocess
 else:
     import subprocess
@@ -221,7 +223,7 @@ class PyaedtServiceWindows(rpyc.Service):
         # code that runs after the connection has already closed
         # (to finalize the service, if needed)
         if self.app:
-            if not os.name == "posix":
+            if not is_linux:
                 if self.app and "release_desktop" in dir(self.app[0]):
                     self.app[0].release_desktop()
 
@@ -266,7 +268,7 @@ class PyaedtServiceWindows(rpyc.Service):
         else:
             return "File wrong or wrong commands."
         executable = "ansysedt.exe"
-        if os.name == "posix" and not ansysem_path and not env_path(aedt_version):
+        if is_linux and not ansysem_path and not env_path(aedt_version):
             ansysem_path = os.getenv("PYAEDT_SERVER_AEDT_PATH", "")
         if env_path(aedt_version) or ansysem_path:
             if not ansysem_path:
@@ -836,7 +838,7 @@ class GlobalService(rpyc.Service):
     def on_disconnect(self, connection):
         # code that runs after the connection has already closed
         # (to finalize the service, if needed)
-        if os.name != "posix":
+        if is_windows:
             sys.stdout = sys.__stdout__
 
     @staticmethod
@@ -871,7 +873,7 @@ class GlobalService(rpyc.Service):
             print("AEDT Session already opened on port {}.".format(port))
             return True
         ansysem_path = os.getenv("PYAEDT_SERVER_AEDT_PATH", "")
-        if os.name == "posix":
+        if is_linux:
             executable = "ansysedt"
         else:
             executable = "ansysedt.exe"
@@ -1026,7 +1028,7 @@ class ServiceManager(rpyc.Service):
     def on_disconnect(self, connection):
         # code that runs after the connection has already closed
         # (to finalize the service, if needed)
-        if os.name != "posix":
+        if is_windows:
             sys.stdout = sys.__stdout__
         for edb in self._edb:
             try:

--- a/pyaedt/siwave.py
+++ b/pyaedt/siwave.py
@@ -15,6 +15,7 @@ import time
 from pyaedt.generic.clr_module import _clr
 from pyaedt.generic.general_methods import _pythonver
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt.generic.general_methods import is_windows
 from pyaedt.generic.general_methods import pyaedt_function_handler
 from pyaedt.misc import list_installed_ansysem
 
@@ -61,7 +62,7 @@ class Siwave(object):
         if is_ironpython:
             _com = "pythonnet"
             import System
-        elif os.name == "nt":  # pragma: no cover
+        elif is_windows:  # pragma: no cover
             modules = [tup[1] for tup in pkgutil.iter_modules()]
             if _clr:
                 import win32com.client


### PR DESCRIPTION
Request #2688 

The [PR](https://github.com/pyansys/pyaedt/pull/2670/files) #2670 introduced `is_windows` and `is_linux` booleans. 
We can replace all `os.name == "posix"`, `os.name != "posix"`, `os.name == "nt"`, `os.name != "nt"` with the booleans