### PR TITLE
assign_source function

### DIFF
--- a/_unittest/test_98_Icepak.py
+++ b/_unittest/test_98_Icepak.py
@@ -455,6 +455,46 @@ class TestClass(BasisTest, object):
             temperature="28cel",
         )
         assert self.aedtapp.create_source_power(self.aedtapp.modeler["boxSource"].name, input_power="20W")
+        self.aedtapp.modeler.create_box([0, 0, 0], [20, 20, 20], name="boxSource2")
+        x = [1, 2, 3]
+        y = [3, 4, 5]
+        self.aedtapp.create_dataset1d_design("Test_DataSet", x, y)
+        assert self.aedtapp.assign_source(
+            self.aedtapp.modeler["boxSource"].top_face_z.id,
+            "Total Power",
+            "10W",
+            voltage_current_choice="Current",
+            voltage_current_value="1A",
+        )
+        assert not self.aedtapp.assign_source(
+            self.aedtapp.modeler["boxSource"].top_face_x.id,
+            "Total Power",
+            assignment_value={"Type": "Temp Dep", "Function": "Piecewise Linear", "Values": ["1W", "Test_DataSet"]},
+            voltage_current_choice="Current",
+            voltage_current_value={"Type": "Transient", "Function": "Sinusoidal", "Values": ["0A", 1, 1, "1s"]},
+        )
+        assert not self.aedtapp.assign_source(
+            self.aedtapp.modeler["boxSource"].top_face_x.id,
+            "Total Power",
+            assignment_value={"Type": "Temp Dep", "Function": "Sinusoidal", "Values": ["0W", 1, 1, "1K"]},
+            voltage_current_choice="Current",
+            voltage_current_value={"Type": "Transient", "Function": "Sinusoidal", "Values": ["0A", 1, 1, "1s"]},
+        )
+        self.aedtapp.solution_type = "Transient"
+        assert self.aedtapp.assign_source(
+            self.aedtapp.modeler["boxSource"].top_face_x.id,
+            "Total Power",
+            assignment_value={"Type": "Temp Dep", "Function": "Piecewise Linear", "Values": ["1mW", "Test_DataSet"]},
+            voltage_current_choice="Current",
+            voltage_current_value={"Type": "Transient", "Function": "Sinusoidal", "Values": ["0A", 1, 1, "1s"]},
+        )
+        assert self.aedtapp.assign_source(
+            self.aedtapp.modeler["boxSource"].top_face_y.id,
+            "Total Power",
+            assignment_value={"Type": "Temp Dep", "Function": "Piecewise Linear", "Values": "Test_DataSet"},
+            voltage_current_choice="Current",
+            voltage_current_value={"Type": "Transient", "Function": "Sinusoidal", "Values": ["0A", 1, 1, "1s"]},
+        )
 
     def test_34_import_idf(self):
         self.aedtapp.insert_design("IDF")

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -630,6 +630,9 @@ class Icepak(FieldAnalysis3D):
     ):
         """Create a source power for a face.
 
+        .. deprecated:: 0.6.71
+            This method is replaced by `assign_source`.
+
         Parameters
         ----------
         face_id : int or str

--- a/pyaedt/icepak.py
+++ b/pyaedt/icepak.py
@@ -3739,7 +3739,7 @@ class Icepak(FieldAnalysis3D):
         return {"{} Variation Data".format(quantity): out_dict}
 
     @pyaedt_function_handler()
-    def assign_source_power(
+    def assign_source(
         self,
         assignment,
         thermal_condition,


### PR DESCRIPTION
New function for assigning the source boundary condition. The old one (`create_source_power`) is deprecated. The new function has clearer arguments, and it is more general: it supports both temperature dependent assignment and transient ones.