### PR TITLE
Replace methods get/set_notes() by 'notes' property for emit revision.

### DIFF
--- a/pyaedt/emit_core/results/results.py
+++ b/pyaedt/emit_core/results/results.py
@@ -148,8 +148,8 @@ class Results:
         Parameters
         ----------
         revision_name : str
-            Revision to load. If revision_name = None, the
-            latest revision will be returned.
+            Revision to load. The default is  ``None`` in which
+            case the latest revision will be returned.
 
         Returns
         -------
@@ -186,10 +186,7 @@ class Results:
     def analyze(self):
         """
         Analyze the current revision or create a new revision if
-         the design has changed.
-
-        Parameters
-        ----------
+        the design has changed.
 
         Returns
         -------

--- a/pyaedt/emit_core/results/revision.py
+++ b/pyaedt/emit_core/results/revision.py
@@ -309,46 +309,22 @@ class Revision:
             self.result_mode_error()
         return freqs
 
-    @pyaedt_function_handler
-    def set_notes(self, notes):
+    @property
+    def notes(self):
         """
         Add notes to the revision.
 
-        Parameters
-        ----------
-        notes : str
-            Notes to add to the revision.
-
-        Returns
-        -------
-        None
-
         Examples
         ----------
-        >>> notes = "Added a filter to the WiFi Radio."
-        >>> freqs = aedtapp.results.current_revision.set_notes(notes)
-        """
-        design = self.emit_project.odesktop.GetActiveProject().GetActiveDesign()
-        design.SetResultNotes(self.name, notes)
-        self.emit_project._emit_api.save_project()
-
-    @pyaedt_function_handler
-    def get_notes(self):
-        """
-        Get the current revision's notes.
-
-        Parameters
-        ----------
-        None
-
-        Returns
-        -------
-        notes : str
-            Notes to add to the revision.
-
-        Examples
-        ----------
-        >>> notes = aedtapp.results.current_revision.get_notes()
+        >>> aedtapp.results.current_revision.notes = "Added a filter to the WiFi Radio."
+        >>> aedtapp.results.current_revision.notes
+        'Added a filter to the WiFi Radio.'
         """
         design = self.emit_project.odesktop.GetActiveProject().GetActiveDesign()
         return design.GetResultNotes(self.name)
+
+    @notes.setter
+    def notes(self, notes):
+        design = self.emit_project.odesktop.GetActiveProject().GetActiveDesign()
+        design.SetResultNotes(self.name, notes)
+        self.emit_project._emit_api.save_project()


### PR DESCRIPTION
@jsalant22 Feel free to decline this PR. I just thought that using a property might be easier for the users to find when they are using the auto-completion tools.