### PR TITLE
Graceful checks and Error dialogs if Toolkit files are missing.

### DIFF
--- a/pyaedt/misc/Console.py_build
+++ b/pyaedt/misc/Console.py_build
@@ -11,7 +11,13 @@ interactive Python session.
 """
 import os
 import sys
+
+from System.Windows.Forms import MessageBox
+from System.Windows.Forms import MessageBoxButtons
+from System.Windows.Forms import MessageBoxIcon
+
 is_linux = os.name == "posix"
+
 if is_linux:
     import subprocessdotnet as subprocess
 else:
@@ -25,11 +31,12 @@ def main():
     pyaedt_toolkit_dir = os.path.normpath(os.path.join(current_dir, r"##TOOLKIT_REL_LIB_DIR##"))
     python_exe = r"##IPYTHON_EXE##" % version
     pyaedt_script = os.path.join(pyaedt_toolkit_dir, "console_setup.py")
+    check_file(python_exe)
+    check_file(pyaedt_script)
     if is_linux:
         term = get_linux_terminal()
         if not term:
-            oDesktop.AddMessage("", "", 2, "No Terminals found.")
-            sys.exit()
+            show_error("No Terminals found.")
         edt_root = os.path.normpath(oDesktop.GetExeDir())
         os.environ["ANSYSEM_ROOT{}".format(version)] = edt_root
         ld_library_path_dirs_to_add = [
@@ -42,14 +49,14 @@ def main():
         os.environ["LD_LIBRARY_PATH"] = ":".join(ld_library_path_dirs_to_add) + ":" + os.getenv("LD_LIBRARY_PATH", "")
 
         command = [
-                term,
-                "-e",
-                '{}'.format(python_exe),
-                "-i",
-                '{}'.format(pyaedt_script),
-                str(oDesktop.GetProcessID()),
-                str(oDesktop.GetVersion()[:6]),
-                       ]
+            term,
+            "-e",
+            "{}".format(python_exe),
+            "-i",
+            "{}".format(pyaedt_script),
+            str(oDesktop.GetProcessID()),
+            str(oDesktop.GetVersion()[:6]),
+        ]
     else:
         command = [
             '"{}"'.format(python_exe),
@@ -57,12 +64,12 @@ def main():
             '"{}"'.format(pyaedt_script),
             str(oDesktop.GetProcessID()),
             str(oDesktop.GetVersion()[:6]),
-                   ]
+        ]
     subprocess.Popen(" ".join(command))
 
 
 def get_linux_terminal():
-    for terminal in ['x-terminal-emulator', 'konsole', 'xterm', 'gnome-terminal', 'lxterminal', 'mlterm']:
+    for terminal in ["x-terminal-emulator", "konsole", "xterm", "gnome-terminal", "lxterminal", "mlterm"]:
         term = which(terminal)
         if term:
             return term
@@ -86,6 +93,19 @@ def which(program):
                 return exe_file
 
     return None
+
+
+def check_file(file_path):
+    if not os.path.isfile(file_path):
+        show_error(
+            '"{}" does not exist. Please run the "Install PyAEDT" button in the Automation ribbon.'.format(file_path)
+        )
+
+
+def show_error(msg):
+    oDesktop.AddMessage("", "", 2, str(msg))
+    MessageBox.Show(str(msg), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error)
+    sys.exit()
 
 
 if __name__ == "__main__":

--- a/pyaedt/misc/Console.py_build
+++ b/pyaedt/misc/Console.py_build
@@ -98,7 +98,7 @@ def which(program):
 def check_file(file_path):
     if not os.path.isfile(file_path):
         show_error(
-            '"{}" does not exist. Please run the "Install PyAEDT" button in the Automation ribbon.'.format(file_path)
+            '"{}" does not exist. Please click on the "Install PyAEDT" button in the Automation ribbon.'.format(file_path)
         )
 
 

--- a/pyaedt/misc/Jupyter.py_build
+++ b/pyaedt/misc/Jupyter.py_build
@@ -9,11 +9,47 @@ directory and launches it.
 import os
 import random
 import string
+import sys
+
+from System.Windows.Forms import MessageBox
+from System.Windows.Forms import MessageBoxButtons
+from System.Windows.Forms import MessageBoxIcon
+
 is_linux = os.name == "posix"
+
 if is_linux:
     import subprocessdotnet as subprocess
 else:
     import subprocess
+
+
+def main():
+    # Launch file
+    proj_dir = oDesktop.GetProjectDirectory()
+    os.chdir(proj_dir)
+
+    version = oDesktop.GetVersion()[2:6].replace(".", "")
+    current_dir = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
+    pyaedt_toolkit_dir = os.path.normpath(os.path.join(current_dir, r"##TOOLKIT_REL_LIB_DIR##"))
+    jupyter_exe = r"##JUPYTER_EXE##" % version
+    template = os.path.join(pyaedt_toolkit_dir, "jupyter_template.ipynb")
+    target = os.path.join(proj_dir, generate_unique_name("pyaedt", ".ipynb", n=3))
+    check_file(jupyter_exe)
+    check_file(template)
+
+    with open(template, "r") as source:
+        with open(target, "w") as t:
+            for line in source:
+                line = line.replace("PROCESSID", str(oDesktop.GetProcessID())).replace(
+                    "AEDTVERSION", oDesktop.GetVersion()[:6]
+                )
+                t.write(line)
+    if is_linux:
+        command = ["{}".format(jupyter_exe), "lab", "{}".format(target)]
+    else:
+        command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target)]
+
+    subprocess.Popen(" ".join(command))
 
 
 def generate_unique_name(rootname, suffix="", n=6):
@@ -24,26 +60,18 @@ def generate_unique_name(rootname, suffix="", n=6):
     return unique_name
 
 
-# Launch file
-proj_dir = oDesktop.GetProjectDirectory()
-os.chdir(proj_dir)
+def check_file(file_path):
+    if not os.path.isfile(file_path):
+        show_error(
+            '"{}" does not exist. Please run the "Install PyAEDT" button in the Automation ribbon.'.format(file_path)
+        )
 
-version = oDesktop.GetVersion()[2:6].replace(".", "")
-current_dir = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
-pyaedt_toolkit_dir = os.path.normpath(os.path.join(current_dir, r"##TOOLKIT_REL_LIB_DIR##"))
-jupyter_exe = r"##JUPYTER_EXE##" % version
-template = os.path.join(pyaedt_toolkit_dir, "jupyter_template.ipynb")
-target = os.path.join(proj_dir, generate_unique_name("pyaedt", ".ipynb", n=3))
-with open(template, "r") as source:
-    with open(target, "w") as t:
-        for line in source:
-            line = line.replace("PROCESSID", str(oDesktop.GetProcessID())).replace(
-                "AEDTVERSION", oDesktop.GetVersion()[:6]
-            )
-            t.write(line)
-if is_linux:
-    command = ["{}".format(jupyter_exe), "lab", "{}".format(target)]
-else:
-    command = ['"{}"'.format(jupyter_exe), "lab", '"{}"'.format(target)]
 
-subprocess.Popen(" ".join(command))
+def show_error(msg):
+    oDesktop.AddMessage("", "", 2, str(msg))
+    MessageBox.Show(str(msg), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error)
+    sys.exit()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyaedt/misc/Run_PyAEDT_Script.py_build
+++ b/pyaedt/misc/Run_PyAEDT_Script.py_build
@@ -13,59 +13,83 @@ was launched as well as the AEDT instance that has them open.
 
 """
 import os
-is_linux = os.name == "posix"
-if is_linux:
-    import subprocessdotnet as subprocess
-    import clr
-    clr.AddReference("System.Windows.Forms")
-else:
-    import subprocess
-import ScriptEnv
+import sys
 
-
+from System.Windows.Forms import MessageBox
+from System.Windows.Forms import MessageBoxButtons
+from System.Windows.Forms import MessageBoxIcon
 from System.Windows.Forms import OpenFileDialog
 
-oProject = oDesktop.GetActiveProject()
-oDesign = oProject.GetActiveDesign()
+is_linux = os.name == "posix"
+script_name = os.path.splitext(os.path.basename(__file__))[0]
 
-# Choose file to launch
-file_dialog = OpenFileDialog()
-file_dialog.InitialDirectory = oProject.GetPath()
-file_dialog.Filter = "python files(*.py)|*.py"
-ret = file_dialog.ShowDialog()
-print("ret: " + repr(ret))
+if is_linux:
+    import subprocessdotnet as subprocess
+else:
+    import subprocess
 
-try:
-    if ret == ret.OK:
-        # launch file
-        version = oDesktop.GetVersion()[2:6].replace(".", "")
-        current_dir = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
-        pyaedt_toolkit_dir = os.path.normpath(os.path.join(current_dir, r"##TOOLKIT_REL_LIB_DIR##"))
-        config_file = open(
-            os.path.join(pyaedt_toolkit_dir, "python_interpreter.bat"), "r"
-        )  # will fail with a file not found error if it isn't here
-        python_exe = r"##PYTHON_EXE##" % version
-        print("python.exe: " + python_exe)
-        pyaedt_script = file_dialog.FileName
-        print("pyaedt_script: " + str(pyaedt_script))
-        if is_linux:
-            command = [
-                python_exe,
-                pyaedt_script,
-                str(oDesktop.GetProcessID()),
-                str(oDesktop.GetVersion()[:6]),
-            ]
+
+def main():
+    oProject = oDesktop.GetActiveProject()
+
+    # Choose file to launch
+    file_dialog = OpenFileDialog()
+    file_dialog.InitialDirectory = oProject.GetPath()
+    file_dialog.Filter = "python files (*.py)|*.py"
+    ret = file_dialog.ShowDialog()
+    debug("ret: " + repr(ret))
+
+    try:
+        if ret == ret.OK:
+            # launch file
+            version = oDesktop.GetVersion()[2:6].replace(".", "")
+            current_dir = os.path.dirname(os.path.abspath(os.path.realpath(__file__)))
+            pyaedt_toolkit_dir = os.path.normpath(os.path.join(current_dir, r"##TOOLKIT_REL_LIB_DIR##"))
+            config_file = open(
+                os.path.join(pyaedt_toolkit_dir, "python_interpreter.bat"), "r"
+            )  # will fail with a file not found error if it isn't here
+            python_exe = r"##PYTHON_EXE##" % version
+            pyaedt_script = file_dialog.FileName
+            check_file(python_exe)
+            check_file(pyaedt_script)
+            if is_linux:
+                command = [
+                    python_exe,
+                    pyaedt_script,
+                    str(oDesktop.GetProcessID()),
+                    str(oDesktop.GetVersion()[:6]),
+                ]
+            else:
+                command = [
+                    '""'.format(python_exe),
+                    '""'.format(pyaedt_script),
+                    str(oDesktop.GetProcessID()),
+                    str(oDesktop.GetVersion()[:6]),
+                ]
+            subprocess.Popen(command)
         else:
-            command = [
-                '""'.format(python_exe),
-                '""'.format(pyaedt_script),
-                str(oDesktop.GetProcessID()),
-                str(oDesktop.GetVersion()[:6]),
-            ]
-        subprocess.Popen(command)
-    else:
-        # exit()
-        print("ret didn't pass the equivalence")
-        print("ret:" + repr(ret))
-except Exception as e:
-    print(str(e))
+            debug("ret didn't pass the equivalence. ret:" + repr(ret))
+    except Exception as e:
+        show_error(str(e))
+
+
+def check_file(file_path):
+    if not os.path.isfile(file_path):
+        show_error(
+            '"{}" does not exist. Please run the "Install PyAEDT" button in the Automation ribbon.'.format(file_path)
+        )
+
+
+def show_error(msg):
+    oDesktop.AddMessage("", "", 2, str(msg))
+    MessageBox.Show(str(msg), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error)
+    sys.exit()
+
+
+def debug(msg):
+    print(script_name + ": " + str(msg))
+    LogDebug(script_name + ": " + str(msg) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Graceful checks and Error dialogs if Toolkit files are missing.

Useful when a user Installs PyAEDT through one version of AEDT and then runs a different version of AEDT. In this case the virtual env. would not have been created for the second AEDT version.

The error message displayed will be `"<file_path>" does not exist. Please run the "Install PyAEDT" button in the Automation ribbon.`

![PyAEDT Toolkit - Graceful checks](https://user-images.githubusercontent.com/83788850/227588183-6f24cc85-ed0e-4b25-8867-23ac25cd48cd.gif)
