### PR TITLE
Toolkits don't show up on Linux and 23.1 or before. 

### DIFF
--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -37,6 +37,21 @@ def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False
                 os.system('ln -s "{}" "{}"'.format(pyaedt_path, pers1))
 
         toolkits = ["Project"]
+        # Bug on Linux 23.1 and before where Project level toolkits don't show up. Thus copying to individual design
+        # toolkits.
+        if is_linux and aedt_version <= "2023.1":
+            toolkits = [
+                "2DExtractor",
+                "CircuitDesign",
+                "HFSS",
+                "HFSS-IE",
+                "HFSS3DLayoutDesign",
+                "Icepak",
+                "Maxwell2D",
+                "Maxwell3D",
+                "Q3DExtractor",
+                "Mechanical",
+            ]
 
         for product in toolkits:
             if use_sys_lib:
@@ -63,6 +78,14 @@ def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False
 def install_toolkit(toolkit_dir, product, aedt_version):
     tool_dir = os.path.join(toolkit_dir, product, "PyAEDT")
     lib_dir = os.path.join(tool_dir, "Lib")
+    toolkit_rel_lib_dir = os.path.relpath(lib_dir, tool_dir)
+    # Bug on Linux 23.1 and before where Project level toolkits don't show up. Thus copying to individual design
+    # toolkits.
+    if is_linux and aedt_version <= "2023.1":
+        toolkit_rel_lib_dir = os.path.join("Lib", "PyAEDT")
+        lib_dir = os.path.join(toolkit_dir, toolkit_rel_lib_dir)
+        toolkit_rel_lib_dir = "../../" + toolkit_rel_lib_dir
+        tool_dir = os.path.join(toolkit_dir, product, "PyAEDT")
     os.makedirs(lib_dir, exist_ok=True)
     os.makedirs(tool_dir, exist_ok=True)
     files_to_copy = ["Console", "Run_PyAEDT_Script", "Jupyter"]
@@ -83,7 +106,7 @@ def install_toolkit(toolkit_dir, product, aedt_version):
                 print("Building to " + os.path.join(tool_dir, file_name_dest))
                 build_file_data = build_file.read()
                 build_file_data = (
-                    build_file_data.replace("##TOOLKIT_REL_LIB_DIR##", os.path.relpath(lib_dir, tool_dir))
+                    build_file_data.replace("##TOOLKIT_REL_LIB_DIR##", toolkit_rel_lib_dir)
                     .replace("##PYTHON_EXE##", executable_version_agnostic)
                     .replace("##IPYTHON_EXE##", ipython_executable)
                     .replace("##JUPYTER_EXE##", jupyter_executable)


### PR DESCRIPTION
Bug on Linux 23.1 and before where Project level toolkits don't show up. Thus copying to individual design toolkits.

![image](https://user-images.githubusercontent.com/83788850/227015347-4970c916-ab81-443c-830b-57c4d51615dd.png)
