### PR TITLE
Use argparse for toolkit installer; Fix new Desktop session; sync PyAEDT installer files; use tabs

### DIFF
--- a/doc/source/Resources/pyaedt_with_IDE.bat
+++ b/doc/source/Resources/pyaedt_with_IDE.bat
@@ -33,9 +33,9 @@ if NOT [%usepython%]==[] (
 if NOT [%usewheel%]==[] (
 	set wheelpyaedt="!argVec[%usewheel%]!"
 	if [%usepython%]==[] (
-	    echo ----------------------------------------------------------------------
-	    echo WheelHouse has been specified. Make sure you are using version 3_7.
-	 	echo ----------------------------------------------------------------------
+		echo ----------------------------------------------------------------------
+		echo WheelHouse has been specified. Make sure you are using version 3_7.
+		echo ----------------------------------------------------------------------
 
 	) ELSE (
 	echo ----------------------------------------------------------------------------------------------
@@ -49,21 +49,21 @@ if NOT [%usewheel%]==[] (
 set env_vars=ANSYSEM_ROOT232 ANSYSEM_ROOT231 ANSYSEM_ROOT222 ANSYSEM_ROOT221 ANSYSEM_ROOT212
 set /A choice_index=1
 for %%c in (%env_vars%) do (
-    set env_var_name=%%c
-    if defined !env_var_name! (
-        set root_var[!choice_index!]=!env_var_name!
-        set version=!env_var_name:ANSYSEM_ROOT=!
-        set versions[!choice_index!]=!version!
-        set version_pretty=20!version:~0,2! R!version:~2,1!
-        echo [!choice_index!] !version_pretty!
-	    set /A choice_index=!choice_index!+1
-    )
+	set env_var_name=%%c
+	if defined !env_var_name! (
+		set root_var[!choice_index!]=!env_var_name!
+		set version=!env_var_name:ANSYSEM_ROOT=!
+		set versions[!choice_index!]=!version!
+		set version_pretty=20!version:~0,2! R!version:~2,1!
+		echo [!choice_index!] !version_pretty!
+		set /A choice_index=!choice_index!+1
+	)
 )
 REM If choice_index wasn't incremented then it means none of the variables are installed
 if [%choice_index%]==1 (
-    echo AEDT 2021 R2 or later must be installed.
-    pause
-    EXIT /B
+	echo AEDT 2021 R2 or later must be installed.
+	pause
+	EXIT /B
 )
 
 set /p chosen_index="Select Version to Install PyAEDT for (number in bracket): "
@@ -75,10 +75,10 @@ echo Selected %version% at !%chosen_root%!.
 
 set aedt_path=potato
 if [%specified_python%]==[y] (
-    aedt_path=!argVec[%python_path_index%]!
+	aedt_path=!argVec[%python_path_index%]!
 ) else (
-    set aedt_path=!%chosen_root%!\commonfiles\CPython\3_7\winx64\Release\python
-    echo Built-in Python is !aedt_path!.
+	set aedt_path=!%chosen_root%!\commonfiles\CPython\3_7\winx64\Release\python
+	echo Built-in Python is !aedt_path!.
 )
 set aedt_path=!aedt_path:"=!
 
@@ -89,50 +89,62 @@ echo %aedt_path%
 set pyaedt_install_dir=%APPDATA%\pyaedt_env_ide\v%version%
 echo %pyaedt_install_dir%
 if NOT exist "%pyaedt_install_dir%" (
-    set install_pyaedt=y
+	set install_pyaedt=y
 )
 setlocal enableDelayedExpansion
 
 if [%install_pyaedt%]==[y] (
-    if exist "%pyaedt_install_dir%" (
-        echo Removing existing PyAEDT environment.
-        @RD /S /Q "%pyaedt_install_dir%"
-    )
-    echo Installing PyAEDT environment in "%pyaedt_install_dir%".
+	if exist "%pyaedt_install_dir%" (
+		echo Removing existing PyAEDT environment.
+		@RD /S /Q "%pyaedt_install_dir%"
+	)
+	echo Installing PyAEDT environment in "%pyaedt_install_dir%".
 
-    cd "%APPDATA%"
+	cd "%APPDATA%"
 
-    if [%pythonpyaedt%] == [] (
-    "%aedt_path%\python.exe" -m venv "%pyaedt_install_dir%" --system-site-packages
-    ) ELSE (
-        "%pythonpyaedt%\python.exe" -m venv "%pyaedt_install_dir%"
-    )
-    call "%pyaedt_install_dir%\Scripts\activate.bat"
-    if NOT [%wheelpyaedt%]==[] (
-        echo Installing PyAEDT from local wheels %arg1%.
-        pip install --no-cache-dir --no-index --find-links=%wheelpyaedt% pyaedt
-    ) ELSE (
+	if [%pythonpyaedt%] == [] (
+	"%aedt_path%\python.exe" -m venv "%pyaedt_install_dir%" --system-site-packages
+	) ELSE (
+		"%pythonpyaedt%\python.exe" -m venv "%pyaedt_install_dir%"
+	)
+	call "%pyaedt_install_dir%\Scripts\activate.bat"
+	if NOT [%wheelpyaedt%]==[] (
+		echo Installing PyAEDT from local wheels %arg1%.
+		pip install --no-cache-dir --no-index --find-links=%wheelpyaedt% pyaedt
+	) ELSE (
+		IF EXIST %current_dir%.git (
+			echo Installing PyAEDT from local clone "%current_dir%".
+		) ELSE (
+			echo Installing PyAEDT from pip.
+		)
 
-        python -m pip install --upgrade pip
-        pip --default-timeout=1000 install wheel
+		python -m pip install --upgrade pip
+		pip --default-timeout=1000 install wheel
 
-        pip --default-timeout=1000 install pyaedt
-        pip --default-timeout=1000 install jupyterlab -I
-        if [%install_spyder%]==[y] pip --default-timeout=1000 install spyder
-        pip --default-timeout=1000 install ipython -U
+		IF EXIST %current_dir%.git (
+			pushd %current_dir%
+			pip install .
+			popd
+		) ELSE (
+			pip --default-timeout=1000 install pyaedt
+		)
+
+		pip --default-timeout=1000 install jupyterlab -I
+		if [%install_spyder%]==[y] pip --default-timeout=1000 install spyder
+		pip --default-timeout=1000 install ipython -U
 		pip --default-timeout=1000 install ipyvtklink
-    )
+	)
 	if [%pythonpyaedt%]==[] (
-        if %version% geq 231 pip uninstall -y pywin32
+		if %version% geq 231 pip uninstall -y pywin32
 	)
 
-    call python "%pyaedt_install_dir%\Lib\site-packages\pyaedt\misc\aedtlib_personalib_install.py" %version% 0 1
+	call python "%pyaedt_install_dir%\Lib\site-packages\pyaedt\misc\aedtlib_personalib_install.py" --version=%version%
 )
 if [%update_pyaedt%]==[y] (
-    echo Updating PyAEDT.
-    "%pyaedt_install_dir%\Scripts\pip" install pythonnet  -U
-    "%pyaedt_install_dir%\Scripts\pip" install pyaedt --no-deps -U
-    call "%pyaedt_install_dir%\Scripts\python" "%pyaedt_install_dir%\Lib\site-packages\pyaedt\misc\aedtlib_personalib_install.py" %version% 0 1
+	echo Updating PyAEDT.
+	"%pyaedt_install_dir%\Scripts\pip" install pythonnet  -U
+	"%pyaedt_install_dir%\Scripts\pip" install pyaedt --no-deps -U
+	call "%pyaedt_install_dir%\Scripts\python" "%pyaedt_install_dir%\Lib\site-packages\pyaedt\misc\aedtlib_personalib_install.py" --version=%version%
 
 )
 

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -61,6 +61,8 @@ def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False
 
     sessions = grpc_active_sessions(aedt_version, is_student_version)
     if not sessions:
+        if not new_desktop_session:
+            print("Launching new AEDT desktop session.")
         new_desktop_session = True
     with Desktop(
         specified_version=aedt_version,
@@ -73,7 +75,7 @@ def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False
         pid = desktop.GetProcessID()
         # Linking pyaedt in PersonalLib for IronPython compatibility.
         if os.path.exists(pers1):
-            d.logger.info("PersonalLib already mapped")
+            d.logger.info("PersonalLib already mapped.")
         else:
             if is_windows:
                 os.system('mklink /D "{}" "{}"'.format(pers1, pyaedt_path))
@@ -102,16 +104,16 @@ def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False
                 try:
                     sys_dir = os.path.join(d.syslib, "Toolkits")
                     install_toolkit(sys_dir, product, aedt_version)
-                    d.logger.info("Installed toolkit for {} in sys lib".format(product))
+                    d.logger.info("Installed toolkit for {} in sys lib.".format(product))
 
                 except IOError:
                     pers_dir = os.path.join(d.personallib, "Toolkits")
                     install_toolkit(pers_dir, product, aedt_version)
-                    d.logger.info("Installed toolkit for {} in personal lib".format(product))
+                    d.logger.info("Installed toolkit for {} in personal lib.".format(product))
             else:
                 pers_dir = os.path.join(d.personallib, "Toolkits")
                 install_toolkit(pers_dir, product, aedt_version)
-                d.logger.info("Installed toolkit for {} in personal lib".format(product))
+                d.logger.info("Installed toolkit for {} in personal lib.".format(product))
     if pid and new_desktop_session:
         try:
             os.kill(pid, 9)

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -62,7 +62,7 @@ def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False
     sessions = grpc_active_sessions(aedt_version, is_student_version)
     if not sessions:
         if not new_desktop_session:
-            print("Launching new AEDT desktop session.")
+            print("Launching a new AEDT desktop session.")
         new_desktop_session = True
     with Desktop(
         specified_version=aedt_version,

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -30,7 +30,9 @@ def main():
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="Install PyAEDT and setup PyAEDT toolkits in AEDT.")
-    parser.add_argument("--version", "-v", default="231", metavar="XY.Z", help="AEDT three-digit version (e.g. 231).")
+    parser.add_argument(
+        "--version", "-v", default="231", metavar="XY.Z", help="AEDT three-digit version (e.g. 231). Default=231"
+    )
     parser.add_argument("--student", action="store_true", help="Install toolkits for AEDT Student Version.")
     parser.add_argument("--sys_lib", action="store_true", help="Install toolkits in SysLib.")
     parser.add_argument(

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import shutil
 import sys
@@ -18,6 +19,36 @@ sys.path.append(os.path.normpath(os.path.join(pyaedt_path, "..")))
 is_linux = os.name == "posix"
 is_windows = not is_linux
 pid = 0
+
+
+def main():
+    args = parse_arguments()
+    add_pyaedt_to_aedt(
+        args.version, is_student_version=args.student, use_sys_lib=args.sys_lib, new_desktop_session=args.new_session
+    )
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="Install PyAEDT and setup PyAEDT toolkits in AEDT.")
+    parser.add_argument("--version", "-v", default="231", metavar="XY.Z", help="AEDT three-digit version (e.g. 231).")
+    parser.add_argument("--student", action="store_true", help="Install toolkits for AEDT Student Version.")
+    parser.add_argument("--sys_lib", action="store_true", help="Install toolkits in SysLib.")
+    parser.add_argument(
+        "--new_session", action="store_true", help="Start a new session of AEDT after installing PyAEDT."
+    )
+
+    args = parser.parse_args()
+    args = process_arguments(args, parser)
+    return args
+
+
+def process_arguments(args, parser):
+    if len(args.version) != 3:
+        parser.print_help()
+        parser.error("Version should be a three digit number (e.g. 231)")
+
+    args.version = "20" + args.version[-3:-1] + "." + args.version[-1:]
+    return args
 
 
 def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False, new_desktop_session=False):
@@ -189,19 +220,4 @@ def exe():
 
 
 if __name__ == "__main__":
-    student_version = False
-    if len(sys.argv) < 2:
-        version = "2022.2"
-    elif sys.argv[1].endswith("sv"):
-        v = sys.argv[1][:-2]
-        version = "20" + v[-3:-1] + "." + v[-1:]
-        student_version = True
-    else:
-        v = sys.argv[1]
-        version = "20" + v[-3:-1] + "." + v[-1:]
-    sys_lib = True
-    if len(sys.argv) >= 3:
-        sys_lib = True if sys.argv[2] == "1" else False
-    if len(sys.argv) == 4:
-        new_session = True if sys.argv[3] == "1" else False
-    add_pyaedt_to_aedt(version, student_version, sys_lib)
+    main()

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -33,7 +33,9 @@ def parse_arguments():
     parser.add_argument(
         "--version", "-v", default="231", metavar="XY.Z", help="AEDT three-digit version (e.g. 231). Default=231"
     )
-    parser.add_argument("--student", action="store_true", help="Install toolkits for AEDT Student Version.")
+    parser.add_argument(
+        "--student", "--student_version", action="store_true", help="Install toolkits for AEDT Student Version."
+    )
     parser.add_argument("--sys_lib", "--syslib", action="store_true", help="Install toolkits in SysLib.")
     parser.add_argument(
         "--new_session", action="store_true", help="Start a new session of AEDT after installing PyAEDT."

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -34,7 +34,7 @@ def parse_arguments():
         "--version", "-v", default="231", metavar="XY.Z", help="AEDT three-digit version (e.g. 231). Default=231"
     )
     parser.add_argument("--student", action="store_true", help="Install toolkits for AEDT Student Version.")
-    parser.add_argument("--sys_lib", action="store_true", help="Install toolkits in SysLib.")
+    parser.add_argument("--sys_lib", "--syslib", action="store_true", help="Install toolkits in SysLib.")
     parser.add_argument(
         "--new_session", action="store_true", help="Start a new session of AEDT after installing PyAEDT."
     )

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -57,7 +57,11 @@ def process_arguments(args, parser):
 
 def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False, new_desktop_session=False):
     from pyaedt import Desktop
+    from pyaedt.generic.general_methods import grpc_active_sessions
 
+    sessions = grpc_active_sessions(aedt_version, is_student_version)
+    if not sessions:
+        new_desktop_session = True
     with Desktop(
         specified_version=aedt_version,
         non_graphical=new_desktop_session,

--- a/pyaedt/misc/aedtlib_personalib_install.py
+++ b/pyaedt/misc/aedtlib_personalib_install.py
@@ -57,7 +57,10 @@ def add_pyaedt_to_aedt(aedt_version, is_student_version=False, use_sys_lib=False
     from pyaedt import Desktop
 
     with Desktop(
-        aedt_version, new_desktop_session, new_desktop_session=new_desktop_session, student_version=is_student_version
+        specified_version=aedt_version,
+        non_graphical=new_desktop_session,
+        new_desktop_session=new_desktop_session,
+        student_version=is_student_version,
     ) as d:
         desktop = sys.modules["__main__"].oDesktop
         pers1 = os.path.join(desktop.GetPersonalLibDirectory(), "pyaedt")

--- a/pyaedt_with_IDE.bat
+++ b/pyaedt_with_IDE.bat
@@ -138,13 +138,13 @@ if [%install_pyaedt%]==[y] (
 		if %version% geq 231 pip uninstall -y pywin32
 	)
 
-	call python "%pyaedt_install_dir%\Lib\site-packages\pyaedt\misc\aedtlib_personalib_install.py" %version%
+	call python "%pyaedt_install_dir%\Lib\site-packages\pyaedt\misc\aedtlib_personalib_install.py" --version=%version%
 )
 if [%update_pyaedt%]==[y] (
 	echo Updating PyAEDT.
 	"%pyaedt_install_dir%\Scripts\pip" install pythonnet  -U
 	"%pyaedt_install_dir%\Scripts\pip" install pyaedt --no-deps -U
-	call "%pyaedt_install_dir%\Scripts\python" "%pyaedt_install_dir%\Lib\site-packages\pyaedt\misc\aedtlib_personalib_install.py" %version%
+	call "%pyaedt_install_dir%\Scripts\python" "%pyaedt_install_dir%\Lib\site-packages\pyaedt\misc\aedtlib_personalib_install.py" --version=%version%
 
 )
 


### PR DESCRIPTION
Use argparse for toolkit installer; Fix new Desktop session; sync PyAEDT installer files; use tabs

```
C:\Junk>python C:\AnsysDEV\develop\pyaedt\pyaedt\misc\aedtlib_personalib_install.py --help
usage: aedtlib_personalib_install.py [-h] [--version XY.Z] [--student] [--sys_lib] [--new_session]

Install PyAEDT and setup PyAEDT toolkits in AEDT.

options:
  -h, --help            show this help message and exit
  --version XY.Z, -v XY.Z
                        AEDT three-digit version (e.g. 231). Default=231
  --student             Install toolkits for AEDT Student Version.
  --sys_lib             Install toolkits in SysLib.
  --new_session         Start a new session of AEDT after installing PyAEDT.

```
![image](https://user-images.githubusercontent.com/83788850/232114417-e1b562ab-d67d-4fb5-882f-77198c7ff293.png)

![image](https://user-images.githubusercontent.com/83788850/232114355-b330566b-8a3c-4809-960d-357e4ad69cd8.png)

Also confirmed it works when executing the file `pyaedt_with_IDE.bat` from the repo
```
Launching a new AEDT desktop session.
pyaedt INFO: using existing logger.
pyaedt INFO: AEDT installation Path C:\Program Files\AnsysEM\v232\Win64
pyaedt INFO: Launching AEDT with the gRPC plugin.
pyaedt INFO: New AEDT session is starting on gRPC port 59152
pyaedt INFO: Ansoft.ElectronicsDesktop.2023.2  version started with process ID 11564.
pyaedt INFO: pyaedt v0.7.dev0
pyaedt INFO: Python version 3.7.13 (remotes/origin/b9c51cafc7069541f2d60b32b54097a87cd88df6-dirty:b9c51caf, Dec 14 2) [MSC v.1920 64 bit (AMD64)]
You do not have sufficient privilege to perform this operation.
Building to C:\Users\***\Documents\Ansoft\PersonalLib\Toolkits\Project\PyAEDT\Console.py
Building to C:\Users\***\Documents\Ansoft\PersonalLib\Toolkits\Project\PyAEDT\Run PyAEDT Script.py
Building to C:\Users\***\Documents\Ansoft\PersonalLib\Toolkits\Project\PyAEDT\Jupyter.py
pyaedt INFO: Installed toolkit for Project in personal lib.
pyaedt INFO: Project files removed from handlers.
```
