### PR TITLE
Replace all remaining os.name checks with is_windows, is_linux booleans Ref: #2689

### DIFF
--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -31,6 +31,7 @@ from pyaedt import settings
 from pyaedt.generic.general_methods import generate_unique_name
 from pyaedt.generic.general_methods import inside_desktop
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt.generic.general_methods import is_windows
 
 settings.enable_error_handler = False
 settings.enable_desktop_logs = False
@@ -218,10 +219,10 @@ def desktop_init():
     #         # release_desktop(close_projects=False, close_desktop=True)
     #     except:
     #         pass
-    if os.name != "posix" or is_ironpython:
+    if is_windows or is_ironpython:
         desktop = Desktop(desktop_version, settings.non_graphical, new_thread)
     yield
-    if os.name != "posix" or is_ironpython:
+    if is_windows or is_ironpython:
         desktop.release_desktop(True, True)
         del desktop
 

--- a/_unittest/test_02_2D_modeler.py
+++ b/_unittest/test_02_2D_modeler.py
@@ -6,6 +6,7 @@ import sys
 from _unittest.conftest import BasisTest
 
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt.generic.general_methods import is_linux
 from pyaedt.generic.general_methods import isclose
 from pyaedt.maxwell import Maxwell2d
 
@@ -132,7 +133,7 @@ class TestClass(BasisTest, object):
         assert pg2.material_name == "copper"
         assert isclose(pg2.faces[0].area, 5.196152422706631)
 
-    @pytest.mark.skipif(os.name == "posix" or sys.version_info < (3, 8), reason="Not running in ironpython")
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="Not running in ironpython")
     def test_09_plot(self):
         self.aedtapp.modeler.create_regular_polygon([0, 0, 0], [0, 0, 2])
         self.aedtapp.modeler.create_regular_polygon(

--- a/_unittest/test_12_PostProcessing.py
+++ b/_unittest/test_12_PostProcessing.py
@@ -14,6 +14,7 @@ from pyaedt import Q3d
 from pyaedt import settings
 from pyaedt.generic.DataHandlers import json_to_dict
 from pyaedt.generic.general_methods import is_ironpython
+from pyaedt.generic.general_methods import is_linux
 from pyaedt.generic.plot import _parse_aedtplt
 from pyaedt.generic.plot import _parse_streamline
 
@@ -104,7 +105,7 @@ class TestClass(BasisTest, object):
         assert len(self.aedtapp.setups[0].sweeps[0].frequencies) > 0
         assert isinstance(self.aedtapp.setups[0].sweeps[0].basis_frequencies, list)
 
-    @pytest.mark.skipif(os.name == "posix" or sys.version_info < (3, 8), reason="Not running in ironpython")
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="Not running in ironpython")
     def test_01_Animate_plt(self):
         cutlist = ["Global:XY"]
         phases = [str(i * 5) + "deg" for i in range(2)]
@@ -646,7 +647,7 @@ class TestClass(BasisTest, object):
         path = self.aedtapp.post.export_model_picture()
         assert path
 
-    @pytest.mark.skipif(os.name == "posix" or sys.version_info < (3, 8), reason="Not running in ironpython")
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="Not running in ironpython")
     def test_14_Field_Ploton_cutplanedesignname(self):
         cutlist = ["Global:XY"]
         setup_name = self.aedtapp.existing_analysis_sweeps[0]
@@ -681,7 +682,7 @@ class TestClass(BasisTest, object):
         plot_obj.plot(plot_obj.image_file)
         assert os.path.exists(plot_obj.image_file)
 
-    @pytest.mark.skipif(os.name == "posix" or sys.version_info < (3, 8), reason="Not running in ironpython")
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="Not running in ironpython")
     def test_14B_Field_Ploton_Vector(self):
         cutlist = ["Global:XY"]
         setup_name = self.aedtapp.existing_analysis_sweeps[0]
@@ -706,14 +707,14 @@ class TestClass(BasisTest, object):
         )
         assert os.path.exists(plot_obj.image_file)
 
-    @pytest.mark.skipif(os.name == "posix" or sys.version_info < (3, 8), reason="Not running in ironpython")
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="Not running in ironpython")
     def test_15_export_plot(self):
         obj = self.aedtapp.post.plot_model_obj(
             show=False, export_path=os.path.join(self.local_scratch.path, "image.jpg")
         )
         assert os.path.exists(obj.image_file)
 
-    @pytest.mark.skipif(os.name == "posix" or sys.version_info < (3, 8), reason="Not running in ironpython")
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="Not running in ironpython")
     def test_16_create_field_plot(self):
         cutlist = ["Global:XY"]
         plot = self.aedtapp.post._create_fieldplot(
@@ -859,7 +860,7 @@ class TestClass(BasisTest, object):
         assert len(app2.post.field_plots) == len(self.aedtapp.post.field_plots)
 
     @pytest.mark.skipif(
-        os.name == "posix" or sys.version_info < (3, 8), reason="plot_scene method is not supported in ironpython"
+        is_linux or sys.version_info < (3, 8), reason="plot_scene method is not supported in ironpython"
     )
     def test_55_time_plot(self):
         self.sbr_test.analyze(self.sbr_test.active_setup, use_auto_settings=False)
@@ -1059,9 +1060,7 @@ class TestClass(BasisTest, object):
             os.path.join(local_path, "example_models", "report_json", "Modal_Report.json")
         )
 
-    @pytest.mark.skipif(
-        os.name == "posix" or sys.version_info < (3, 8), reason="FarFieldSolution not supported by Ironpython"
-    )
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="FarFieldSolution not supported by Ironpython")
     def test_71_antenna_plot(self):
         ffdata = self.field_test.get_antenna_ffd_solution_data(frequencies=30e9, sphere_name="3D")
         ffdata.phase_offset = [0, 90, 0, 90]
@@ -1111,9 +1110,7 @@ class TestClass(BasisTest, object):
         )
         assert os.path.exists(os.path.join(self.local_scratch.path, "3d2.jpg"))
 
-    @pytest.mark.skipif(
-        os.name == "posix" or sys.version_info < (3, 8), reason="FarFieldSolution not supported by Ironpython"
-    )
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="FarFieldSolution not supported by Ironpython")
     def test_72_antenna_plot(self):
         ffdata = self.array_test.get_antenna_ffd_solution_data(frequencies=3.5e9, sphere_name="3D")
         ffdata.frequency = 3.5e9

--- a/_unittest/test_17_SBR.py
+++ b/_unittest/test_17_SBR.py
@@ -7,6 +7,7 @@ from _unittest.conftest import local_path
 
 from pyaedt import Hfss
 from pyaedt import is_ironpython
+from pyaedt import is_linux
 
 try:
     import pytest  # noqa: F401
@@ -185,7 +186,7 @@ class TestClass(BasisTest, object):
         for part in parts_dict["parts"]:
             assert os.path.exists(parts_dict["parts"][part]["file_name"])
 
-    @pytest.mark.skipif(os.name == "posix" or sys.version_info < (3, 8), reason="Not supported.")
+    @pytest.mark.skipif(is_linux or sys.version_info < (3, 8), reason="Not supported.")
     def test_13_link_array(self):
         self.array.setups[0].props["MaximumPasses"] = 1
         assert self.sbr_platform.create_sbr_linked_antenna(self.array, target_cs="antenna_CS", fieldtype="farfield")
@@ -243,7 +244,7 @@ class TestClass(BasisTest, object):
         assert vrt.update()
         assert vrt.delete()
 
-    @pytest.mark.skipif(os.name == "posix" or is_ironpython, reason="feature supported in Cpython")
+    @pytest.mark.skipif(is_linux or is_ironpython, reason="feature supported in Cpython")
     def test_16_read_hdm(self):
         self.aedtapp.insert_design("hdm")
         hdm_path = os.path.join(local_path, "example_models", test_subfolder, "freighter_rays.hdm")

--- a/_unittest/test_22_Circuit_DynamicLink.py
+++ b/_unittest/test_22_Circuit_DynamicLink.py
@@ -10,6 +10,7 @@ from pyaedt import Circuit
 from pyaedt import Hfss
 from pyaedt import Q2d
 from pyaedt import Q3d
+from pyaedt.generic.general_methods import is_linux
 
 try:
     import pytest
@@ -94,9 +95,7 @@ class TestClass(BasisTest, object):
         assert hfss_comp.id == 87
         assert hfss_comp.composed_name == "CompInst@uUSB;87;3"
 
-    @pytest.mark.skipif(
-        config.get("skip_circuits", False) or os.name == "posix", reason="Skipped because Desktop is crashing"
-    )
+    @pytest.mark.skipif(config.get("skip_circuits", False) or is_linux, reason="Skipped because Desktop is crashing")
     def test_04_refresh_dynamic_link(self):
         assert self.aedtapp.modeler.schematic.refresh_dynamic_link("uUSB")
 
@@ -209,7 +208,7 @@ class TestClass(BasisTest, object):
         LNA_setup.props["SweepDefinition"]["Data"] = " ".join(sweep_list)
         assert LNA_setup.update()
 
-    @pytest.mark.skipif(os.name == "posix", reason="Skipped because Desktop is crashing")
+    @pytest.mark.skipif(is_linux, reason="Skipped because Desktop is crashing")
     def test_10_q3d_link(self):
         self.aedtapp.insert_design("test_link")
         q2d = Q2d(self.q3d, specified_version=desktop_version)
@@ -239,7 +238,7 @@ class TestClass(BasisTest, object):
             hfss, solution_name="Setup2 : Sweep", tline_port="1"
         )
 
-    @pytest.mark.skipif(os.name == "posix", reason="Skipped because Desktop is crashing")
+    @pytest.mark.skipif(is_linux, reason="Skipped because Desktop is crashing")
     def test_11_siwave_link(self):
         model = os.path.join(local_path, "example_models", test_subfloder, "Galileo_um.siw")
         model_out = self.local_scratch.copyfile(model)
@@ -250,9 +249,7 @@ class TestClass(BasisTest, object):
         assert siw_comp
         assert len(siw_comp.pins) == 2
 
-    @pytest.mark.skipif(
-        config.get("skip_circuits", False) or os.name == "posix", reason="Skipped because Desktop is crashing"
-    )
+    @pytest.mark.skipif(config.get("skip_circuits", False) or is_linux, reason="Skipped because Desktop is crashing")
     def test_12_create_interface_port(self):
         page_port = self.aedtapp.modeler.components.create_page_port(name="Port12", location=[0, -0.50])
         interface_port = self.aedtapp.modeler.components.create_interface_port(name="Port12", location=[0.3, -0.50])

--- a/_unittest/test_26_emit.py
+++ b/_unittest/test_26_emit.py
@@ -9,6 +9,7 @@ from _unittest.conftest import is_ironpython
 from pyaedt import Emit
 from pyaedt.emit_core import EmitConstants as econsts
 from pyaedt.generic import constants as consts
+from pyaedt.generic.general_methods import is_linux
 from pyaedt.modeler.circuits.PrimitivesEmit import EmitAntennaComponent
 from pyaedt.modeler.circuits.PrimitivesEmit import EmitComponent
 from pyaedt.modeler.circuits.PrimitivesEmit import EmitComponents
@@ -21,7 +22,7 @@ except ImportError:
 test_subfolder = "T26"
 
 
-@pytest.mark.skipif(os.name == "posix", reason="Emit API fails on linux.")
+@pytest.mark.skipif(is_linux, reason="Emit API fails on linux.")
 class TestClass(BasisTest, object):
     def setup_class(self):
         BasisTest.my_setup(self)

--- a/_unittest/test_32_RMxprt.py
+++ b/_unittest/test_32_RMxprt.py
@@ -3,6 +3,7 @@ import os
 from _unittest.conftest import BasisTest
 
 from pyaedt import Rmxprt
+from pyaedt.generic.general_methods import is_linux
 
 try:
     import pytest
@@ -11,7 +12,7 @@ except ImportError:
 test_project_name = "motor"
 
 
-@pytest.mark.skipif(os.name == "posix", reason="Emit API fails on linux.")
+@pytest.mark.skipif(is_linux, reason="Emit API fails on linux.")
 class TestClass(BasisTest, object):
     def setup_class(self):
         BasisTest.my_setup(self)

--- a/_unittest/test_34_TwinBuilder.py
+++ b/_unittest/test_34_TwinBuilder.py
@@ -5,6 +5,7 @@ from _unittest.conftest import BasisTest
 from _unittest.conftest import local_path
 
 from pyaedt import TwinBuilder
+from pyaedt.generic.general_methods import is_linux
 
 try:
     import pytest
@@ -13,7 +14,7 @@ except ImportError:
 test_subfolder = "T21"
 
 
-@pytest.mark.skipif(os.name == "posix", reason="Emit API fails on linux.")
+@pytest.mark.skipif(is_linux, reason="Emit API fails on linux.")
 class TestClass(BasisTest, object):
     def setup_class(self):
         project_name = "TwinBuilderProject"

--- a/pyaedt/misc/Run_PyAEDT_Script.py_build
+++ b/pyaedt/misc/Run_PyAEDT_Script.py_build
@@ -48,7 +48,7 @@ try:
         print("python.exe: " + python_exe)
         pyaedt_script = file_dialog.FileName
         print("pyaedt_script: " + str(pyaedt_script))
-        if os.name =="posix":
+        if is_linux:
             command = [
                 python_exe,
                 pyaedt_script,


### PR DESCRIPTION
Request #2688 

The [PR](https://github.com/pyansys/pyaedt/pull/2670/files) #2670 introduced `is_windows` and `is_linux` booleans. 
We can replace all `os.name == "posix"`, `os.name != "posix"`, `os.name == "nt"`, `os.name != "nt"` with the booleans