### PR TITLE
Test cleanup

### DIFF
--- a/_unittest/test_00_Advanced_EDB.py
+++ b/_unittest/test_00_Advanced_EDB.py
@@ -749,7 +749,7 @@ class TestClass(BasisTest, object):
             f.writelines("PowerNets = ['GND']\n")
             f.writelines("Components = ['U2A5', 'U1B5']")
         sim_config = SimulationConfiguration(cfg_file)
-        assert Edb(target_path).build_simulation_project(sim_config)
+        assert Edb(target_path, edbversion=desktop_version).build_simulation_project(sim_config)
 
     @pytest.mark.skipif(is_ironpython or is_linux, reason="Not supported in IPY")
     def test_16_solve(self):
@@ -882,7 +882,7 @@ class TestClass(BasisTest, object):
                         assert (pedb_lay.side_hallhuray_nodule_radius - layer["side_hallhuray_nodule_radius"]) < delta
                         assert (pedb_lay.side_hallhuray_surface_ratio - layer["side_hallhuray_surface_ratio"]) < delta
         edbapp.close_edb()
-        edbapp = Edb()
+        edbapp = Edb(edbversion=desktop_version)
         json_path = os.path.join(local_path, "example_models", test_subfolder, "test_mat2.json")
         assert edbapp.stackup.import_stackup(json_path)
         assert "SOLDER" in edbapp.stackup.stackup_layers

--- a/_unittest/test_00_EDB.py
+++ b/_unittest/test_00_EDB.py
@@ -795,7 +795,7 @@ class TestClass(BasisTest, object):
         edbapp.close_edb()
 
     def test_071_create_edb(self):
-        edb = Edb(os.path.join(self.local_scratch.path, "temp.aedb"))
+        edb = Edb(os.path.join(self.local_scratch.path, "temp.aedb"), edbversion=desktop_version)
         assert edb
         assert edb.active_layout
         edb.close_edb()
@@ -1345,7 +1345,7 @@ class TestClass(BasisTest, object):
         source_path = os.path.join(local_path, "example_models", test_subfolder, "test_107.aedb")
         target_path = os.path.join(self.local_scratch.path, "test_113.aedb")
         self.local_scratch.copyfolder(source_path, target_path)
-        edb = Edb(target_path)
+        edb = Edb(target_path, edbversion=desktop_version)
         initial_extent_info = edb.active_cell.GetHFSSExtentInfo()
         assert initial_extent_info.ExtentType == edb.edb.Utility.HFSSExtentInfoType.Conforming
         config = SimulationConfiguration()
@@ -1413,7 +1413,7 @@ class TestClass(BasisTest, object):
         if not os.path.exists(self.local_scratch.path):
             os.mkdir(self.local_scratch.path)
         self.local_scratch.copyfolder(source_path, target_path)
-        edb = Edb(target_path)
+        edb = Edb(target_path, edbversion=desktop_version)
         assert len(list(edb.active_cell.SimulationSetups)) == 0
         sim_config = SimulationConfiguration()
         sim_config.enforce_causality = False
@@ -1434,7 +1434,7 @@ class TestClass(BasisTest, object):
         source_path = os.path.join(local_path, "example_models", test_subfolder, "Galileo.aedb")
         target_path = os.path.join(self.local_scratch.path, "test_0117.aedb")
         self.local_scratch.copyfolder(source_path, target_path)
-        edb = Edb(target_path)
+        edb = Edb(target_path, edbversion=desktop_version)
         sim_setup = SimulationConfiguration()
         sim_setup.mesh_sizefactor = 1.9
         assert not sim_setup.do_lambda_refinement
@@ -2231,7 +2231,7 @@ class TestClass(BasisTest, object):
         assert len(self.edbapp.pins) > 0
 
     def test_130_create_padstack_instance(self):
-        edb = Edb()
+        edb = Edb(edbversion=desktop_version)
         edb.stackup.add_layer(layer_name="top", fillMaterial="AIR", thickness="30um")
         edb.stackup.add_layer(layer_name="contact", fillMaterial="AIR", thickness="100um", base_layer="top")
 

--- a/_unittest/test_01_Design.py
+++ b/_unittest/test_01_Design.py
@@ -329,7 +329,7 @@ class TestClass(BasisTest, object):
         assert settings.force_error_on_missing_project == True
         e = None
         try:
-            h = Hfss("c:/dummy/test.aedt")
+            h = Hfss("c:/dummy/test.aedt", specified_version=desktop_version)
         except Exception as e:
             exception_raised = True
             assert e.args[0] == "Project doesn't exists. Check it and retry."
@@ -351,12 +351,12 @@ class TestClass(BasisTest, object):
 
     def test_36_test_load(self):
         file_name = os.path.join(self.local_scratch.path, "test_36.aedt")
-        hfss = Hfss(projectname=file_name)
+        hfss = Hfss(projectname=file_name, specified_version=desktop_version)
         hfss.save_project()
         assert hfss
-        h3d = Hfss3dLayout(file_name)
+        h3d = Hfss3dLayout(file_name, specified_version=desktop_version)
         assert h3d
-        h3d = Hfss3dLayout(file_name)
+        h3d = Hfss3dLayout(file_name, specified_version=desktop_version)
         assert h3d
         file_name2 = os.path.join(self.local_scratch.path, "test_36_2.aedt")
         file_name2_lock = os.path.join(self.local_scratch.path, "test_36_2.aedt.lock")
@@ -365,7 +365,7 @@ class TestClass(BasisTest, object):
         with open(file_name2_lock, "w") as f:
             f.write(" ")
         try:
-            hfss = Hfss(projectname=file_name2)
+            hfss = Hfss(projectname=file_name2, specified_version=desktop_version)
         except:
             assert True
         try:
@@ -373,7 +373,7 @@ class TestClass(BasisTest, object):
             file_name3 = os.path.join(self.local_scratch.path, "test_36_2.aedb", "edb.def")
             with open(file_name3, "w") as f:
                 f.write(" ")
-            hfss = Hfss3dLayout(projectname=file_name3)
+            hfss = Hfss3dLayout(projectname=file_name3, specified_version=desktop_version)
         except:
             assert True
 

--- a/_unittest/test_08_Primitives3D.py
+++ b/_unittest/test_08_Primitives3D.py
@@ -976,7 +976,7 @@ class TestClass(BasisTest, object):
         self.aedtapp.modeler.model_units = save_model_units
 
     def test_54b_open_and_load_a_polyline(self):
-        aedtapp = Hfss(self.test_54b_project)
+        aedtapp = Hfss(self.test_54b_project, specified_version=config["desktopVersion"])
         # self.aedtapp.load_project(self.test_54b_project)
 
         poly1 = aedtapp.modeler["Inductor1"]

--- a/_unittest/test_09_VariableManager.py
+++ b/_unittest/test_09_VariableManager.py
@@ -4,6 +4,7 @@ from __future__ import division  # noreorder
 import math
 
 from _unittest.conftest import BasisTest
+from _unittest.conftest import desktop_version
 
 from pyaedt import MaxwellCircuit
 from pyaedt.application.Variables import Variable
@@ -392,7 +393,7 @@ class TestClass(BasisTest, object):
         assert self.aedtapp.variable_manager["getvalue2"].numeric_value == 1.0
 
     def test_16_maxwell_circuit_variables(self):
-        mc = MaxwellCircuit()
+        mc = MaxwellCircuit(specified_version=desktop_version)
         mc["var2"] = "10mm"
         assert mc["var2"] == "10mm"
         v_circuit = mc.variable_manager

--- a/_unittest/test_11_Setup.py
+++ b/_unittest/test_11_Setup.py
@@ -57,7 +57,7 @@ class TestClass(BasisTest, object):
         assert sweep2.props["Type"] == "Interpolating"
 
     def test_02_create_circuit_setup(self):
-        circuit = Circuit()
+        circuit = Circuit(specified_version=desktop_version)
         setup1 = circuit.create_setup("circuit", self.aedtapp.SETUPS.NexximLNA)
         assert setup1.name == "circuit"
         setup1.props["SweepDefinition"]["Data"] = "LINC 0GHz 4GHz 501"

--- a/_unittest/test_12_PostProcessing.py
+++ b/_unittest/test_12_PostProcessing.py
@@ -65,10 +65,12 @@ class TestClass(BasisTest, object):
         self.circuit_test = BasisTest.add_app(
             self, project_name=test_circuit_name, design_name="Diode", application=Circuit, subfolder=test_subfolder
         )
-        self.diff_test = Circuit(designname="diff", projectname=self.circuit_test.project_name)
+        self.diff_test = Circuit(
+            designname="diff", projectname=self.circuit_test.project_name, specified_version=config["desktopVersion"]
+        )
         self.sbr_test = BasisTest.add_app(self, project_name=sbr_file, subfolder=test_subfolder)
         self.q3dtest = BasisTest.add_app(self, project_name=q3d_file, application=Q3d, subfolder=test_subfolder)
-        self.q2dtest = Q2d(projectname=self.q3dtest.project_name)
+        self.q2dtest = Q2d(projectname=self.q3dtest.project_name, specified_version=config["desktopVersion"])
         self.eye_test = BasisTest.add_app(self, project_name=eye_diagram, application=Circuit, subfolder=test_subfolder)
         self.ami_test = BasisTest.add_app(self, project_name=ami, application=Circuit, subfolder=test_subfolder)
         self.array_test = BasisTest.add_app(self, project_name=array, subfolder=test_subfolder)
@@ -855,7 +857,7 @@ class TestClass(BasisTest, object):
 
     def test_54_reload(self):
         self.aedtapp.save_project()
-        app2 = Hfss(self.aedtapp.project_name)
+        app2 = Hfss(self.aedtapp.project_name, specified_version=config["desktopVersion"])
         assert len(app2.post.field_plots) == len(self.aedtapp.post.field_plots)
 
     @pytest.mark.skipif(

--- a/_unittest/test_17_SBR.py
+++ b/_unittest/test_17_SBR.py
@@ -1,6 +1,11 @@
 import os
 import sys
 
+try:
+    import osmnx
+except ImportError:
+    pass
+
 from _unittest.conftest import BasisTest
 from _unittest.conftest import desktop_version
 from _unittest.conftest import local_path
@@ -47,6 +52,9 @@ class TestClass(BasisTest, object):
         self.source = Hfss(self.aedtapp.project_name, "feeder", specified_version=desktop_version)
         self.sbr_platform = BasisTest.add_app(self, project_name=sbr_platform, subfolder=test_subfolder)
         self.array = BasisTest.add_app(self, project_name=array, subfolder=test_subfolder)
+        if not is_ironpython and not is_linux:
+            # this should be changed upstream to use a HOME or TEMP folder by default...
+            osmnx.settings.cache_folder = os.path.join(self.local_scratch.path, "cache")
 
     def teardown_class(self):
         BasisTest.my_teardown(self)

--- a/_unittest/test_17_SBR.py
+++ b/_unittest/test_17_SBR.py
@@ -177,7 +177,7 @@ class TestClass(BasisTest, object):
         assert sweep.props["Sim. Setups"] == [setup.name]
 
     def test_11_add_sbr_boundaries_in_hfss_solution(self):
-        hfss_terminal = Hfss(solution_type="Terminal")
+        hfss_terminal = Hfss(solution_type="Terminal", specified_version=desktop_version)
 
         # sbr file based antenna should only work for SBR+ solution.
         assert not hfss_terminal.create_sbr_file_based_antenna(

--- a/_unittest/test_20_HFSS.py
+++ b/_unittest/test_20_HFSS.py
@@ -1359,7 +1359,7 @@ class TestClass(BasisTest, object):
         assert len(exported_files) > 0
 
     def test_52_crate_setup_hybrid_sbr(self):
-        aedtapp = Hfss(projectname="test_52")
+        aedtapp = Hfss(projectname="test_52", specified_version=desktop_version)
         udp = aedtapp.modeler.Position(0, 0, 0)
         coax_dimension = 200
         aedtapp.modeler.create_cylinder(aedtapp.AXIS.X, udp, 3, coax_dimension, 0, "inner")
@@ -1374,7 +1374,7 @@ class TestClass(BasisTest, object):
 
     @pytest.mark.skipif(is_ironpython, reason="Method usese Pandas")
     def test_53_import_source_excitation(self):
-        aedtapp = Hfss(solution_type="Modal", projectname="test_53")
+        aedtapp = Hfss(solution_type="Modal", projectname="test_53", specified_version=desktop_version)
         freq_domain = os.path.join(local_path, "example_models", test_subfolder, "S Parameter Table 1.csv")
         time_domain = os.path.join(local_path, "example_models", test_subfolder, "Sinusoidal.csv")
 
@@ -1396,7 +1396,7 @@ class TestClass(BasisTest, object):
         self.aedtapp.close_project(name=aedtapp.project_name, save_project=False)
 
     def test_54_assign_symmetry(self):
-        aedtapp = Hfss(projectname="test_54")
+        aedtapp = Hfss(projectname="test_54", specified_version=desktop_version)
         aedtapp.modeler.create_box([0, -100, 0], [200, 200, 200], name="SymmetryForFaces")
         ids = [i.id for i in aedtapp.modeler["SymmetryForFaces"].faces]
         assert aedtapp.assign_symmetry(ids)

--- a/_unittest/test_21_Circuit.py
+++ b/_unittest/test_21_Circuit.py
@@ -705,7 +705,7 @@ class TestClass(BasisTest, object):
         c.excitations["PortTest"].delete()
         assert len(c.excitation_objets) == 0
         self.aedtapp.save_project()
-        c = Circuit(designname="sources")
+        c = Circuit(designname="sources", specified_version=config["desktopVersion"])
         assert c.sources
 
     def test_41_set_variable(self):

--- a/_unittest/test_22_Circuit_DynamicLink.py
+++ b/_unittest/test_22_Circuit_DynamicLink.py
@@ -65,7 +65,7 @@ class TestClass(BasisTest, object):
                         ).encode()
                         found = True
                 outf.write(line + b"\n")
-        self.aedtapp = Circuit(self.test_project)
+        self.aedtapp = Circuit(self.test_project, specified_version=desktop_version)
         self.aedtapps.append(self.aedtapp)
 
     def teardown_class(self):
@@ -88,7 +88,7 @@ class TestClass(BasisTest, object):
 
         assert len(pin_names) == 4
         assert "usb_P_pcb" in pin_names
-        hfss = Hfss(designname="uUSB", projectname=source_project_path)
+        hfss = Hfss(designname="uUSB", projectname=source_project_path, specified_version=desktop_version)
         hfss_comp = self.aedtapp.modeler.schematic.add_subcircuit_dynamic_link(hfss, comp_name="uUSB")
         assert hfss_comp.id == 87
         assert hfss_comp.composed_name == "CompInst@uUSB;87;3"

--- a/_unittest/test_35_MaxwellCircuit.py
+++ b/_unittest/test_35_MaxwellCircuit.py
@@ -2,6 +2,7 @@
 import os
 
 from _unittest.conftest import BasisTest
+from _unittest.conftest import desktop_version
 
 from pyaedt import Maxwell2d
 from pyaedt import MaxwellCircuit
@@ -68,7 +69,7 @@ class TestClass(BasisTest, object):
         assert os.path.exists(netlist_file)
         netlist_file_invalid = os.path.join(self.local_scratch.path, "export_netlist.sh")
         assert not self.aedtapp.export_netlist_from_schematic(netlist_file_invalid)
-        m2d = Maxwell2d(designname="test")
+        m2d = Maxwell2d(designname="test", specified_version=desktop_version)
         m2d.solution_type = SOLUTIONS.Maxwell2d.TransientZ
         m2d.modeler.create_circle([0, 0, 0], 10, name="Circle_inner")
         m2d.modeler.create_circle([0, 0, 0], 30, name="Circle_outer")

--- a/_unittest/test_36_Q2D_PostProcessing.py
+++ b/_unittest/test_36_Q2D_PostProcessing.py
@@ -27,7 +27,7 @@ class TestClass(BasisTest, object):
         test_project = self.local_scratch.copyfile(
             os.path.join(local_path, "example_models", test_subfolder, q2d_solved_sweep + ".aedtz")
         )
-        with Q2d(test_project) as q2d:
+        with Q2d(test_project, specified_version=config["desktopVersion"]) as q2d:
             try:
                 export_folder = os.path.join(self.local_scratch.path, "export_folder")
                 files = q2d.export_w_elements(False, export_folder)
@@ -43,7 +43,7 @@ class TestClass(BasisTest, object):
         test_project = self.local_scratch.copyfile(
             os.path.join(local_path, "example_models", test_subfolder, q2d_solved_nominal + ".aedtz")
         )
-        with Q2d(test_project) as q2d:
+        with Q2d(test_project, specified_version=config["desktopVersion"]) as q2d:
             try:
                 export_folder = os.path.join(self.local_scratch.path, "export_folder")
                 files = q2d.export_w_elements(False, export_folder)
@@ -59,7 +59,7 @@ class TestClass(BasisTest, object):
         test_project = self.local_scratch.copyfile(
             os.path.join(local_path, "example_models", test_subfolder, q2d_solved_nominal + ".aedtz")
         )
-        with Q2d(test_project) as q2d:
+        with Q2d(test_project, specified_version=config["desktopVersion"]) as q2d:
             try:
                 files = q2d.export_w_elements(False)
                 assert len(files) == 1

--- a/_unittest/test_41_3dlayout_modeler.py
+++ b/_unittest/test_41_3dlayout_modeler.py
@@ -640,7 +640,9 @@ class TestClass(BasisTest, object):
     def test_37_import_gds(self):
         self.aedtapp.insert_design("gds")
         gds_file = os.path.join(local_path, "example_models", "cad", "GDS", "gds1.gds")
-        control_file = os.path.join(local_path, "example_models", "cad", "GDS", "gds1.tech")
+        control_file = self.local_scratch.copyfile(
+            os.path.join(local_path, "example_models", "cad", "GDS", "gds1.tech")
+        )
         aedb_file = os.path.join(self.local_scratch.path, "gds_out.aedb")
         assert self.aedtapp.import_gds(gds_file, aedb_path=aedb_file, control_file=control_file)
 

--- a/_unittest/test_42_configuration_files.py
+++ b/_unittest/test_42_configuration_files.py
@@ -41,7 +41,7 @@ class TestClass(BasisTest, object):
         BasisTest.my_setup(self)
         self.aedtapp = BasisTest.add_app(self, project_name=test_project_name, subfolder=test_subfolder)
         self.q3dtest = BasisTest.add_app(self, project_name=q3d_file, application=Q3d, subfolder=test_subfolder)
-        self.q2dtest = Q2d(projectname=q3d_file)
+        self.q2dtest = Q2d(projectname=q3d_file, specified_version=config["desktopVersion"])
         self.icepak_a = BasisTest.add_app(self, project_name=ipk_name + "_a", application=Icepak)
         self.icepak_b = BasisTest.add_app(self, project_name=ipk_name + "_b", application=Icepak)
         self.hfss3dl_a = BasisTest.add_app(
@@ -61,7 +61,9 @@ class TestClass(BasisTest, object):
         filename = self.aedtapp.design_name
         file_path = os.path.join(self.aedtapp.working_directory, filename + ".x_t")
         self.aedtapp.export_3d_model(filename, self.aedtapp.working_directory, ".x_t", [], [])
-        app = Hfss(projectname="new_proj", solution_type=self.aedtapp.solution_type)
+        app = Hfss(
+            projectname="new_proj", solution_type=self.aedtapp.solution_type, specified_version=config["desktopVersion"]
+        )
         app.modeler.import_3d_cad(file_path)
         out = app.configurations.import_config(conf_file)
         app.close_project(save_project=False)
@@ -75,7 +77,7 @@ class TestClass(BasisTest, object):
         filename = self.q3dtest.design_name
         file_path = os.path.join(self.q3dtest.working_directory, filename + ".x_t")
         self.q3dtest.export_3d_model(filename, self.q3dtest.working_directory, ".x_t", [], [])
-        app = Q3d(projectname="new_proj_Q3d")
+        app = Q3d(projectname="new_proj_Q3d", specified_version=config["desktopVersion"])
         app.modeler.import_3d_cad(file_path)
         out = app.configurations.import_config(conf_file)
         app.close_project(save_project=False)
@@ -89,7 +91,7 @@ class TestClass(BasisTest, object):
         filename = self.q2dtest.design_name
         file_path = os.path.join(self.q2dtest.working_directory, filename + ".x_t")
         self.q2dtest.export_3d_model(filename, self.q2dtest.working_directory, ".x_t", [], [])
-        app = Q2d(projectname="new_proj_Q2d")
+        app = Q2d(projectname="new_proj_Q2d", specified_version=config["desktopVersion"])
         app.modeler.import_3d_cad(file_path)
         out = app.configurations.import_config(conf_file)
         app.close_project(save_project=False)
@@ -183,7 +185,7 @@ class TestClass(BasisTest, object):
         assert self.icepak_a.configurations.export_config()
         f.delete()
         file_path = os.path.join(self.icepak_a.working_directory, filename + ".x_t")
-        app = Icepak(projectname="new_proj_Ipk_a")
+        app = Icepak(projectname="new_proj_Ipk_a", specified_version=config["desktopVersion"])
         app.modeler.import_3d_cad(file_path)
         out = app.configurations.import_config(conf_file)
         assert isinstance(out, dict)
@@ -249,7 +251,7 @@ class TestClass(BasisTest, object):
         conf_file = self.icepak_b.configurations.export_config()
         assert os.path.exists(conf_file)
         file_path = os.path.join(self.icepak_b.working_directory, filename + ".x_t")
-        app = Icepak(projectname="new_proj_Ipk")
+        app = Icepak(projectname="new_proj_Ipk", specified_version=config["desktopVersion"])
         app.modeler.import_3d_cad(file_path)
         out = app.configurations.import_config(conf_file)
         assert isinstance(out, dict)

--- a/pyaedt/modeler/advanced_cad/oms.py
+++ b/pyaedt/modeler/advanced_cad/oms.py
@@ -438,7 +438,7 @@ class TerrainPrep(object):
         num_samples = int(np.ceil(max_radius * 2 / sample_grid_size))
         x_samples = np.linspace(utm_x_min, utm_x_max, int(num_samples))
         y_samples = np.linspace(utm_y_min, utm_y_max, int(num_samples))
-        elevation_data = srtm.get_data(local_cache_dir="tmp_cache")
+        elevation_data = srtm.get_data()
 
         all_data = np.zeros((num_samples, num_samples))
         all_utm = np.zeros((num_samples, num_samples, 2))


### PR DESCRIPTION
1. Clean up test outputs from Git working tree
2. Ensure all top-level pyaedt objects for tests specify either edbversion or specified_version

Fixes #2848 
Fixes #2851 