### PR TITLE
Use GetResultDirectory in Revision

### DIFF
--- a/examples/07-EMIT/ComputeChannelSeparation.py.back
+++ b/examples/07-EMIT/ComputeChannelSeparation.py.back
@@ -53,7 +53,7 @@ import numpy as np
 
 non_graphical = os.getenv("PYAEDT_NON_GRAPHICAL", "False").lower() in ("true", "1", "t")
 NewThread = False
-desktop_version = "2022.2"
+desktop_version = "2023.2"
 
 ###############################################################################
 # Launch AEDT with EMIT
@@ -218,11 +218,11 @@ def minimum_tx_channel_separation(rx_band, tx_band, emi_threshold):
     # keeping the EMI below the threshold.
     # Freqs are used to set the domain, so they need to be in Hz
     rx_frequencies = rev.get_active_frequencies(
-        rx_band[0], rx_band[1], modeRx, "Hz"
+        rx_band[0], rx_band[1], modeRx
     )
     rx_channel_count = len(rx_frequencies)
     tx_frequencies = rev.get_active_frequencies(
-        tx_band[0], tx_band[1], modeTx, "Hz"
+        tx_band[0], tx_band[1], modeTx
     )
     tx_channel_count = len(tx_frequencies)
     chpair = domain

--- a/examples/07-EMIT/ComputeProtectionLevels.py.back
+++ b/examples/07-EMIT/ComputeProtectionLevels.py.back
@@ -270,8 +270,8 @@ for tx_radio in tx_radios:
                 domain.set_interferer(tx_radio, tx_band, tx_freq)
                 #interaction = rev.run(domain)
                 instance = interaction.get_instance(domain)
-                if instance.get_value(modePower) > max_power:
-                    max_power = instance.get_value(modePower)
+                if instance.get_value(mode_power) > max_power:
+                    max_power = instance.get_value(mode_power)
                     
         # If the worst case for the band-pair is below the power thresholds, then
         # there are no interference issues and no offset is required.

--- a/pyaedt/emit_core/__init__.py
+++ b/pyaedt/emit_core/__init__.py
@@ -1,6 +1,8 @@
 from importlib import import_module
+import imp
 import os
 import sys
+from pyaedt import pyaedt_logger as logger
 
 EMIT_API_PYTHON = None
 
@@ -24,6 +26,9 @@ def _set_api(aedt_version):
     desktop_path = os.environ.get(aedt_version)
     if desktop_path and numeric_version > 231:
         path = os.path.join(desktop_path, "Delcross")
-        sys.path.append(path)
+        sys.path.insert(0,path)
+        module_path = imp.find_module("EmitApiPython")[1]
+        logger.info("Importing EmitApiPython from: {}".format(module_path))
         global EMIT_API_PYTHON
         EMIT_API_PYTHON = import_module("EmitApiPython")
+        logger.info("Loaded {}".format(EMIT_API_PYTHON.EmitApi().get_version(True)))

--- a/pyaedt/emit_core/__init__.py
+++ b/pyaedt/emit_core/__init__.py
@@ -1,7 +1,8 @@
-from importlib import import_module
 import imp
+from importlib import import_module
 import os
 import sys
+
 from pyaedt import pyaedt_logger as logger
 
 EMIT_API_PYTHON = None
@@ -26,7 +27,7 @@ def _set_api(aedt_version):
     desktop_path = os.environ.get(aedt_version)
     if desktop_path and numeric_version > 231:
         path = os.path.join(desktop_path, "Delcross")
-        sys.path.insert(0,path)
+        sys.path.insert(0, path)
         module_path = imp.find_module("EmitApiPython")[1]
         logger.info("Importing EmitApiPython from: {}".format(module_path))
         global EMIT_API_PYTHON

--- a/pyaedt/emit_core/results/results.py
+++ b/pyaedt/emit_core/results/results.py
@@ -48,7 +48,7 @@ class Results:
 
         Raises
         ------
-        RuntimeException if the name given is an ex
+        RuntimeError if the name given is not the name of an existing result set and a current result set already exists.
 
         Returns
         -------

--- a/pyaedt/emit_core/results/results.py
+++ b/pyaedt/emit_core/results/results.py
@@ -48,7 +48,8 @@ class Results:
 
         Raises
         ------
-        RuntimeError if the name given is not the name of an existing result set and a current result set already exists.
+        RuntimeError if the name given is not the name of an existing result set and a current result set already 
+        exists.
 
         Returns
         -------

--- a/pyaedt/emit_core/results/results.py
+++ b/pyaedt/emit_core/results/results.py
@@ -43,8 +43,8 @@ class Results:
         Parameters
         ----------
         name : str, optional
-            Name for the new revision, if created. If name is ``None``, it will
-            be named after the current design revision.
+            Name for the new revision, if created. The default is ``None``, in which
+            case the name of the current design revision is used.
 
         Raises
         ------

--- a/pyaedt/emit_core/results/results.py
+++ b/pyaedt/emit_core/results/results.py
@@ -38,27 +38,22 @@ class Results:
 
     @pyaedt_function_handler()
     def _add_revision(self, name=None):
-        """Add a new revision.
+        """Add a new revision or get the current revision if it already exists.
 
         Parameters
         ----------
         name : str, optional
-            Name for the new revision. If None, it will
-            be named the current design revision.
+            Name for the new revision, if created. If name is ``None``, it will
+            be named after the current design revision.
+
+        Raises
+        ------
+        RuntimeException if the name given is an ex
 
         Returns
         -------
         ``Revision`` object that was created.
         """
-        if name == None:
-            # check for a Current Revision that just hasn't been
-            # loaded by pyaedt
-            if self.design.GetCurrentResult() == "":
-                self.design.AddResult()
-                rev_num = self.design.GetRevision()
-                name = "Revision {}".format(rev_num)
-            else:
-                name = self.design.GetCurrentResult()
         revision = Revision(self, self.emit_project, name)
         self.revisions.append(revision)
         return revision

--- a/pyaedt/emit_core/results/results.py
+++ b/pyaedt/emit_core/results/results.py
@@ -48,7 +48,7 @@ class Results:
 
         Raises
         ------
-        RuntimeError if the name given is not the name of an existing result set and a current result set already 
+        RuntimeError if the name given is not the name of an existing result set and a current result set already
         exists.
 
         Returns

--- a/pyaedt/emit_core/results/revision.py
+++ b/pyaedt/emit_core/results/revision.py
@@ -15,8 +15,8 @@ class Revision:
     emit_obj :
          ``Emit`` object that this revision is associated with.
     name : str, optional
-        Name of the revision to create. The default is ``None``, in which case a
-        default name is given.
+        Name of the revision to create. The default is ``None``, in which
+        case the name of the current design revision is used.
 
     Raises
     ------

--- a/pyaedt/emit_core/results/revision.py
+++ b/pyaedt/emit_core/results/revision.py
@@ -21,7 +21,7 @@ class Revision:
 
     Raises
     ------
-    RuntimeError if a name is given that is not an existing result set name and there is already a current result set.        
+    RuntimeError if a name is given that is not an existing result set name and there is already a current result set.
 
     Examples
     --------
@@ -53,9 +53,9 @@ class Revision:
         """Emit project."""
 
         raw_props = emit_obj.odesign.GetResultProperties(name)
-        key = lambda s: s.split('=',1)[0]
-        val = lambda s: s.split('=',1)[1]
-        props = {key(s):val(s) for s in raw_props}
+        key = lambda s: s.split("=", 1)[0]
+        val = lambda s: s.split("=", 1)[1]
+        props = {key(s): val(s) for s in raw_props}
 
         self.revision_number = int(props["Revision"])
         """Unique revision number from the Emit design"""

--- a/pyaedt/emit_core/results/revision.py
+++ b/pyaedt/emit_core/results/revision.py
@@ -322,5 +322,5 @@ class Revision:
 
     @notes.setter
     def notes(self, notes):
-        design = self.emit_project.odesign.SetResultNotes(self.name, notes)
+        self.emit_project.odesign.SetResultNotes(self.name, notes)
         self.emit_project._emit_api.save_project()

--- a/pyaedt/emit_core/results/revision.py
+++ b/pyaedt/emit_core/results/revision.py
@@ -20,7 +20,7 @@ class Revision:
 
     Raises
     ------
-    RuntimeError if a name is given that is not an existing result set name and there is already a current result set.
+    RuntimeError if the name given is not the name of an existing result set and a current result set already exists.
 
     Examples
     --------

--- a/pyaedt/emit_core/results/revision.py
+++ b/pyaedt/emit_core/results/revision.py
@@ -1,4 +1,3 @@
-import os
 import warnings
 
 import pyaedt.emit_core.EmitConstants as emitConsts


### PR DESCRIPTION
Also:
- Use Revision constructor for _add_revision in Results
- Fix errors in ComputeChannelSeparation.py and ComputeProtectionLevels.py
- Add some logging output to EMIT API import