### PR TITLE
fix some emit bugs

### DIFF
--- a/_unittest/test_26_emit.py
+++ b/_unittest/test_26_emit.py
@@ -475,6 +475,8 @@ class TestClass(BasisTest, object):
         self.aedtapp = BasisTest.add_app(self, application=Emit)
         rad1, ant1 = self.aedtapp.modeler.components.create_radio_antenna("New Radio")
         rad2, ant2 = self.aedtapp.modeler.components.create_radio_antenna("Bluetooth Low Energy (LE)")
+        rad3, ant3 = self.aedtapp.modeler.components.create_radio_antenna("WiFi - 802.11-2012")
+        rad4, ant4 = self.aedtapp.modeler.components.create_radio_antenna("WiFi 6")
 
         # Check type
         rad_type = rad1.get_type()
@@ -487,13 +489,21 @@ class TestClass(BasisTest, object):
         assert ants[0].name == "Antenna"
         ants = rad2.get_connected_antennas()
         assert ants[0].name == "Antenna 2"
-
+        
+        # Set all Bands for WiFi radios, enabled
+        band_nodes = rad3.bands()
+        for bn in band_nodes:
+            bn.enabled = True            
+        band_nodes = rad4.bands()
+        for bn in band_nodes:
+            bn.enabled = True
+            
         # Set up the results
         rev = self.aedtapp.results.analyze()
 
         # Get Tx Radios
         radios = rev.get_interferer_names()
-        assert radios == ["Radio", "Bluetooth Low Energy (LE)"]
+        assert radios == ["Radio", "Bluetooth Low Energy (LE)", 'WiFi - 802.11-2012', "WiFi 6"]
 
         # Get the Bands
         bands = rev.get_band_names(radios[0], econsts.tx_rx_mode().rx)
@@ -502,6 +512,46 @@ class TestClass(BasisTest, object):
         # Get the Freqs
         freqs = rev.get_active_frequencies(radios[0], bands[0], econsts.tx_rx_mode().rx, "MHz")
         assert freqs == [100.0]
+        
+        # Test error for trying to get BOTH tx and rx freqs
+        exception_raised = False
+        try:
+            freqs = rev.get_active_frequencies(radios[0], bands[0], econsts.tx_rx_mode().both, "MHz")
+        except:
+            exception_raised = True
+        assert exception_raised
+                
+        # Get WiFi 2012 Tx Bands
+        bands = rev.get_band_names(radios[2], econsts.tx_rx_mode().rx)
+        assert len(bands) == 16
+        
+        # Get WiFi 2012 Tx Bands
+        bands = rev.get_band_names(radios[2], econsts.tx_rx_mode().tx)
+        assert len(bands) == 16
+        
+        # Get WiFi 2012 All Bands
+        bands = rev.get_band_names(radios[2], econsts.tx_rx_mode().both)
+        assert len(bands) == 32
+        
+        # Get WiFi 2012 All Bands (default args)
+        bands = rev.get_band_names(radios[2])
+        assert len(bands) == 32
+        
+        # Get WiFi 6 All Bands (default args)
+        bands = rev.get_band_names(radios[3])
+        assert len(bands) == 192    
+        
+        # Get WiFi 6 Tx Bands
+        bands = rev.get_band_names(radios[3], econsts.tx_rx_mode().rx)
+        assert len(bands) == 192
+        
+        # Get WiFi 6 Tx Bands
+        bands = rev.get_band_names(radios[3], econsts.tx_rx_mode().tx)
+        assert len(bands) == 192
+        
+        # Get WiFi 6 All Bands
+        bands = rev.get_band_names(radios[3], econsts.tx_rx_mode().both)
+        assert len(bands) == 192    
 
         # Add an emitter
         emitter1 = self.aedtapp.modeler.components.create_component("USB_3.x")
@@ -513,11 +563,11 @@ class TestClass(BasisTest, object):
 
         # Get transmitters only
         transmitters = rev2.get_interferer_names(econsts.interferer_type().transmitters)
-        assert transmitters == ["Radio", "Bluetooth Low Energy (LE)"]
+        assert transmitters == ["Radio", "Bluetooth Low Energy (LE)", 'WiFi - 802.11-2012', "WiFi 6"]
 
         # Get all interferers
         all_ix = rev2.get_interferer_names(econsts.interferer_type().transmitters_and_emitters)
-        assert all_ix == ["Radio", "Bluetooth Low Energy (LE)", "USB_3.x"]
+        assert all_ix == ["Radio", "Bluetooth Low Energy (LE)", 'WiFi - 802.11-2012', "WiFi 6", "USB_3.x"]
 
     @pytest.mark.skipif(
         config["desktopVersion"] <= "2022.1" or is_ironpython, reason="Skipped on versions earlier than 2021.2"

--- a/_unittest/test_26_emit.py
+++ b/_unittest/test_26_emit.py
@@ -521,7 +521,7 @@ class TestClass(BasisTest, object):
             exception_raised = True
         assert exception_raised
 
-        # Get WiFi 2012 Tx Bands
+        # Get WiFi 2012 Rx Bands
         bands = rev.get_band_names(radios[2], econsts.tx_rx_mode().rx)
         assert len(bands) == 16
 
@@ -541,7 +541,7 @@ class TestClass(BasisTest, object):
         bands = rev.get_band_names(radios[3])
         assert len(bands) == 192
 
-        # Get WiFi 6 Tx Bands
+        # Get WiFi 6 Rx Bands
         bands = rev.get_band_names(radios[3], econsts.tx_rx_mode().rx)
         assert len(bands) == 192
 

--- a/_unittest/test_26_emit.py
+++ b/_unittest/test_26_emit.py
@@ -489,21 +489,21 @@ class TestClass(BasisTest, object):
         assert ants[0].name == "Antenna"
         ants = rad2.get_connected_antennas()
         assert ants[0].name == "Antenna 2"
-        
+
         # Set all Bands for WiFi radios, enabled
         band_nodes = rad3.bands()
         for bn in band_nodes:
-            bn.enabled = True            
+            bn.enabled = True
         band_nodes = rad4.bands()
         for bn in band_nodes:
             bn.enabled = True
-            
+
         # Set up the results
         rev = self.aedtapp.results.analyze()
 
         # Get Tx Radios
         radios = rev.get_interferer_names()
-        assert radios == ["Radio", "Bluetooth Low Energy (LE)", 'WiFi - 802.11-2012', "WiFi 6"]
+        assert radios == ["Radio", "Bluetooth Low Energy (LE)", "WiFi - 802.11-2012", "WiFi 6"]
 
         # Get the Bands
         bands = rev.get_band_names(radios[0], econsts.tx_rx_mode().rx)
@@ -512,7 +512,7 @@ class TestClass(BasisTest, object):
         # Get the Freqs
         freqs = rev.get_active_frequencies(radios[0], bands[0], econsts.tx_rx_mode().rx, "MHz")
         assert freqs == [100.0]
-        
+
         # Test error for trying to get BOTH tx and rx freqs
         exception_raised = False
         try:
@@ -520,38 +520,38 @@ class TestClass(BasisTest, object):
         except:
             exception_raised = True
         assert exception_raised
-                
+
         # Get WiFi 2012 Tx Bands
         bands = rev.get_band_names(radios[2], econsts.tx_rx_mode().rx)
         assert len(bands) == 16
-        
+
         # Get WiFi 2012 Tx Bands
         bands = rev.get_band_names(radios[2], econsts.tx_rx_mode().tx)
         assert len(bands) == 16
-        
+
         # Get WiFi 2012 All Bands
         bands = rev.get_band_names(radios[2], econsts.tx_rx_mode().both)
         assert len(bands) == 32
-        
+
         # Get WiFi 2012 All Bands (default args)
         bands = rev.get_band_names(radios[2])
         assert len(bands) == 32
-        
+
         # Get WiFi 6 All Bands (default args)
         bands = rev.get_band_names(radios[3])
-        assert len(bands) == 192    
-        
+        assert len(bands) == 192
+
         # Get WiFi 6 Tx Bands
         bands = rev.get_band_names(radios[3], econsts.tx_rx_mode().rx)
         assert len(bands) == 192
-        
+
         # Get WiFi 6 Tx Bands
         bands = rev.get_band_names(radios[3], econsts.tx_rx_mode().tx)
         assert len(bands) == 192
-        
+
         # Get WiFi 6 All Bands
         bands = rev.get_band_names(radios[3], econsts.tx_rx_mode().both)
-        assert len(bands) == 192    
+        assert len(bands) == 192
 
         # Add an emitter
         emitter1 = self.aedtapp.modeler.components.create_component("USB_3.x")
@@ -563,11 +563,11 @@ class TestClass(BasisTest, object):
 
         # Get transmitters only
         transmitters = rev2.get_interferer_names(econsts.interferer_type().transmitters)
-        assert transmitters == ["Radio", "Bluetooth Low Energy (LE)", 'WiFi - 802.11-2012', "WiFi 6"]
+        assert transmitters == ["Radio", "Bluetooth Low Energy (LE)", "WiFi - 802.11-2012", "WiFi 6"]
 
         # Get all interferers
         all_ix = rev2.get_interferer_names(econsts.interferer_type().transmitters_and_emitters)
-        assert all_ix == ["Radio", "Bluetooth Low Energy (LE)", 'WiFi - 802.11-2012', "WiFi 6", "USB_3.x"]
+        assert all_ix == ["Radio", "Bluetooth Low Energy (LE)", "WiFi - 802.11-2012", "WiFi 6", "USB_3.x"]
 
     @pytest.mark.skipif(
         config["desktopVersion"] <= "2022.1" or is_ironpython, reason="Skipped on versions earlier than 2021.2"

--- a/pyaedt/emit_core/results/revision.py
+++ b/pyaedt/emit_core/results/revision.py
@@ -272,7 +272,7 @@ class Revision:
         return bands
 
     @pyaedt_function_handler()
-    def get_active_frequencies(self, radio_name, band_name, tx_rx_mode=None, units=""):
+    def get_active_frequencies(self, radio_name, band_name, tx_rx_mode, units=""):
         """
         Get a list of active frequencies for a ``tx`` or ``rx`` band in a radio/emitter.
 
@@ -282,7 +282,7 @@ class Revision:
             Name of the radio/emitter.
         band_name : str
            Name of the band.
-        tx_rx : :class:`EmitConstants.tx_rx_mode`, optional
+        tx_rx : :class:`EmitConstants.tx_rx_mode`
             Specifies whether to get ``tx`` or ``rx`` radio freqs. The default
             is ``None``, in which case both ``tx`` and ``rx`` freqs are returned.
         units : str, optional
@@ -299,8 +299,8 @@ class Revision:
         >>> freqs = aedtapp.results.current_revision.get_active_frequencies(
                 'Bluetooth', 'Rx - Base Data Rate', Emit.tx_rx_mode.rx)
         """
-        if tx_rx_mode is None:
-            tx_rx_mode = emitConsts.tx_rx_mode().both
+        if tx_rx_mode is None or tx_rx_mode == emitConsts.tx_rx_mode().both:
+            raise ValueError("The mode type must be specified as either Tx or Rx.")
         if self.revision_loaded:
             freqs = self.emit_project._emit_api.get_active_frequencies(radio_name, band_name, tx_rx_mode, units)
         else:

--- a/pyaedt/modeler/circuits/PrimitivesEmit.py
+++ b/pyaedt/modeler/circuits/PrimitivesEmit.py
@@ -726,7 +726,7 @@ class EmitRadioComponent(EmitComponent):
         for node in band_nodes:
             if band_name == node.props["Name"]:
                 return node
-        return False
+        return None
 
     def band_start_frequency(self, band_node, units=""):
         """Get the start frequency of the band node.

--- a/pyaedt/modeler/circuits/PrimitivesEmit.py
+++ b/pyaedt/modeler/circuits/PrimitivesEmit.py
@@ -308,7 +308,7 @@ class EmitComponent(object):
         nodes = components.odesign.GetComponentNodeNames(component_name)
         root_node = nodes[0]
         prop_list = components.odesign.GetComponentNodeProperties(component_name, root_node)
-        props = dict(p.split("=",1) for p in prop_list)
+        props = dict(p.split("=", 1) for p in prop_list)
         root_node_type = props["Type"]
         if root_node_type.endswith("Node"):
             root_node_type = root_node_type[: -len("Node")]
@@ -461,7 +461,7 @@ class EmitComponent(object):
         if node is not None:
             node_name = root_node + "-*-" + "-*-".join(node.split("/")[1:])
         props_list = self.odesign.GetComponentNodeProperties(self.name, node_name)
-        props = dict(p.split("=",1) for p in props_list)
+        props = dict(p.split("=", 1) for p in props_list)
         return props
 
     @pyaedt_function_handler()
@@ -711,7 +711,7 @@ class EmitRadioComponent(EmitComponent):
             List of the band nodes in the radio."""
         band_nodes = self.get_prop_nodes({"Type": "Band"})
         return band_nodes
-    
+
     def band_node(self, band_name):
         """Get the specified band node from this radio.
 
@@ -861,7 +861,7 @@ class EmitComponentPropNode(object):
         Dict
             Dictionary of all the properties for this node."""
         prop_list = self.odesign.GetComponentNodeProperties(self.parent_component.name, self.node_name)
-        props = dict(p.split("=",1) for p in prop_list)
+        props = dict(p.split("=", 1) for p in prop_list)
         return props
 
     @property

--- a/pyaedt/modeler/circuits/PrimitivesEmit.py
+++ b/pyaedt/modeler/circuits/PrimitivesEmit.py
@@ -308,7 +308,7 @@ class EmitComponent(object):
         nodes = components.odesign.GetComponentNodeNames(component_name)
         root_node = nodes[0]
         prop_list = components.odesign.GetComponentNodeProperties(component_name, root_node)
-        props = dict(p.split("=") for p in prop_list)
+        props = dict(p.split("=",1) for p in prop_list)
         root_node_type = props["Type"]
         if root_node_type.endswith("Node"):
             root_node_type = root_node_type[: -len("Node")]
@@ -461,7 +461,7 @@ class EmitComponent(object):
         if node is not None:
             node_name = root_node + "-*-" + "-*-".join(node.split("/")[1:])
         props_list = self.odesign.GetComponentNodeProperties(self.name, node_name)
-        props = dict(p.split("=") for p in props_list)
+        props = dict(p.split("=",1) for p in props_list)
         return props
 
     @pyaedt_function_handler()
@@ -711,6 +711,22 @@ class EmitRadioComponent(EmitComponent):
             List of the band nodes in the radio."""
         band_nodes = self.get_prop_nodes({"Type": "Band"})
         return band_nodes
+    
+    def band_node(self, band_name):
+        """Get the specified band node from this radio.
+
+        Parameters
+        ----------
+        band_name : name of the desired band node.
+
+        Returns
+        -------
+        band_node : Instance of the band node."""
+        band_nodes = self.bands()
+        for node in band_nodes:
+            if band_name == node.props["Name"]:
+                return node
+        return False
 
     def band_start_frequency(self, band_node, units=""):
         """Get the start frequency of the band node.
@@ -845,7 +861,7 @@ class EmitComponentPropNode(object):
         Dict
             Dictionary of all the properties for this node."""
         prop_list = self.odesign.GetComponentNodeProperties(self.parent_component.name, self.node_name)
-        props = dict(p.split("=") for p in prop_list)
+        props = dict(p.split("=",1) for p in prop_list)
         return props
 
     @property


### PR DESCRIPTION
B829904: only split the first instance of '=' when getting component node props

B829824: make tx_rx_mode non-optional for get_active_frequencies and raise an error if 'both' is specified.

also added a function to get the band_node when given the radio_node and the band_name