### PR TITLE
FIX: Create versions.json

### DIFF
--- a/release/versions.json
+++ b/release/versions.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "dev",
+    "version": "dev",
+    "url": "https://aedt.docs.pyansys.com/version/dev/"
+  },
+  {
+    "name": "0.6 (stable)",
+    "version": "0.6",
+    "url": "https://aedt.docs.pyansys.com/version/stable/"
+  }
+]


### PR DESCRIPTION
Add ``release/version.json`` file, which currently points to an older format, with the correct link only for the switcher. This should allow the current release to function properly. For future releases, we can ensure that the file points to the correct file ``versions.json``  from the start, and we can remove the old ``release/version.json`` file at that time.