### PR TITLE
Fixed teardown for IronPython unit tests

### DIFF
--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -122,20 +122,20 @@ class BasisTest(object):
                 edbapp.close_edb()
             except:
                 pass
-        if self.desktop:
+        if self.desktop and not is_ironpython:
             try:
                 os.kill(self._main.desktop_pid, 9)
             except:
                 pass
             self.desktop.release_desktop(False, True)
+            try:
+                del self._main.desktop_pid
+            except:
+                pass
 
         del self.edbapps
         del self.aedtapps
         self.desktop = None
-        try:
-            del self._main.desktop_pid
-        except:
-            pass
         try:
             logger.remove_all_project_file_logger()
             shutil.rmtree(self.local_scratch.path, ignore_errors=True)

--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -132,7 +132,12 @@ class BasisTest(object):
                 del self._main.desktop_pid
             except:
                 pass
-
+        elif self.desktop:
+            for proj in self.desktop.project_list:
+                try:
+                    self.desktop.odesktop.CloseProject(proj)
+                except:
+                    pass
         del self.edbapps
         del self.aedtapps
         self.desktop = None

--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -133,11 +133,18 @@ class BasisTest(object):
             except:
                 pass
         elif self.desktop:
-            if self.desktop.project_list:
-                proj_list = [i for i in self.desktop.project_list]
+            try:
+                oDesktop = self._main.oDesktop
+                proj_list = oDesktop.GetProjectList()
+            except Exception as e:
+                oDesktop = None
+                proj_list = []
+            if oDesktop and not settings.non_graphical:
+                oDesktop.ClearMessages("", "", 3)
+            if proj_list:
                 for proj in proj_list:
                     try:
-                        self.desktop.odesktop.CloseProject(proj)
+                        oDesktop.CloseProject(proj)
                     except:
                         pass
         del self.edbapps

--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -134,7 +134,8 @@ class BasisTest(object):
                 pass
         elif self.desktop:
             if self.desktop.project_list:
-                for proj in self.desktop.project_list:
+                proj_list = [i for i in self.desktop.project_list]
+                for proj in proj_list:
                     try:
                         self.desktop.odesktop.CloseProject(proj)
                     except:

--- a/_unittest/conftest.py
+++ b/_unittest/conftest.py
@@ -133,11 +133,12 @@ class BasisTest(object):
             except:
                 pass
         elif self.desktop:
-            for proj in self.desktop.project_list:
-                try:
-                    self.desktop.odesktop.CloseProject(proj)
-                except:
-                    pass
+            if self.desktop.project_list:
+                for proj in self.desktop.project_list:
+                    try:
+                        self.desktop.odesktop.CloseProject(proj)
+                    except:
+                        pass
         del self.edbapps
         del self.aedtapps
         self.desktop = None

--- a/pyaedt/generic/filesystem.py
+++ b/pyaedt/generic/filesystem.py
@@ -97,7 +97,7 @@ class Scratch:
             except OSError:  # pragma: no cover
                 pass
         try:
-            dst_file = shutil.copy2(src_file, dst_file)
+            shutil.copy2(src_file, dst_file)
         except shutil.SameFileError:  # pragma: no cover
             pass
 


### PR DESCRIPTION
All IronPython unit tests are not running (they are practically jumped over) due to a bug in teardown method. 