### PR TITLE
Padstack instances were not deleted in delete_nets name because of wrong check

### DIFF
--- a/pyaedt/edb_core/padstack.py
+++ b/pyaedt/edb_core/padstack.py
@@ -347,7 +347,7 @@ class EdbPadstacks(object):
             net_names = [net_names]
 
         for p_id, p in self.instances.items():
-            if p.name in net_names:
+            if p.net_name in net_names:
                 if not p.delete():  # pragma: no cover
                     return False
         return True


### PR DESCRIPTION
#2734 